### PR TITLE
fix: single-source version from CMakeLists.txt

### DIFF
--- a/installers/pip/iowarp_core/__init__.py
+++ b/installers/pip/iowarp_core/__init__.py
@@ -8,7 +8,11 @@ import ctypes
 import os
 import sys
 
-__version__ = "1.0.0"
+try:
+    from importlib.metadata import version as _pkg_version
+    __version__ = _pkg_version("iowarp-core")
+except Exception:
+    __version__ = "0.0.0-dev"
 
 _PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 _LIB_DIR = os.path.join(_PACKAGE_DIR, "lib")

--- a/installers/pip/pyproject.toml
+++ b/installers/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "iowarp-core"
-version = "1.0.0"
+dynamic = ["version"]
 description = "IOWarp Context Management Platform"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
@@ -55,3 +55,7 @@ WRP_CORE_ENABLE_CUDA = "OFF"
 WRP_CORE_ENABLE_ROCM = "OFF"
 WRP_CORE_ENABLE_OPENMP = "OFF"
 HSHM_LOG_LEVEL = "1"
+
+[tool.scikit-build.metadata]
+version.provider = "scikit_build_core.metadata.cmake"
+version.provider-path = "../.."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "iowarp-core"
-version = "1.0.0"
+dynamic = ["version"]
 description = "IOWarp Context Management Platform"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
@@ -56,3 +56,7 @@ WRP_CORE_ENABLE_ROCM = "OFF"
 WRP_CORE_ENABLE_OPENMP = "OFF"
 WRP_CORE_ENABLE_IO_URING = "ON"
 HSHM_LOG_LEVEL = "1"
+
+[tool.scikit-build.metadata]
+version.provider = "scikit_build_core.metadata.cmake"
+version.provider-path = "."


### PR DESCRIPTION
## Summary
- Replace hardcoded `version = "1.0.0"` in both `pyproject.toml` files with `dynamic = ["version"]` and scikit-build-core's CMake metadata provider
- Replace hardcoded `__version__` in `__init__.py` with runtime `importlib.metadata` lookup
- `CMakeLists.txt` line 2 is now the single source of truth for the package version

## Test plan
- [ ] `cmake -B build -S .` still sets `PROJECT_VERSION` correctly
- [ ] `pip install .` produces a wheel with the correct version from CMake
- [ ] `python -c "import iowarp_core; print(iowarp_core.get_version())"` prints the CMake version

🤖 Generated with [Claude Code](https://claude.com/claude-code)