### PR TITLE
fix: GCC 11 coroutine bug and test environment paths

### DIFF
--- a/context-runtime/modules/bdev/src/bdev_runtime.cc
+++ b/context-runtime/modules/bdev/src/bdev_runtime.cc
@@ -458,11 +458,15 @@ chi::TaskResume Runtime::Create(hipc::FullPtr<CreateTask> task, chi::RunContext 
 
 chi::TaskResume Runtime::AllocateBlocks(hipc::FullPtr<AllocateBlocksTask> task,
                              chi::RunContext &ctx) {
+  HLOG(kDebug, "bdev::AllocateBlocks: ENTER - pool_id_=({},{}), size={}, container_id={}",
+       task->pool_id_.major_, task->pool_id_.minor_, task->size_, container_id_);
+
   // Get worker ID for allocation
   int worker_id = static_cast<int>(GetWorkerID(ctx));
 
   chi::u64 total_size = task->size_;
   if (total_size == 0) {
+    HLOG(kDebug, "bdev::AllocateBlocks: size is 0, returning empty blocks");
     task->blocks_.clear();
     task->return_code_ = 0;  // Nothing to allocate
     co_return;
@@ -554,6 +558,9 @@ chi::TaskResume Runtime::AllocateBlocks(hipc::FullPtr<AllocateBlocksTask> task,
   for (size_t i = 0; i < local_blocks.size(); i++) {
     task->blocks_.emplace_back(local_blocks[i]);
   }
+
+  HLOG(kDebug, "bdev::AllocateBlocks: SUCCESS - allocated {} blocks, task->blocks_.size()={}",
+       local_blocks.size(), task->blocks_.size());
 
   task->return_code_ = 0;
   (void)ctx;

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -1489,4 +1489,12 @@ void Worker::ReschedulePeriodicTask(RunContext *run_ctx,
   AddToBlockedQueue(run_ctx);
 }
 
+RunContext* GetCurrentRunContextFromWorker() {
+  Worker* worker = CHI_CUR_WORKER;
+  if (worker) {
+    return worker->GetCurrentRunContext();
+  }
+  return nullptr;
+}
+
 }  // namespace chi

--- a/context-transfer-engine/adapter/adios2/CMakeLists.txt
+++ b/context-transfer-engine/adapter/adios2/CMakeLists.txt
@@ -1,9 +1,11 @@
-# Find ADIOS2
-find_package(ADIOS2 QUIET)
+# Find ADIOS2 (only if not already found)
 if(NOT ADIOS2_FOUND)
-  message(WARNING "ADIOS2 not found. ADIOS2 adapter will not be built.")
-  message(STATUS "To install ADIOS2: conda install adios2 or build from source")
-  return()
+  find_package(ADIOS2 QUIET)
+  if(NOT ADIOS2_FOUND)
+    message(WARNING "ADIOS2 not found. ADIOS2 adapter will not be built.")
+    message(STATUS "To install ADIOS2: conda install adios2 or build from source")
+    return()
+  endif()
 endif()
 
 message(STATUS "Found ADIOS2")

--- a/context-transfer-engine/test/unit/adapters/adios2/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/adapters/adios2/CMakeLists.txt
@@ -4,11 +4,13 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-# Find ADIOS2
-find_package(ADIOS2 QUIET)
+# Find ADIOS2 (only if not already found)
 if(NOT ADIOS2_FOUND)
-  message(WARNING "ADIOS2 not found. ADIOS2 adapter tests will not be built.")
-  return()
+  find_package(ADIOS2 QUIET)
+  if(NOT ADIOS2_FOUND)
+    message(WARNING "ADIOS2 not found. ADIOS2 adapter tests will not be built.")
+    return()
+  endif()
 endif()
 
 message(STATUS "Building ADIOS2 adapter tests")
@@ -73,6 +75,18 @@ add_test(NAME adios2_adapter_integration
 
 # Set test properties for proper execution environment
 # Use CMAKE_CURRENT_SOURCE_DIR to get the path to cte_config.yaml
+# Get conda lib path from environment or CMAKE_PREFIX_PATH
+set(CONDA_LIB_PATH "")
+if(DEFINED ENV{CONDA_PREFIX})
+    set(CONDA_LIB_PATH "$ENV{CONDA_PREFIX}/lib")
+elseif(CMAKE_PREFIX_PATH)
+    # Extract first entry as likely conda path
+    list(GET CMAKE_PREFIX_PATH 0 FIRST_PREFIX)
+    if(EXISTS "${FIRST_PREFIX}/lib")
+        set(CONDA_LIB_PATH "${FIRST_PREFIX}/lib")
+    endif()
+endif()
+
 set_tests_properties(
     adios2_adapter_init
     adios2_adapter_step
@@ -87,7 +101,7 @@ set_tests_properties(
     PROPERTIES
         TIMEOUT 300  # 5 minute timeout for each test
         LABELS "unit;adapter;adios2"
-        ENVIRONMENT "ADIOS2_PLUGIN_PATH=${CMAKE_BINARY_DIR}/bin;CHIMAERA_WITH_RUNTIME=1;WRP_RUNTIME_CONF=${CMAKE_CURRENT_SOURCE_DIR}/cte_config.yaml;LD_LIBRARY_PATH=/home/iowarp/miniconda3/lib:$ENV{LD_LIBRARY_PATH}"
+        ENVIRONMENT "ADIOS2_PLUGIN_PATH=${CMAKE_BINARY_DIR}/bin;CHIMAERA_WITH_RUNTIME=1;WRP_RUNTIME_CONF=${CMAKE_CURRENT_SOURCE_DIR}/cte_config.yaml;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:${CONDA_LIB_PATH}:$ENV{LD_LIBRARY_PATH}"
 )
 
 # Install test target

--- a/context-transport-primitives/test/unit/introspect/run_mixed_mapping_test.sh
+++ b/context-transport-primitives/test/unit/introspect/run_mixed_mapping_test.sh
@@ -6,7 +6,18 @@
 set -e  # Exit on error
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TEST_BINARY="/workspace/build/bin/test_mixed_mapping"
+# Find test binary relative to script location (script is in source tree, binary in build tree)
+# The binary is at: ${BUILD_DIR}/bin/test_mixed_mapping
+# We determine BUILD_DIR from CMAKE_BINARY_DIR which is passed via environment or derived
+if [ -n "$CMAKE_BINARY_DIR" ]; then
+    TEST_BINARY="$CMAKE_BINARY_DIR/bin/test_mixed_mapping"
+else
+    # Default: look for build directory relative to source root
+    # Script is at: core/context-transport-primitives/test/unit/introspect/
+    # So source root is 4 directories up
+    SOURCE_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+    TEST_BINARY="$SOURCE_ROOT/build/bin/test_mixed_mapping"
+fi
 
 echo "========================================"
 echo "Mixed Mapping Test Script"

--- a/external/iowarp-gray-scott/CMakeLists.txt
+++ b/external/iowarp-gray-scott/CMakeLists.txt
@@ -14,7 +14,9 @@ option(ENABLE_VTK "Build VTK visualization apps" OFF)
 
 # Find required packages
 find_package(MPI REQUIRED)
-find_package(ADIOS2 REQUIRED)
+if(NOT ADIOS2_FOUND)
+  find_package(ADIOS2 REQUIRED)
+endif()
 
 # Configuration messages
 message(STATUS "========================================")


### PR DESCRIPTION
This commit fixes multiple issues discovered during ctest -D Experimental:

1. **GCC 11 Coroutine Bug (Critical)**: Fixed an issue where GCC 11.4.0's C++20 coroutine implementation would skip the entire await machinery when await_resume() returned a value that was discarded. The compiler generated "statement has no effect" warning and optimized away the co_await suspension.

   Fix: Changed Future::await_resume() return type from Future<TaskT, AllocT>& to void. Also refactored await_suspend() to use type-erased coroutine handle and get RunContext from thread-local Worker storage via helper function GetCurrentRunContextFromWorker().

2. **ADIOS2 Test Environment**: Fixed hardcoded LD_LIBRARY_PATH in ADIOS2 adapter test CMakeLists.txt. Now dynamically detects conda path from CONDA_PREFIX or CMAKE_PREFIX_PATH and includes CMAKE_BINARY_DIR/bin.

3. **ADIOS2 Duplicate Target**: Added ADIOS2_FOUND guards to prevent find_package(ADIOS2) from being called multiple times, which caused "target already exists" CMake errors.

4. **Mixed Mapping Test Script**: Fixed hardcoded test binary path in run_mixed_mapping_test.sh to work with any build directory.

All 145 tests now pass with ctest -D Experimental.