### PR TITLE
fix(lsan): suppress CAE autogen DefineModel leaks resolved via bdev v…

### DIFF
--- a/CI/lsan_suppressions.txt
+++ b/CI/lsan_suppressions.txt
@@ -167,6 +167,19 @@ leak:chi::LocalLoadTaskArchive::bulk
 leak:context-transfer-engine/core/src/autogen/core_lib_exec.cc
 
 # ---------------------------------------------------------------------------
+# CAE core module: coroutine frame / DefineModel allocations in autogen Init
+# wrp_cae::core::Runtime::Init() in context-assimilation-engine/core/src/
+# autogen/core_lib_exec.cc calls DefineModel() (and other Init-time methods)
+# through the Container vtable. When the vtable entry for DefineModel resolves
+# to the copy compiled into libchimaera_bdev_runtime.so (dynamic-linker
+# first-wins for weak inline symbols), the frame lacks a source path and
+# leak:chimaera/container.h cannot match it. Suppress by Init call-site: all
+# allocations during CAE pool creation are architectural (runtime-lifetime
+# containers not destroyed on server shutdown), identical to the CTE pattern.
+# ---------------------------------------------------------------------------
+leak:context-assimilation-engine/core/src/autogen/core_lib_exec.cc
+
+# ---------------------------------------------------------------------------
 # bdev / ZMQ transport: block-data vectors allocated during RecvBulks
 # hshm::lbm::ZeroMqTransport::RecvBulks<chi::LoadTaskArchive>() receives a
 # ZMQ multi-part message and deserialises bdev Block entries into heap vectors


### PR DESCRIPTION
…table

In CAE pool initialization, wrp_cae::core::Runtime::Init() calls Container::DefineModel() through the vtable. Due to dynamic-linker first-wins resolution of weak inline symbols, the vtable entry can resolve to the copy compiled into libchimaera_bdev_runtime.so, which lacks DWARF source info for the frame. This means the existing leak:chimaera/container.h suppression cannot match the frame.

Adding leak:context-assimilation-engine/core/src/autogen/core_lib_exec.cc covers all allocations during CAE pool creation via the Init call-site, which always has a source path. This eliminates the 28 CDash defects from ASan build 3391668 (stamp 20260303-0407).