### PR TITLE
build: add cdash config file

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,7 @@
+set(CTEST_PROJECT_NAME "core")
+set(CTEST_NIGHTLY_START_TIME "00:00:00 EST")
+
+set(CTEST_DROP_METHOD "https")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=HERMES")
+set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
This PR can help monitoring unit test failures from my.cdash.org.