### PR TITLE
fix: bump version to 1.0.1 for PyPI release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.0.0 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.0.1 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options


### PR DESCRIPTION
## Summary
- Bump version to 1.0.1 in CMakeLists.txt (single source of truth)
- Version 1.0.0 is permanently reserved on PyPI after a prior upload/delete

## Test plan
- [ ] CI pip wheel build passes and publishes to PyPI as 1.0.1
- [ ] `pip install iowarp-core==1.0.1` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)