### PR TITLE
Fix HDF5 assimilator chunking and add distributed task support

### DIFF
--- a/context-assimilation-engine/core/include/wrp_cae/core/autogen/core_methods.h
+++ b/context-assimilation-engine/core/include/wrp_cae/core/autogen/core_methods.h
@@ -16,6 +16,7 @@ GLOBAL_CONST chi::u32 kDestroy = 1;
 
 // core-specific methods
 GLOBAL_CONST chi::u32 kParseOmni = 10;
+GLOBAL_CONST chi::u32 kProcessHdf5Dataset = 11;
 }  // namespace Method
 
 }  // namespace wrp_cae::core

--- a/context-assimilation-engine/core/include/wrp_cae/core/core_client.h
+++ b/context-assimilation-engine/core/include/wrp_cae/core/core_client.h
@@ -58,6 +58,32 @@ class Client : public chi::ContainerClient {
     return ipc_manager->Send(task);
   }
 
+  /**
+   * Asynchronous ProcessHdf5Dataset - Process a single HDF5 dataset
+   * Can be routed to a specific node for distributed processing
+   * @param pool_query Pool query for routing (use PoolQuery::Physical(node_id) for specific node)
+   * @param file_path Path to the HDF5 file
+   * @param dataset_path Path to the dataset within the HDF5 file
+   * @param tag_prefix Tag prefix for CTE storage
+   */
+  chi::Future<ProcessHdf5DatasetTask> AsyncProcessHdf5Dataset(
+      const chi::PoolQuery& pool_query,
+      const std::string& file_path,
+      const std::string& dataset_path,
+      const std::string& tag_prefix) {
+    auto* ipc_manager = CHI_IPC;
+
+    auto task = ipc_manager->NewTask<ProcessHdf5DatasetTask>(
+        chi::CreateTaskId(),
+        pool_id_,
+        pool_query,
+        file_path,
+        dataset_path,
+        tag_prefix);
+
+    return ipc_manager->Send(task);
+  }
+
 };
 
 }  // namespace wrp_cae::core

