### PR TITLE
Disable conda in Docker container builds

### DIFF
--- a/docker/deploy-cpu.Dockerfile
+++ b/docker/deploy-cpu.Dockerfile
@@ -54,7 +54,7 @@ RUN sudo chown -R $(whoami):$(whoami) /workspace && \
     cd /workspace && \
     mkdir -p build && \
     cd build && \
-    cmake --preset build-cpu-release ../ && \
+    cmake --preset build-cpu-release -DWRP_CORE_ENABLE_CONDA=OFF ../ && \
     sudo make -j$(nproc) install
 
 # Seed default config at ~/.chimaera/chimaera.yaml (picked up automatically by runtime)

--- a/docker/redis_bench/Dockerfile
+++ b/docker/redis_bench/Dockerfile
@@ -17,7 +17,7 @@ RUN sudo chown -R $(whoami):$(whoami) /workspace && \
     git submodule update --init --recursive && \
     mkdir -p build && \
     cd build && \
-    cmake --preset build-cpu-release ../ && \
+    cmake --preset build-cpu-release -DWRP_CORE_ENABLE_CONDA=OFF ../ && \
     sudo make -j$(nproc) install && \
     sudo rm -rf /workspace
 

--- a/docker/wrp_cte_bench/Dockerfile
+++ b/docker/wrp_cte_bench/Dockerfile
@@ -17,7 +17,7 @@ RUN sudo chown -R $(whoami):$(whoami) /workspace && \
     git submodule update --init --recursive && \
     mkdir -p build && \
     cd build && \
-    cmake --preset build-cpu-release ../ && \
+    cmake --preset build-cpu-release -DWRP_CORE_ENABLE_CONDA=OFF ../ && \
     sudo make -j$(nproc) install && \
     sudo rm -rf /workspace
 


### PR DESCRIPTION
## Summary
- Override `WRP_CORE_ENABLE_CONDA=OFF` in all Docker builds (`deploy-cpu`, `redis_bench`, `wrp_cte_bench`)
- Docker containers use apt/source-built deps, not conda, so the preset default of `CONDA=ON` causes CMake to fail with `CONDA_PREFIX not set`

## Test plan
- [x] CI `build-core-containers` workflow passes on this branch (run 22253164910) — all jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)