### PR TITLE
273 eventmanageraddevent causes epoll ctl eexist errors due to duplicate fd registration

### DIFF
--- a/context-transport-primitives/include/hermes_shm/lightbeam/event_manager.h
+++ b/context-transport-primitives/include/hermes_shm/lightbeam/event_manager.h
@@ -95,7 +95,7 @@ class EventManager {
         return -1;
       }
       it->second.action_ = action;
-      return it->second.event_id;
+      return it->second.event_id_;
     }
     int event_id = next_event_id_++;
     if (epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, fd, &ev) == -1) {


### PR DESCRIPTION
In context-runtime/modules/admin/src/admin_runtime.cc (lines ~102-118), the admin runtime calls RegisterEventManager() for both TCP and
IPC transports on the same worker's EventManager. The RegisterEventManager() in socket_transport.h iterates through client_fds_ and
calls AddEvent() for each. If a ZMQ transport has already registered certain file descriptors, the socket transport tries to add them again,
causing epoll_ctl(EPOLL_CTL_ADD) to fail with EEXIST.

A code to check if the event exists or not is added to avoid the error message. 