### PR TITLE
Rename runtime-deployment submodule to jarvis-cd, add Docker venv install

### DIFF
--- a/docker/deploy-cpu.Dockerfile
+++ b/docker/deploy-cpu.Dockerfile
@@ -40,12 +40,14 @@ FROM iowarp/deps-cpu:latest AS builder
 WORKDIR /workspace
 COPY . /workspace/
 
-ENV PATH="/home/iowarp/.local/bin:${PATH}"
+ENV VIRTUAL_ENV="/home/iowarp/venv"
+ENV PATH="${VIRTUAL_ENV}/bin:/home/iowarp/.local/bin:${PATH}"
 
 RUN sudo chown -R $(whoami):$(whoami) /workspace && \
     git submodule update --init --recursive && \
-    cd /workspace/external/runtime-deployment && \
-    pip3 install --break-system-packages -e . -r requirements.txt && \
+    cd /workspace/external/jarvis-cd && \
+    pip install -r requirements.txt && \
+    pip install -e . && \
     jarvis init && \
     jarvis rg build && \
     jarvis repo add /workspace/jarvis_iowarp && \


### PR DESCRIPTION
## Summary
- Rename `external/runtime-deployment` submodule to `external/jarvis-cd` (URL unchanged)
- Install Jarvis-CD into Python venv in `deps-cpu.Dockerfile` and `deploy-cpu.Dockerfile`
- Set `VIRTUAL_ENV` env var so the venv is active in all shell contexts (interactive, non-interactive, CI)
- Remove `--break-system-packages` from `deploy-cpu.Dockerfile` in favor of the venv
- Add submodule clone instructions (`--recurse-submodules`) to `README.md`

## Test plan
- [x] Verified `pip install -r requirements.txt && pip install -e .` succeeds from the submodule
- [x] Verified `jarvis --help` runs correctly after install
- [x] Full `docker build` of `deploy-cpu.Dockerfile` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)