### PR TITLE
feat: make bare import wrp_cee work for pip installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.0.2 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.0.3 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options
@@ -973,6 +973,12 @@ endif()
 install(FILES context-runtime/config/chimaera_default.yaml
   COMPONENT pip_package
   DESTINATION ${PIP_PKG_DIR}/data)
+
+# .pth file at site-packages root so "import wrp_cee" works without
+# explicitly importing iowarp_core first (triggers _setup() at startup).
+install(FILES installers/pip/iowarp_core.pth
+  COMPONENT pip_package
+  DESTINATION .)
 
 #------------------------------------------------------------------------------
 # CPack Configuration

--- a/installers/pip/iowarp_core.pth
+++ b/installers/pip/iowarp_core.pth
@@ -1,0 +1,1 @@
+import iowarp_core

--- a/installers/pip/iowarp_core/__init__.py
+++ b/installers/pip/iowarp_core/__init__.py
@@ -2,9 +2,15 @@
 
 Sets up library search paths so IOWarp shared libraries and Python
 extensions can be loaded without system-wide installation.
+
+Usage::
+
+    import wrp_cee as cee          # Context Exploration Engine
+    import wrp_cte_core_ext        # Context Transfer Engine
 """
 
 import ctypes
+import importlib
 import os
 import shutil
 import sys
@@ -21,6 +27,10 @@ _EXT_DIR = os.path.join(_PACKAGE_DIR, "ext")
 _BIN_DIR = os.path.join(_PACKAGE_DIR, "bin")
 _DATA_DIR = os.path.join(_PACKAGE_DIR, "data")
 
+# Extension modules that live in ext/ and can be imported via
+# "from iowarp_core import <name>".
+_EXT_MODULES = {"wrp_cee", "wrp_cte_core_ext"}
+
 
 def _setup():
     """Configure library and extension paths at import time."""
@@ -32,19 +42,32 @@ def _setup():
                 _LIB_DIR + ":" + ld_path if ld_path else _LIB_DIR
             )
 
-        # Pre-load shared libraries in dependency order with RTLD_GLOBAL
-        # so symbols are available to all subsequently loaded IOWarp libraries.
+        # Pre-load ALL shared libraries in dependency order with RTLD_GLOBAL
+        # so symbols are globally visible to subsequently loaded extensions.
         # LD_LIBRARY_PATH changes above only affect child processes, so we
         # must explicitly load each library for the current process.
+        # Python loads extension modules with RTLD_LOCAL by default, which
+        # hides symbols from transitive dependencies and breaks nanobind
+        # modules like wrp_cee that depend on multiple IOWarp libraries.
         for _lib_name in [
             "libhermes_shm_host.so",
             "libchimaera_cxx.so",
+            "libchimaera_admin_client.so",
+            "libchimaera_admin_runtime.so",
+            "libchimaera_bdev_client.so",
+            "libchimaera_bdev_runtime.so",
+            "libwrp_cte_core_client.so",
+            "libwrp_cte_core_runtime.so",
+            "libwrp_cte_cae_config.so",
+            "libwrp_cae_core_client.so",
+            "libwrp_cae_core_runtime.so",
+            "libwrp_cee_api.so",
         ]:
             _lib_path = os.path.join(_LIB_DIR, _lib_name)
             if os.path.exists(_lib_path):
                 ctypes.CDLL(_lib_path, mode=ctypes.RTLD_GLOBAL)
 
-    # Add ext/ to sys.path so 'import wrp_cte_core_ext' works
+    # Add ext/ to sys.path so extension modules can be found by import
     if os.path.isdir(_EXT_DIR) and _EXT_DIR not in sys.path:
         sys.path.insert(0, _EXT_DIR)
 
@@ -62,6 +85,13 @@ def _setup():
 
 
 _setup()
+
+
+# PEP 562: "from iowarp_core import wrp_cee" lazily loads the extension.
+def __getattr__(name):
+    if name in _EXT_MODULES:
+        return importlib.import_module(name)
+    raise AttributeError(f"module 'iowarp_core' has no attribute {name!r}")
 
 
 def get_version():
@@ -91,10 +121,17 @@ def get_data_dir():
 
 def cte_available():
     """Check if the Context Transfer Engine extension is available."""
-    ext_path = os.path.join(_EXT_DIR, "wrp_cte_core_ext")
-    # Check for any .so file matching the extension name
     if os.path.isdir(_EXT_DIR):
         for f in os.listdir(_EXT_DIR):
             if f.startswith("wrp_cte_core_ext") and f.endswith(".so"):
+                return True
+    return False
+
+
+def cee_available():
+    """Check if the Context Exploration Engine extension is available."""
+    if os.path.isdir(_EXT_DIR):
+        for f in os.listdir(_EXT_DIR):
+            if f.startswith("wrp_cee") and f.endswith(".so"):
                 return True
     return False


### PR DESCRIPTION
## Summary
- Add `.pth` file to trigger `iowarp_core._setup()` at Python startup, ensuring `ext/` is on `sys.path` so bare `import wrp_cee` works consistently across cmake, conda, and pip installs
- Preload all 12 shared libraries with `RTLD_GLOBAL` in dependency order so nanobind extensions find their symbols
- Add `__getattr__` for `from iowarp_core import wrp_cee` convenience, plus `cee_available()` / `cte_available()` helpers
- Bump version to 1.0.3

## Test plan
- [ ] `pip install iowarp-core` from PyPI
- [ ] `python -c "import wrp_cee"` works without importing iowarp_core first
- [ ] `python -c "from iowarp_core import wrp_cee"` also works
- [ ] `python -c "import iowarp_core; print(iowarp_core.get_version())"` prints 1.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)