### PR TITLE
Fix CUDA annotations for priv::vector

### DIFF
--- a/context-transport-primitives/include/hermes_shm/data_structures/priv/vector.h
+++ b/context-transport-primitives/include/hermes_shm/data_structures/priv/vector.h
@@ -550,6 +550,7 @@ class vector {
    *
    * @param min_capacity Minimum capacity needed
    */
+  HSHM_INLINE_CROSS_FUN
   void Grow(size_type min_capacity) {
     size_type new_capacity = (capacity_ == 0) ? 1 : capacity_ * 2;
     while (new_capacity < min_capacity) {
@@ -565,6 +566,7 @@ class vector {
    * @param pos Position to construct at
    * @param val Value to move construct
    */
+  HSHM_INLINE_CROSS_FUN
   void ConstructMove(size_type pos, T&& val) {
     if constexpr (kIsPod) {
       data_.ptr_[pos] = static_cast<T&&>(val);
@@ -580,6 +582,7 @@ class vector {
    * @param pos Position to construct at
    * @param val Value to copy construct
    */
+  HSHM_INLINE_CROSS_FUN
   void ConstructCopy(size_type pos, const T& val) {
     if constexpr (kIsPod) {
       data_.ptr_[pos] = val;
@@ -594,6 +597,7 @@ class vector {
    *
    * @param pos Position to destroy
    */
+  HSHM_INLINE_CROSS_FUN
   void Destroy(size_type pos) {
     if constexpr (!kIsPod) {
       data_.ptr_[pos].~T();
@@ -607,6 +611,7 @@ class vector {
    * @param first First position to destroy
    * @param last Last position (exclusive)
    */
+  HSHM_INLINE_CROSS_FUN
   void DestroyRange(size_type first, size_type last) {
     if constexpr (!kIsPod) {
       for (size_type i = first; i < last; ++i) {
@@ -622,6 +627,7 @@ class vector {
    *
    * @param alloc Pointer to allocator instance for memory management
    */
+  HSHM_INLINE_CROSS_FUN
   explicit vector(AllocT* alloc)
     : data_(hipc::FullPtr<T>::GetNull()), size_(0), capacity_(0), alloc_(alloc) {}
 
@@ -630,6 +636,7 @@ class vector {
    * Destroys all elements and deallocates memory using allocator.
    * Note: Does not deallocate the allocator itself (managed externally).
    */
+  HSHM_INLINE_CROSS_FUN
   ~vector() {
     clear();
     if (!data_.IsNull() && alloc_ != nullptr) {
@@ -645,6 +652,7 @@ class vector {
    * @param count Number of elements to create with default values
    * @param alloc Pointer to allocator instance for memory management
    */
+  HSHM_INLINE_CROSS_FUN
   explicit vector(size_type count, AllocT* alloc)
       : data_(hipc::FullPtr<T>::GetNull()), size_(0), capacity_(0), alloc_(alloc) {
     reserve(count);
@@ -666,6 +674,7 @@ class vector {
    * @param value Value to initialize elements with
    * @param alloc Pointer to allocator instance for memory management
    */
+  HSHM_INLINE_CROSS_FUN
   vector(size_type count, const T& value, AllocT* alloc)
       : data_(hipc::FullPtr<T>::GetNull()), size_(0), capacity_(0), alloc_(alloc) {
     reserve(count);
@@ -681,6 +690,7 @@ class vector {
    * @param init Initializer list
    * @param alloc Pointer to allocator instance for memory management
    */
+  HSHM_INLINE_CROSS_FUN
   vector(std::initializer_list<T> init, AllocT* alloc)
       : data_(hipc::FullPtr<T>::GetNull()), size_(0), capacity_(0), alloc_(alloc) {
     reserve(init.size());
@@ -695,6 +705,7 @@ class vector {
    *
    * @param other Vector to copy from
    */
+  HSHM_INLINE_CROSS_FUN
   vector(const vector& other)
       : data_(hipc::FullPtr<T>::GetNull()), size_(0), capacity_(0), alloc_(other.alloc_) {
     if (alloc_ != nullptr) {
@@ -711,6 +722,7 @@ class vector {
    *
    * @param other Vector to move from
    */
+  HSHM_INLINE_CROSS_FUN
   vector(vector&& other) noexcept
       : data_(other.data_), size_(other.size_), capacity_(other.capacity_),
         alloc_(other.alloc_) {
@@ -727,6 +739,7 @@ class vector {
    * @param other Vector to copy from
    * @return Reference to this vector
    */
+  HSHM_INLINE_CROSS_FUN
   vector& operator=(const vector& other) {
     if (this != &other) {
       clear();
@@ -748,6 +761,7 @@ class vector {
    * @param other Vector to move from
    * @return Reference to this vector
    */
+  HSHM_INLINE_CROSS_FUN
   vector& operator=(vector&& other) noexcept {
     if (this != &other) {
       clear();
@@ -772,6 +786,7 @@ class vector {
    * @param init Initializer list
    * @return Reference to this vector
    */
+  HSHM_INLINE_CROSS_FUN
   vector& operator=(std::initializer_list<T> init) {
     clear();
     reserve(init.size());
@@ -789,6 +804,7 @@ class vector {
    * @return Reference to element at position
    * @throws std::out_of_range if position is out of bounds
    */
+  HSHM_INLINE_CROSS_FUN
   T& at(size_type pos) {
     if (pos >= size_) {
       throw std::out_of_range("Vector index out of bounds");
@@ -804,6 +820,7 @@ class vector {
    * @return Const reference to element at position
    * @throws std::out_of_range if position is out of bounds
    */
+  HSHM_INLINE_CROSS_FUN
   const T& at(size_type pos) const {
     if (pos >= size_) {
       throw std::out_of_range("Vector index out of bounds");
@@ -818,6 +835,7 @@ class vector {
    * @param pos Position to access
    * @return Reference to element at position
    */
+  HSHM_INLINE_CROSS_FUN
   T& operator[](size_type pos) {
     return data_.ptr_[pos];
   }
@@ -829,6 +847,7 @@ class vector {
    * @param pos Position to access
    * @return Const reference to element at position
    */
+  HSHM_INLINE_CROSS_FUN
   const T& operator[](size_type pos) const {
     return data_.ptr_[pos];
   }
@@ -839,6 +858,7 @@ class vector {
    *
    * @return Reference to first element
    */
+  HSHM_INLINE_CROSS_FUN
   T& front() {
     return data_.ptr_[0];
   }
@@ -849,6 +869,7 @@ class vector {
    *
    * @return Const reference to first element
    */
+  HSHM_INLINE_CROSS_FUN
   const T& front() const {
     return data_.ptr_[0];
   }
@@ -859,6 +880,7 @@ class vector {
    *
    * @return Reference to last element
    */
+  HSHM_INLINE_CROSS_FUN
   T& back() {
     return data_.ptr_[size_ - 1];
   }
@@ -869,6 +891,7 @@ class vector {
    *
    * @return Const reference to last element
    */
+  HSHM_INLINE_CROSS_FUN
   const T& back() const {
     return data_.ptr_[size_ - 1];
   }
@@ -879,6 +902,7 @@ class vector {
    *
    * @return Pointer to underlying data array
    */
+  HSHM_INLINE_CROSS_FUN
   T* data() {
     return data_.ptr_;
   }
@@ -889,6 +913,7 @@ class vector {
    *
    * @return Const pointer to underlying data array
    */
+  HSHM_INLINE_CROSS_FUN
   const T* data() const {
     return data_.ptr_;
   }
@@ -899,6 +924,7 @@ class vector {
    *
    * @return Iterator to first element
    */
+  HSHM_INLINE_CROSS_FUN
   iterator begin() {
     return iterator(data_.ptr_);
   }
@@ -909,6 +935,7 @@ class vector {
    *
    * @return Const iterator to first element
    */
+  HSHM_INLINE_CROSS_FUN
   const_iterator begin() const {
     return const_iterator(data_.ptr_);
   }
@@ -919,6 +946,7 @@ class vector {
    *
    * @return Const iterator to first element
    */
+  HSHM_INLINE_CROSS_FUN
   const_iterator cbegin() const {
     return const_iterator(data_.ptr_);
   }
@@ -929,6 +957,7 @@ class vector {
    *
    * @return Iterator to one past last element
    */
+  HSHM_INLINE_CROSS_FUN
   iterator end() {
     return iterator(data_.ptr_ + size_);
   }
@@ -939,6 +968,7 @@ class vector {
    *
    * @return Const iterator to one past last element
    */
+  HSHM_INLINE_CROSS_FUN
   const_iterator end() const {
     return const_iterator(data_.ptr_ + size_);
   }
@@ -949,6 +979,7 @@ class vector {
    *
    * @return Const iterator to one past last element
    */
+  HSHM_INLINE_CROSS_FUN
   const_iterator cend() const {
     return const_iterator(data_.ptr_ + size_);
   }
@@ -958,6 +989,7 @@ class vector {
    *
    * @return Reverse iterator to last element
    */
+  HSHM_INLINE_CROSS_FUN
   reverse_iterator rbegin() {
     return reverse_iterator(end());
   }
@@ -967,6 +999,7 @@ class vector {
    *
    * @return Const reverse iterator to last element
    */
+  HSHM_INLINE_CROSS_FUN
   const_reverse_iterator rbegin() const {
     return const_reverse_iterator(end());
   }
@@ -976,6 +1009,7 @@ class vector {
    *
    * @return Const reverse iterator to last element
    */
+  HSHM_INLINE_CROSS_FUN
   const_reverse_iterator crbegin() const {
     return const_reverse_iterator(end());
   }
@@ -985,6 +1019,7 @@ class vector {
    *
    * @return Reverse iterator to one before first element
    */
+  HSHM_INLINE_CROSS_FUN
   reverse_iterator rend() {
     return reverse_iterator(begin());
   }
@@ -994,6 +1029,7 @@ class vector {
    *
    * @return Const reverse iterator to one before first element
    */
+  HSHM_INLINE_CROSS_FUN
   const_reverse_iterator rend() const {
     return const_reverse_iterator(begin());
   }
@@ -1003,6 +1039,7 @@ class vector {
    *
    * @return Const reverse iterator to one before first element
    */
+  HSHM_INLINE_CROSS_FUN
   const_reverse_iterator crend() const {
     return const_reverse_iterator(begin());
   }
@@ -1012,6 +1049,7 @@ class vector {
    *
    * @return True if size is zero
    */
+  HSHM_INLINE_CROSS_FUN
   bool empty() const {
     return size_ == 0;
   }
@@ -1021,6 +1059,7 @@ class vector {
    *
    * @return Current size
    */
+  HSHM_INLINE_CROSS_FUN
   size_type size() const {
     return size_;
   }
@@ -1030,6 +1069,7 @@ class vector {
    *
    * @return Current capacity
    */
+  HSHM_INLINE_CROSS_FUN
   size_type capacity() const {
     return capacity_;
   }
@@ -1041,6 +1081,7 @@ class vector {
    *
    * @param new_capacity Desired capacity
    */
+  HSHM_INLINE_CROSS_FUN
   void reserve(size_type new_capacity) {
     if (new_capacity <= capacity_ || alloc_ == nullptr) {
       return;
@@ -1069,6 +1110,7 @@ class vector {
    * Reduces capacity to match current size, freeing unused memory.
    * Uses allocator's AllocateObjs and Free methods for proper management.
    */
+  HSHM_INLINE_CROSS_FUN
   void shrink_to_fit() {
     if (size_ < capacity_ && alloc_ != nullptr) {
       if (size_ == 0) {
@@ -1101,6 +1143,7 @@ class vector {
    *
    * @param val Element to add
    */
+  HSHM_INLINE_CROSS_FUN
   void push_back(const T& val) {
     if (size_ >= capacity_) {
       Grow(size_ + 1);
@@ -1114,6 +1157,7 @@ class vector {
    *
    * @param val Element to add
    */
+  HSHM_INLINE_CROSS_FUN
   void push_back(T&& val) {
     if (size_ >= capacity_) {
       Grow(size_ + 1);
@@ -1125,6 +1169,7 @@ class vector {
   /**
    * Remove last element from vector
    */
+  HSHM_INLINE_CROSS_FUN
   void pop_back() {
     if (size_ > 0) {
       Destroy(size_ - 1);
@@ -1135,6 +1180,7 @@ class vector {
   /**
    * Clear all elements from vector
    */
+  HSHM_INLINE_CROSS_FUN
   void clear() {
     DestroyRange(0, size_);
     size_ = 0;
@@ -1148,6 +1194,7 @@ class vector {
    * @param val Value to insert
    * @return Iterator to inserted element
    */
+  HSHM_INLINE_CROSS_FUN
   iterator insert(const_iterator pos, const T& val) {
     size_type idx = pos.get() - data_.ptr_;
     if (size_ >= capacity_) {
@@ -1177,6 +1224,7 @@ class vector {
    * @param val Value to insert
    * @return Iterator to inserted element
    */
+  HSHM_INLINE_CROSS_FUN
   iterator insert(const_iterator pos, T&& val) {
     size_type idx = pos.get() - data_.ptr_;
     if (size_ >= capacity_) {
@@ -1207,6 +1255,7 @@ class vector {
    * @param last Iterator to one past last element to insert
    * @return Iterator to first inserted element
    */
+  HSHM_INLINE_CROSS_FUN
   iterator insert(const_iterator pos, const_iterator first,
                   const_iterator last) {
     size_type idx = pos.get() - data_.ptr_;
@@ -1241,6 +1290,7 @@ class vector {
    * @param pos Iterator to element to erase
    * @return Iterator to element following erased element
    */
+  HSHM_INLINE_CROSS_FUN
   iterator erase(const_iterator pos) {
     size_type idx = pos.get() - data_.ptr_;
 
@@ -1266,6 +1316,7 @@ class vector {
    * @param last Iterator to one past last element to erase
    * @return Iterator to element following erased elements
    */
+  HSHM_INLINE_CROSS_FUN
   iterator erase(const_iterator first, const_iterator last) {
     size_type first_idx = first.get() - data_.ptr_;
     size_type last_idx = last.get() - data_.ptr_;
@@ -1292,6 +1343,7 @@ class vector {
    *
    * @param new_size New size
    */
+  HSHM_INLINE_CROSS_FUN
   void resize(size_type new_size) {
     if (new_size > size_) {
       if (new_size > capacity_) {
@@ -1318,6 +1370,7 @@ class vector {
    * @param new_size New size
    * @param value Value to fill new elements with
    */
+  HSHM_INLINE_CROSS_FUN
   void resize(size_type new_size, const T& value) {
     if (new_size > size_) {
       if (new_size > capacity_) {
@@ -1338,6 +1391,7 @@ class vector {
    *
    * @param other Vector to swap with
    */
+  HSHM_INLINE_CROSS_FUN
   void swap(vector& other) noexcept {
     std::swap(data_, other.data_);
     std::swap(size_, other.size_);
@@ -1352,6 +1406,7 @@ class vector {
    * @param ar Archive to save to
    */
   template<class Archive>
+  HSHM_INLINE_CROSS_FUN
   void save(Archive& ar) const {
     hshm::ipc::save_vec<Archive, vector<T, AllocT>, T>(ar, *this);
   }
@@ -1364,6 +1419,7 @@ class vector {
    * @param ar Archive to load from
    */
   template<class Archive>
+  HSHM_INLINE_CROSS_FUN
   void load(Archive& ar) {
     hshm::ipc::load_vec<Archive, vector<T, AllocT>, T>(ar, *this);
   }


### PR DESCRIPTION
Several methods on `hshm::priv::vector` were missing 'HSHM_INLINE_CROSS_FUN' annotations. I've tested that this compiles and runs on the GPU, when compiled with NVCC.

closes #132 