### PR TITLE
fix: remove double-free in ContextRetrieve

### DIFF
--- a/context-exploration-engine/api/src/context_interface.cc
+++ b/context-exploration-engine/api/src/context_interface.cc
@@ -277,10 +277,8 @@ std::vector<std::string> ContextInterface::ContextRetrieve(
         }
       }
 
-      // Delete all tasks in this batch
-      for (auto& task : tasks) {
-        ipc_manager->DelTask(task.GetTaskPtr());
-      }
+      // Task cleanup is handled by Future destructors when 'tasks'
+      // goes out of scope. Manual DelTask here causes a double-free.
     }
 
     // Convert buffer to std::string

--- a/context-exploration-engine/api/test/CMakeLists.txt
+++ b/context-exploration-engine/api/test/CMakeLists.txt
@@ -140,7 +140,31 @@ if(TARGET wrp_cee)
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
   )
 
-  message(STATUS "CEE Python tests (basic and enhanced) configured")
+  # Copy retrieve roundtrip regression test to build directory
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_context_retrieve_roundtrip.py
+    ${CMAKE_CURRENT_BINARY_DIR}/test_context_retrieve_roundtrip.py
+    COPYONLY
+  )
+
+  # Add retrieve roundtrip test to CTest
+  add_test(
+    NAME test_context_retrieve_roundtrip_python
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/test_context_retrieve_roundtrip.py
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+  set_tests_properties(test_context_retrieve_roundtrip_python PROPERTIES
+    LABELS "cee;api;python;retrieve;regression"
+    TIMEOUT 120
+  )
+
+  install(FILES test_context_retrieve_roundtrip.py
+    DESTINATION share/wrp_cee/test
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  )
+
+  message(STATUS "CEE Python tests (basic, enhanced, and retrieve roundtrip) configured")
 else()
   message(STATUS "CEE Python test skipped (Python bindings not built)")
 endif()

--- a/context-exploration-engine/api/test/test_context_retrieve_roundtrip.py
+++ b/context-exploration-engine/api/test/test_context_retrieve_roundtrip.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Regression test for context_retrieve double-free (issue #192).
+
+Tests full data round-trip: bundle -> query -> retrieve -> verify -> destroy.
+On main this test crashes with SIGABRT (double-free in ContextRetrieve).
+With the fix (removing manual DelTask loop), it passes.
+
+Requires a running IOWarp runtime with wrp_cte_core and wrp_cae_core modules.
+"""
+
+import sys
+import os
+import tempfile
+
+# Add build directory to path for module import
+sys.path.insert(0, os.path.join(os.getcwd(), "bin"))
+sys.path.insert(0, "/usr/local/lib/python3.13/site-packages")
+
+
+def test_retrieve_roundtrip():
+    """Put data into IOWarp, retrieve it, and verify content matches."""
+    import wrp_cee as cee
+
+    ctx_interface = cee.ContextInterface()
+    tag_name = "test_retrieve_roundtrip"
+
+    # Use /dev/shm so the runtime container can also access the file
+    tmpdir = tempfile.mkdtemp(prefix="iowarp_test_", dir="/dev/shm")
+    test_file = os.path.join(tmpdir, "test_data.bin")
+
+    # Create test file with known pattern
+    pattern = b"IOWarp-Roundtrip-Test-" + b"0123456789ABCDEF"
+    file_size = 64 * 1024  # 64 KB
+    original_data = (pattern * (file_size // len(pattern) + 1))[:file_size]
+    with open(test_file, "wb") as f:
+        f.write(original_data)
+
+    try:
+        # 1. Bundle (put)
+        ctx = cee.AssimilationCtx(
+            src=f"file::{test_file}",
+            dst=f"iowarp::{tag_name}",
+            format="binary",
+        )
+        bundle_result = ctx_interface.context_bundle([ctx])
+        assert bundle_result == 0, f"context_bundle failed with code {bundle_result}"
+
+        # 2. Query (verify blobs exist)
+        blobs = ctx_interface.context_query(tag_name, ".*", 0)
+        assert len(blobs) > 0, "context_query returned no blobs after bundle"
+
+        # 3. Retrieve (get data back) - this crashes on main with double-free
+        packed_data = ctx_interface.context_retrieve(
+            tag_name, ".*",
+            max_results=1024,
+            max_context_size=4 * 1024 * 1024,
+            batch_size=32,
+        )
+        total_size = sum(len(d) for d in packed_data)
+        assert total_size > 0, "context_retrieve returned no data"
+
+        # 4. Verify content
+        retrieved_bytes = b"".join(
+            d.encode("latin-1") if isinstance(d, str) else d
+            for d in packed_data
+        )
+        assert original_data in retrieved_bytes, (
+            f"Retrieved data ({len(retrieved_bytes)} bytes) does not contain "
+            f"original data ({len(original_data)} bytes)"
+        )
+
+        # 5. Destroy (cleanup)
+        destroy_result = ctx_interface.context_destroy([tag_name])
+        assert destroy_result == 0, f"context_destroy failed with code {destroy_result}"
+
+        return True
+
+    finally:
+        os.unlink(test_file)
+        os.rmdir(tmpdir)
+
+
+def main():
+    print("=" * 60)
+    print(" Regression test: context_retrieve round-trip (#192)")
+    print("=" * 60)
+
+    try:
+        success = test_retrieve_roundtrip()
+        if success:
+            print("\nPASS: Data round-trip verified successfully")
+            return 0
+    except AssertionError as e:
+        print(f"\nFAIL: {e}")
+        return 1
+    except Exception as e:
+        print(f"\nFAIL: {e}")
+        return 1
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Remove manual `DelTask` loop in `ContextInterface::ContextRetrieve` that double-frees GetBlob tasks already cleaned up by `Future` destructors

## What was happening
`context_retrieve` in the `wrp_cee` Python API crashes with `free(): double free detected in tcache 2` every time it's called. The `bundle`, `query`, and `destroy` operations all work fine.

## Root cause
In `context_interface.cc:280-283`, a manual `DelTask` loop frees each `GetBlobTask`. But the `Future` destructor also frees the same task when `tasks` goes out of scope at the end of the batch loop iteration. Other async tasks in the same function (`AsyncGetOrCreateTag`, `AsyncGetBlobSize`) correctly rely on `Future` destructors without manual `DelTask`.

## How verified
1. Started runtime via `iowarp/cte-bench:latest` Docker image
2. Rebuilt `libwrp_cee_api.so` with the fix, mounted over the original
3. Ran Python test: put 256KB file via `context_bundle` -> `context_query` found blobs -> `context_retrieve` returned data -> verified exact content match -> `context_destroy` cleaned up
4. Full round-trip **PASS** (was crashing before the fix)

Fixes #192

## Test plan
- [x] Python wrp_cee put/get/verify round-trip passes with patched library
- [x] C++ CTE Tag API put/get/verify still passes (unaffected by this change)
- [ ] CI tests