### PR TITLE
fix: install.sh script failing due to MPI detection in conda build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -85,7 +85,7 @@
                 "WRP_CORE_ENABLE_TESTS": "ON",
                 "WRP_CORE_ENABLE_ELF": "OFF",
                 "WRP_CORE_ENABLE_COMPRESS": "OFF",
-                "WRP_CORE_ENABLE_GRAY_SCOTT": "ON",
+                "WRP_CORE_ENABLE_GRAY_SCOTT": "OFF",
                 "WRP_CORE_ENABLE_CONDA": "ON",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "WRP_CORE_ENABLE_ASAN": "OFF",

--- a/external/iowarp-gray-scott/CMakeLists.txt
+++ b/external/iowarp-gray-scott/CMakeLists.txt
@@ -13,7 +13,9 @@ option(USE_TIMERS "Use profiling timers" OFF)
 option(ENABLE_VTK "Build VTK visualization apps" OFF)
 
 # Find required packages
-find_package(MPI REQUIRED)
+if(NOT MPI_FOUND)
+  find_package(MPI REQUIRED)
+endif()
 if(NOT ADIOS2_FOUND)
   find_package(ADIOS2 REQUIRED)
 endif()
@@ -92,6 +94,7 @@ add_executable(gray-scott
     simulation/writer.cpp
 )
 
+target_include_directories(gray-scott PRIVATE ${MPI_C_INCLUDE_DIRS})
 target_link_libraries(gray-scott
     PRIVATE
         adios2::adios2
@@ -110,6 +113,7 @@ add_executable(pdf_calc
     analysis/pdf_calc.cpp
 )
 
+target_include_directories(pdf_calc PRIVATE ${MPI_C_INCLUDE_DIRS})
 target_link_libraries(pdf_calc
     PRIVATE
         adios2::adios2
@@ -136,6 +140,7 @@ if(ENABLE_VTK OR VTK_ROOT)
     if(VTK_FOUND)
         message(STATUS "  Building isosurface (VTK ${VTK_VERSION})")
         add_executable(isosurface analysis/isosurface.cpp)
+        target_include_directories(isosurface PRIVATE ${MPI_C_INCLUDE_DIRS})
         target_link_libraries(isosurface
             PRIVATE
                 adios2::adios2
@@ -158,6 +163,7 @@ if(ENABLE_VTK OR VTK_ROOT)
     if(VTK_FOUND)
         message(STATUS "  Building find_blobs (VTK ${VTK_VERSION})")
         add_executable(find_blobs analysis/find_blobs.cpp)
+        target_include_directories(find_blobs PRIVATE ${MPI_C_INCLUDE_DIRS})
         target_link_libraries(find_blobs
             PRIVATE
                 adios2::adios2
@@ -179,6 +185,7 @@ if(ENABLE_VTK OR VTK_ROOT)
     if(VTK_FOUND)
         message(STATUS "  Building compute_curvature (VTK ${VTK_VERSION})")
         add_executable(compute_curvature analysis/curvature.cpp)
+        target_include_directories(compute_curvature PRIVATE ${MPI_C_INCLUDE_DIRS})
         target_link_libraries(compute_curvature
             PRIVATE
                 adios2::adios2
@@ -201,6 +208,7 @@ if(ENABLE_VTK OR VTK_ROOT)
     if(VTK_FOUND)
         message(STATUS "  Building render_isosurface (VTK ${VTK_VERSION})")
         add_executable(render_isosurface plot/render_isosurface.cpp)
+        target_include_directories(render_isosurface PRIVATE ${MPI_C_INCLUDE_DIRS})
         target_link_libraries(render_isosurface
             PRIVATE
                 adios2::adios2

--- a/installers/conda/recipe.yaml
+++ b/installers/conda/recipe.yaml
@@ -54,7 +54,6 @@ requirements:
     - hdf5
     - catch2
     - libaio
-    - openmpi
   run:
     - python
     - zeromq
@@ -63,7 +62,6 @@ requirements:
     - hdf5
     - catch2
     - libaio
-    - openmpi
 
 tests:
   - script:


### PR DESCRIPTION
## Summary
- Disable Gray-Scott in release preset since MPI detection fails in rattler-build conda environment
- Add MPI_FOUND check in gray-scott CMakeLists.txt to avoid duplicate find_package calls
- Add explicit MPI include directories to gray-scott targets for proper header resolution
- Remove openmpi from conda recipe requirements since Gray-Scott is disabled by default

## Problem
The `install.sh` script was failing because:
1. The release preset enabled `WRP_CORE_ENABLE_GRAY_SCOTT=ON` which requires ADIOS2 and MPI
2. CMake's FindMPI module couldn't properly detect MPI in the rattler-build conda environment (the `MPI_C_WORKS` test fails)
3. Even when MPI was found, the include paths weren't being propagated to the gray-scott targets

## Solution
- Disabled Gray-Scott in the release preset for conda builds
- Users who need Gray-Scott can use the debug preset or enable it manually with proper MPI configuration
- Improved gray-scott CMakeLists.txt to handle MPI includes explicitly and avoid redundant find_package calls

## Test plan
- [x] Run `./install.sh` and verify it completes successfully
- [x] Verify iowarp-core package is installed in conda environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)