--- a/context-assimilation-engine/core/include/wrp_cae/core/core_runtime.h
+++ b/context-assimilation-engine/core/include/wrp_cae/core/core_runtime.h
@@ -67,6 +67,13 @@ class Runtime : public chi::Container {
    */
   chi::TaskResume ParseOmni(hipc::FullPtr<ParseOmniTask> task, chi::RunContext& ctx);
 
+  /**
+   * ProcessHdf5Dataset - Process a single HDF5 dataset (Method::kProcessHdf5Dataset)
+   * Used for distributed processing where each dataset task is routed to a specific node.
+   * @return TaskResume for coroutine suspension/resumption
+   */
+  chi::TaskResume ProcessHdf5Dataset(hipc::FullPtr<ProcessHdf5DatasetTask> task, chi::RunContext& ctx);
+
  private:
   Client client_;
   std::shared_ptr<wrp_cte::core::Client> cte_client_;

--- a/context-assimilation-engine/core/include/wrp_cae/core/factory/hdf5_file_assimilator.h
+++ b/context-assimilation-engine/core/include/wrp_cae/core/factory/hdf5_file_assimilator.h
@@ -79,9 +79,11 @@ class Hdf5FileAssimilator : public BaseAssimilator {
    */
   int DiscoverDatasets(hid_t file_id, std::vector<std::string>& dataset_paths);
 
+ public:
   /**
    * Process a single dataset: create tag, store description, transfer chunks
    * This is a coroutine that uses co_await for async CTE operations.
+   * Made public for use by Runtime::ProcessHdf5Dataset for distributed processing.
    * @param file_id HDF5 file ID
    * @param dataset_path Path to dataset within file (e.g., "/data/temperature")
    * @param tag_prefix Prefix for tag name (destination path without protocol)
@@ -90,6 +92,8 @@ class Hdf5FileAssimilator : public BaseAssimilator {
    */
   chi::TaskResume ProcessDataset(hid_t file_id, const std::string& dataset_path,
                                   const std::string& tag_prefix, int& error_code);
+
+ private:
 
   /**
    * Get human-readable type name for HDF5 datatype

--- a/context-assimilation-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-assimilation-engine/core/src/autogen/core_lib_exec.cc
@@ -47,6 +47,12 @@ chi::TaskResume Runtime::Run(chi::u32 method, hipc::FullPtr<chi::Task> task_ptr,
       co_await ParseOmni(typed_task, rctx);
       break;
     }
+    case Method::kProcessHdf5Dataset: {
+      // Cast task FullPtr to specific type
+      hipc::FullPtr<ProcessHdf5DatasetTask> typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
+      co_await ProcessHdf5Dataset(typed_task, rctx);
+      break;
+    }
     default: {
       // Unknown method - do nothing
       break;
@@ -71,6 +77,10 @@ void Runtime::DelTask(chi::u32 method, hipc::FullPtr<chi::Task> task_ptr) {
     }
     case Method::kParseOmni: {
       ipc_manager->DelTask(task_ptr.template Cast<ParseOmniTask>());
+      break;
+    }
+    case Method::kProcessHdf5Dataset: {
+      ipc_manager->DelTask(task_ptr.template Cast<ProcessHdf5DatasetTask>());
       break;
     }
     default: {
@@ -99,6 +109,11 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
       archive << *typed_task.ptr_;
       break;
     }
+    case Method::kProcessHdf5Dataset: {
+      auto typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
+      archive << *typed_task.ptr_;
+      break;
+    }
     default: {
       // Unknown method - do nothing
       break;
@@ -121,6 +136,11 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
     }
     case Method::kParseOmni: {
       auto typed_task = task_ptr.template Cast<ParseOmniTask>();
+      archive >> *typed_task.ptr_;
+      break;
+    }
+    case Method::kProcessHdf5Dataset: {
+      auto typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
       archive >> *typed_task.ptr_;
       break;
     }
@@ -160,6 +180,12 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::LocalLoadTaskArchive& archive,
       typed_task.ptr_->SerializeIn(archive);
       break;
     }
+    case Method::kProcessHdf5Dataset: {
+      auto typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
+      // Call SerializeIn - task will call Task::SerializeIn for base fields
+      typed_task.ptr_->SerializeIn(archive);
+      break;
+    }
     default: {
       // Unknown method - do nothing
       break;
@@ -192,6 +218,12 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::LocalSaveTaskArchive& archive,
     }
     case Method::kParseOmni: {
       auto typed_task = task_ptr.template Cast<ParseOmniTask>();
+      // Call SerializeOut - task will call Task::SerializeOut for base fields
+      typed_task.ptr_->SerializeOut(archive);
+      break;
+    }
+    case Method::kProcessHdf5Dataset: {
+      auto typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
       // Call SerializeOut - task will call Task::SerializeOut for base fields
       typed_task.ptr_->SerializeOut(archive);
       break;
@@ -243,6 +275,17 @@ hipc::FullPtr<chi::Task> Runtime::NewCopyTask(chi::u32 method, hipc::FullPtr<chi
       }
       break;
     }
+    case Method::kProcessHdf5Dataset: {
+      // Allocate new task
+      auto new_task_ptr = ipc_manager->NewTask<ProcessHdf5DatasetTask>();
+      if (!new_task_ptr.IsNull()) {
+        // Copy task fields (includes base Task fields)
+        auto task_typed = orig_task_ptr.template Cast<ProcessHdf5DatasetTask>();
+        new_task_ptr->Copy(task_typed);
+        return new_task_ptr.template Cast<chi::Task>();
+      }
+      break;
+    }
     default: {
       // For unknown methods, create base Task copy
       auto new_task_ptr = ipc_manager->NewTask<chi::Task>();
@@ -253,7 +296,7 @@ hipc::FullPtr<chi::Task> Runtime::NewCopyTask(chi::u32 method, hipc::FullPtr<chi
       break;
     }
   }
-  
+
   (void)deep;    // Deep copy parameter reserved for future use
   return hipc::FullPtr<chi::Task>();
 }
@@ -275,6 +318,10 @@ hipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
     }
     case Method::kParseOmni: {
       auto new_task_ptr = ipc_manager->NewTask<ParseOmniTask>();
+      return new_task_ptr.template Cast<chi::Task>();
+    }
+    case Method::kProcessHdf5Dataset: {
+      auto new_task_ptr = ipc_manager->NewTask<ProcessHdf5DatasetTask>();
       return new_task_ptr.template Cast<chi::Task>();
     }
     default: {
@@ -307,6 +354,14 @@ void Runtime::Aggregate(chi::u32 method, hipc::FullPtr<chi::Task> origin_task_pt
       // Get typed tasks for Aggregate call
       auto typed_origin = origin_task_ptr.template Cast<ParseOmniTask>();
       auto typed_replica = replica_task_ptr.template Cast<ParseOmniTask>();
+      // Call Aggregate (uses task-specific Aggregate if available, otherwise base Task::Aggregate)
+      typed_origin.ptr_->Aggregate(typed_replica);
+      break;
+    }
+    case Method::kProcessHdf5Dataset: {
+      // Get typed tasks for Aggregate call
+      auto typed_origin = origin_task_ptr.template Cast<ProcessHdf5DatasetTask>();
+      auto typed_replica = replica_task_ptr.template Cast<ProcessHdf5DatasetTask>();
       // Call Aggregate (uses task-specific Aggregate if available, otherwise base Task::Aggregate)
       typed_origin.ptr_->Aggregate(typed_replica);
       break;


### PR DESCRIPTION
This commit fixes the HDF5 file assimilator to properly handle large datasets and adds infrastructure for CTE-native distributed processing.

Key changes:
- Fix HDF5 dataset reading hang by replacing broken hyperslab approach with malloc-based full dataset read followed by chunked CTE transfers
- Add ProcessHdf5DatasetTask for per-dataset distributed task routing
- Add AsyncProcessHdf5Dataset client method with PoolQuery for node targeting
- Update core_lib_exec.cc with ProcessHdf5DatasetTask dispatch cases
- Make ProcessDataset public in hdf5_file_assimilator.h for Runtime access
- Add kProcessHdf5Dataset method constant

The previous hyperslab implementation created a disconnected flat_space dataspace that HDF5 couldn't map to file data, causing reads to hang. The fix reads entire datasets using malloc (bypassing 2MB IPC allocator limit) then chunks data into 1.5MB pieces for CTE transfer.

Tested with TERRA benchmark: 5.3GB processed at ~38 MB/s on 2-4 nodes.