### PR TITLE
Fix uid mismatch to enable file writes from both host and container

### DIFF
--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -4,6 +4,8 @@
 # This devcontainer adds development-specific tools like Claude Code.
 #
 FROM iowarp/deps-cpu:latest
+USER root
+RUN userdel -r ubuntu || true
 
 # The deps-cpu image already includes:
 # - All conda dependencies (boost, hdf5, yaml-cpp, zeromq, cereal, etc.)

--- a/.devcontainer/nvidia-gpu/Dockerfile
+++ b/.devcontainer/nvidia-gpu/Dockerfile
@@ -4,6 +4,8 @@
 # This devcontainer adds development-specific tools like Claude Code.
 #
 FROM iowarp/deps-nvidia:latest
+USER root
+RUN userdel -r ubuntu || true
 
 # The deps-nvidia image already includes (inherited from deps-cpu):
 # - All conda dependencies (boost, hdf5, yaml-cpp, zeromq, cereal, etc.)


### PR DESCRIPTION
Changes in this PR:

- Fix issue #184 by removing user ubuntu in the image to allow devcontainer to match uid