### PR TITLE
fix: Futures memory leak & fix: build issues

### DIFF
--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -786,8 +786,9 @@ class IpcManager {
 
   /** Route a task: resolve pool query, determine local vs global.
    * If force_enqueue is true, always enqueue to the destination worker's lane
-   * (used by SendRuntime which cannot execute tasks directly). */
-  RouteResult RouteTask(Future<Task> &future, bool force_enqueue = false);
+   * (used by SendRuntime which cannot execute tasks directly).
+   * Returns true if the task was routed locally, false if sent over network. */
+  bool RouteTask(Future<Task> &future, bool force_enqueue = false);
 
   /** Resolve a pool query into concrete physical addresses */
   std::vector<PoolQuery> ResolvePoolQuery(const PoolQuery &query,
@@ -799,11 +800,13 @@ class IpcManager {
                    const std::vector<PoolQuery> &pool_queries);
 
   /** Route task locally.
-   * If force_enqueue is true, always enqueue even if dest == current worker. */
-  RouteResult RouteLocal(Future<Task> &future, bool force_enqueue = false);
+   * If force_enqueue is true, always enqueue even if dest == current worker.
+   * Returns true if the task was routed locally. */
+  bool RouteLocal(Future<Task> &future, bool force_enqueue = false);
 
-  /** Route task globally via network */
-  RouteResult RouteGlobal(Future<Task> &future,
+  /** Route task globally via network.
+   * Returns false (task was sent to network, not local). */
+  bool RouteGlobal(Future<Task> &future,
                    const std::vector<PoolQuery> &pool_queries);
 
 #if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -815,6 +815,12 @@ class IpcManager {
   void RouteToGpu(const hipc::FullPtr<Task> &task_ptr, Container *container,
                   u32 gpu_id = 0);
 #endif
+  /** Launch the GPU megakernel. Returns true on success (or no GPUs present). */
+  bool LaunchMegakernel();
+  /** Pause the running GPU megakernel (no-op if no GPU support). */
+  void PauseMegakernel();
+  /** Resume a paused GPU megakernel (no-op if no GPU support). */
+  void ResumeMegakernel();
 
   /**
    * Send a task via SHM lightbeam transport

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -84,6 +84,12 @@ enum class NetQueuePriority : u32 {
   kClientSendIpc = 3,  ///< Priority 3: Client response via IPC
 };
 
+/** Result of RouteTask: whether task stays local (GPU/CPU) or goes over network */
+enum class RouteResult : u32 {
+  Local = 0,    ///< Task stays on the current processor (GPU stays on GPU)
+  Network = 1,  ///< Task must be sent over the network or CPU↔GPU boundary
+};
+
 /**
  * Network queue for storing Future<SendTask> objects
  * One lane with two priorities (SendIn and SendOut)

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -2249,8 +2249,7 @@ HSHM_CROSS_FUN Future<TaskT, AllocT>::~Future() {
       CHI_IPC->FreeBuffer(buffer_shm);
       future_shm_.SetNull();
     }
-    // Auto-free the task (only when consumed to avoid double-free
-    // from runtime-internal Future copies in event queues / RunContext)
+    // Free the heap-allocated task object
     DelTask();
   }
 }

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -635,11 +635,11 @@ void Runtime::SendOut(hipc::FullPtr<chi::Task> origin_task) {
 
   HLOG(kDebug, "[SendOut] Task {}", origin_task->task_id_);
 
-  // Clear TASK_DATA_OWNER before deferred deletion so the destructor
-  // doesn't try to FreeBuffer on transport-allocated data
-  origin_task->ClearFlags(TASK_DATA_OWNER);
-
-  // Defer task deletion to next invocation for zero-copy send safety
+  // Defer task deletion to next invocation for zero-copy send safety.
+  // TASK_DATA_OWNER is intentionally left set so that task destructors
+  // (e.g. ~ReadTask) can free BULK_EXPOSE-allocated buffers.  The
+  // MallocAllocator magic-guard in FreeOffsetNoNullCheck makes FreeBuffer
+  // a safe no-op for any ZMQ zero-copy pointer that lacks the header.
   deferred_deletes.push_back(origin_task);
 }
 
@@ -1231,11 +1231,10 @@ chi::TaskResume Runtime::ClientSend(hipc::FullPtr<ClientSendTask> task,
         HLOG(kError, "ClientSend: lightbeam Send failed: {}", rc);
       }
 
-      // Clear TASK_DATA_OWNER before deferred deletion so the destructor
-      // doesn't try to FreeBuffer on transport-allocated data
-      origin_task->ClearFlags(TASK_DATA_OWNER);
-
-      // Defer task deletion to next invocation for zero-copy send safety
+      // TASK_DATA_OWNER is intentionally left set so that task destructors
+      // (e.g. ~ReadTask) can free BULK_EXPOSE-allocated buffers.  The
+      // MallocAllocator magic-guard makes FreeBuffer a safe no-op for any
+      // non-HSHM pointer.
       deferred_deletes.push_back(origin_task);
 
       did_work = true;

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -800,6 +800,14 @@ void IpcManager::ResumeMegakernel() {
 #endif
 }
 
+void IpcManager::PauseGpuOrchestrator() {
+  PauseMegakernel();
+}
+
+void IpcManager::ResumeGpuOrchestrator() {
+  ResumeMegakernel();
+}
+
 bool IpcManager::ClientInitQueues() {
   if (!main_allocator_) {
     return false;

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -725,27 +725,6 @@ bool IpcManager::ServerInitGpuQueues() {
   }
 }
 
-bool IpcManager::LaunchMegakernel() {
-  int num_gpus = hshm::GpuApi::GetDeviceCount();
-  if (num_gpus == 0) {
-    return true;  // No GPUs, nothing to do
-  }
-
-  ConfigManager *config = CHI_CONFIG_MANAGER;
-  u32 blocks = config->GetGpuBlocks();
-  u32 threads_per_block = config->GetGpuThreadsPerBlock();
-
-  auto *launcher = new MegakernelLauncher();
-  if (!launcher->Launch(gpu_megakernel_info_, blocks, threads_per_block)) {
-    HLOG(kError, "Failed to launch megakernel");
-    delete launcher;
-    return false;
-  }
-
-  megakernel_launcher_ = launcher;
-  return true;
-}
-
 void IpcManager::FinalizeMegakernel() {
   if (megakernel_launcher_) {
     auto *launcher = static_cast<MegakernelLauncher *>(megakernel_launcher_);
@@ -777,6 +756,29 @@ void IpcManager::RegisterMegakernelContainer(const PoolId &pool_id,
 }
 
 #endif
+
+bool IpcManager::LaunchMegakernel() {
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
+  int num_gpus = hshm::GpuApi::GetDeviceCount();
+  if (num_gpus == 0) {
+    return true;  // No GPUs, nothing to do
+  }
+
+  ConfigManager *config = CHI_CONFIG_MANAGER;
+  u32 blocks = config->GetGpuBlocks();
+  u32 threads_per_block = config->GetGpuThreadsPerBlock();
+
+  auto *launcher = new MegakernelLauncher();
+  if (!launcher->Launch(gpu_megakernel_info_, blocks, threads_per_block)) {
+    HLOG(kError, "Failed to launch megakernel");
+    delete launcher;
+    return false;
+  }
+
+  megakernel_launcher_ = launcher;
+#endif
+  return true;
+}
 
 void IpcManager::PauseMegakernel() {
 #if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -88,6 +88,17 @@ set(CLIENT_RETRY_TEST_SOURCES
   test_client_retry.cc
 )
 
+# Future task cleanup regression test
+set(FUTURE_TASK_CLEANUP_TEST_TARGET chimaera_future_task_cleanup_tests)
+set(FUTURE_TASK_CLEANUP_TEST_SOURCES
+  test_future_task_cleanup.cc
+)
+
+# BULK_EXPOSE buffer cleanup regression test
+set(BULK_EXPOSE_CLEANUP_TEST_TARGET chimaera_bulk_expose_cleanup_tests)
+set(BULK_EXPOSE_CLEANUP_TEST_SOURCES
+  test_bulk_expose_cleanup.cc
+)
 
 # GPU IPC AllocateBuffer test executable (only if CUDA or HIP is enabled)
 set(IPC_ALLOCATE_BUFFER_GPU_TEST_TARGET test_ipc_allocate_buffer_gpu)
@@ -296,6 +307,56 @@ set_target_properties(${STREAMING_TEST_TARGET} PROPERTIES
 )
 
 set_target_properties(${STREAMING_TEST_TARGET} PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# Create Future task cleanup regression test executable
+add_executable(${FUTURE_TASK_CLEANUP_TEST_TARGET} ${FUTURE_TASK_CLEANUP_TEST_SOURCES})
+
+target_include_directories(${FUTURE_TASK_CLEANUP_TEST_TARGET} PRIVATE
+  ${CHIMAERA_ROOT}/include
+  ${CHIMAERA_ROOT}/test  # For simple_test.h
+  ${CHIMAERA_ROOT}/modules/MOD_NAME/include  # For MOD_NAME client and tasks
+)
+
+target_link_libraries(${FUTURE_TASK_CLEANUP_TEST_TARGET}
+  chimaera_cxx               # Main Chimaera library
+  chimaera_MOD_NAME_client   # MOD_NAME client
+  chimaera_MOD_NAME_runtime  # MOD_NAME runtime
+  hshm::cxx                  # HermesShm library
+  ${CMAKE_THREAD_LIBS_INIT}  # Threading support
+)
+
+set_target_properties(${FUTURE_TASK_CLEANUP_TEST_TARGET} PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+)
+
+set_target_properties(${FUTURE_TASK_CLEANUP_TEST_TARGET} PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# Create BULK_EXPOSE cleanup regression test executable
+add_executable(${BULK_EXPOSE_CLEANUP_TEST_TARGET} ${BULK_EXPOSE_CLEANUP_TEST_SOURCES})
+
+target_include_directories(${BULK_EXPOSE_CLEANUP_TEST_TARGET} PRIVATE
+  ${CHIMAERA_ROOT}/include
+  ${CHIMAERA_ROOT}/test  # For simple_test.h
+  ${CHIMAERA_ROOT}/modules/bdev/include
+  ${CHIMAERA_ROOT}/modules/admin/include
+)
+
+target_link_libraries(${BULK_EXPOSE_CLEANUP_TEST_TARGET}
+  chimaera_cxx               # Main Chimaera library
+  chimaera_bdev_client        # Bdev module client
+  chimaera_admin_client       # Admin module client
+  hshm::cxx                  # HermesShm library
+  ${CMAKE_THREAD_LIBS_INIT}  # Threading support
+)
+
+set_target_properties(${BULK_EXPOSE_CLEANUP_TEST_TARGET} PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
@@ -754,6 +815,30 @@ if(WRP_CORE_ENABLE_TESTS)
     TIMEOUT 180
   )
 
+  # Future task cleanup regression tests
+  add_test(
+    NAME cr_future_task_cleanup_tests
+    COMMAND ${FUTURE_TASK_CLEANUP_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_future_task_cleanup_tests PROPERTIES
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+    TIMEOUT 120
+    LABELS "regression;memory"
+  )
+
+  # BULK_EXPOSE cleanup regression tests
+  add_test(
+    NAME cr_bulk_expose_cleanup_tests
+    COMMAND ${BULK_EXPOSE_CLEANUP_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_bulk_expose_cleanup_tests PROPERTIES
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+    TIMEOUT 120
+    LABELS "regression;memory"
+  )
+
   # External Client Tests
   # NOTE: Each test case must run in its own process because CHIMAERA_INIT has
   # a static guard that prevents re-initialization. Running all tests in one
@@ -1083,6 +1168,8 @@ install(TARGETS
   ${AUTOGEN_COVERAGE_TEST_TARGET}
   ${STREAMING_TEST_TARGET}
   ${EXTERNAL_CLIENT_TEST_TARGET}
+  ${FUTURE_TASK_CLEANUP_TEST_TARGET}
+  ${BULK_EXPOSE_CLEANUP_TEST_TARGET}
   ${RUNTIME_CLEANUP_TEST_TARGET}
   ${IPC_ERRORS_TEST_TARGET}
   ${IPC_TRANSPORT_MODES_TEST_TARGET}

--- a/context-runtime/test/unit/test_bulk_expose_cleanup.cc
+++ b/context-runtime/test/unit/test_bulk_expose_cleanup.cc
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Regression test: BULK_EXPOSE buffer allocated by the server during
+ * ReadTask deserialization must be freed when the task is deleted.
+ *
+ * Before the fix, SendOut() cleared TASK_DATA_OWNER before deferred
+ * deletion, so ~ReadTask() never freed the AllocateBuffer'd data.
+ * Each AsyncRead leaked the server-side BULK_EXPOSE buffer.
+ *
+ * Strategy
+ * --------
+ * Uses TASK_FORCE_NET to force the network serialization path even in
+ * embedded mode. This ensures the task goes through:
+ *   Send -> ZMQ -> RecvIn (sets TASK_DATA_OWNER, BULK_EXPOSE alloc)
+ *   -> Run -> SendOut (deferred delete with destructor freeing buffer)
+ *
+ * Because TASK_FORCE_NET with embedded mode creates a FutureShm with
+ * origin=SHM (rather than TCP), we must patch the origin to TCP so
+ * ~Future properly calls CleanupResponseArchive for ZMQ recv buffers.
+ *
+ * Measures glibc heap growth via mallinfo() to detect the leak.
+ */
+
+#include "../simple_test.h"
+#include "chimaera/chimaera.h"
+#include "chimaera/ipc_manager.h"
+#include "chimaera/bdev/bdev_client.h"
+#include "chimaera/bdev/bdev_tasks.h"
+
+#include <malloc.h>
+#include <cstring>
+#include <thread>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+static constexpr chi::PoolId kTestPoolId = chi::PoolId(888, 0);
+static constexpr chi::u64 kRamSize = 16 * 1024 * 1024;  // 16MB
+static constexpr chi::u64 kBlockSize = 4096;             // 4KB
+static constexpr chi::u64 kIoSize = 64 * 1024;           // 64KB read size
+static constexpr int kBatchSize = 200;
+static constexpr long kMaxBytesPerRead = 512;  // generous ceiling
+
+static bool g_initialized = false;
+
+/** Wrap a single block into the vector form ReadTask expects. */
+static inline chi::priv::vector<chimaera::bdev::Block> WrapBlock(
+    const chimaera::bdev::Block &block) {
+  chi::priv::vector<chimaera::bdev::Block> blocks(HSHM_MALLOC);
+  blocks.push_back(block);
+  return blocks;
+}
+
+/** Returns mallinfo.uordblks - heap bytes currently in active use. */
+static long heap_in_use() {
+  struct mallinfo mi = mallinfo();
+  return (long)(unsigned int)mi.uordblks;
+}
+
+/** Send a ReadTask with TASK_FORCE_NET so it goes through the network
+ *  serialization path (RecvIn -> BULK_EXPOSE alloc -> SendOut).
+ *  Patches origin to TCP so ~Future calls CleanupResponseArchive. */
+static chi::Future<chimaera::bdev::ReadTask> SendForceNetRead(
+    chimaera::bdev::Client &client,
+    const chimaera::bdev::Block &block,
+    hipc::ShmPtr<> data,
+    size_t size) {
+  auto *ipc = CHI_IPC;
+  auto task_ptr = ipc->NewTask<chimaera::bdev::ReadTask>(
+      chi::CreateTaskId(), client.pool_id_, chi::PoolQuery::Local(),
+      WrapBlock(block), data, size);
+  task_ptr->SetFlags(TASK_FORCE_NET);
+  auto future = ipc->Send(task_ptr);
+  // Patch origin from SHM to TCP so ~Future calls CleanupResponseArchive
+  // for the ZMQ recv buffers created by TASK_FORCE_NET loopback.
+  auto fs = future.GetFutureShm();
+  if (!fs.IsNull()) {
+    fs->origin_ = chi::FutureShm::FUTURE_CLIENT_TCP;
+  }
+  return future;
+}
+
+class BulkExposeFixture {
+ public:
+  BulkExposeFixture() {
+    if (!g_initialized) {
+      bool ok = chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
+      if (ok) {
+        g_initialized = true;
+        SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+        std::this_thread::sleep_for(500ms);
+      }
+    }
+  }
+};
+
+TEST_CASE("BULK_EXPOSE buffer freed after ReadTask (TASK_FORCE_NET)",
+          "[bdev][memory][regression]") {
+  BulkExposeFixture fixture;
+  REQUIRE(g_initialized);
+
+  HLOG(kInfo, "Creating RAM bdev pool...");
+
+  // Create RAM bdev pool
+  chimaera::bdev::Client client(kTestPoolId);
+  auto create_task = client.AsyncCreate(
+      chi::PoolQuery::Dynamic(), "bulk_expose_test", kTestPoolId,
+      chimaera::bdev::BdevType::kRam, kRamSize);
+  create_task.Wait();
+  HLOG(kInfo, "create_task done, return_code={}", create_task->return_code_);
+  REQUIRE(create_task->return_code_ == 0);
+  client.pool_id_ = create_task->new_pool_id_;
+
+  // Allocate a block
+  auto alloc_task = client.AsyncAllocateBlocks(
+      chi::PoolQuery::Local(), kBlockSize);
+  alloc_task.Wait();
+  REQUIRE(alloc_task->return_code_ == 0);
+  REQUIRE(alloc_task->blocks_.size() > 0);
+  chimaera::bdev::Block block = alloc_task->blocks_[0];
+
+  // Write test data so reads return real data (use TASK_FORCE_NET too)
+  {
+    auto write_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+    REQUIRE_FALSE(write_buffer.IsNull());
+    memset(write_buffer.ptr_, 0xAB, kIoSize);
+    auto *ipc = CHI_IPC;
+    auto write_task_ptr = ipc->NewTask<chimaera::bdev::WriteTask>(
+        chi::CreateTaskId(), client.pool_id_, chi::PoolQuery::Local(),
+        WrapBlock(block), write_buffer.shm_.template Cast<void>(), kIoSize);
+    write_task_ptr->SetFlags(TASK_FORCE_NET);
+    auto write_task = ipc->Send(write_task_ptr);
+    write_task.Wait();
+    REQUIRE(write_task->return_code_ == 0);
+    CHI_IPC->FreeBuffer(write_buffer);
+  }
+
+  HLOG(kInfo, "Warm-up reads...");
+
+  // Warm-up: let allocator reach steady state
+  for (int i = 0; i < 20; ++i) {
+    auto read_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+    REQUIRE_FALSE(read_buffer.IsNull());
+    auto read_task = SendForceNetRead(
+        client, block, read_buffer.shm_.template Cast<void>(), kIoSize);
+    read_task.Wait();
+    CHI_IPC->FreeBuffer(read_buffer);
+  }
+  malloc_trim(0);
+
+  HLOG(kInfo, "Starting heap measurement...");
+
+  SECTION("Heap growth per read is below threshold") {
+    long before = heap_in_use();
+    INFO("Heap in-use before batch: " << before << " bytes");
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto read_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+      REQUIRE_FALSE(read_buffer.IsNull());
+      auto read_task = SendForceNetRead(
+          client, block, read_buffer.shm_.template Cast<void>(), kIoSize);
+      read_task.Wait();
+      REQUIRE(read_task->return_code_ == 0);
+      CHI_IPC->FreeBuffer(read_buffer);
+    }
+
+    malloc_trim(0);
+    long after = heap_in_use();
+    INFO("Heap in-use after batch:  " << after << " bytes");
+
+    long growth = after - before;
+    long per_read = growth / kBatchSize;
+    INFO("Total heap growth: " << growth << " bytes  (" << per_read
+                               << " bytes/read)");
+    REQUIRE(per_read < kMaxBytesPerRead);
+  }
+
+  SECTION("Heap stable across two read batches (no monotonic leak)") {
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto read_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+      auto read_task = SendForceNetRead(
+          client, block, read_buffer.shm_.template Cast<void>(), kIoSize);
+      read_task.Wait();
+      CHI_IPC->FreeBuffer(read_buffer);
+    }
+    malloc_trim(0);
+    long after_a = heap_in_use();
+    INFO("Heap after batch A: " << after_a << " bytes");
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto read_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+      auto read_task = SendForceNetRead(
+          client, block, read_buffer.shm_.template Cast<void>(), kIoSize);
+      read_task.Wait();
+      CHI_IPC->FreeBuffer(read_buffer);
+    }
+    malloc_trim(0);
+    long after_b = heap_in_use();
+    INFO("Heap after batch B: " << after_b << " bytes");
+
+    long delta = after_b - after_a;
+    long per_read = delta / kBatchSize;
+    INFO("Heap delta A->B: " << delta << " bytes  (" << per_read
+                             << " bytes/read)");
+    REQUIRE(per_read < kMaxBytesPerRead);
+  }
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-runtime/test/unit/test_future_task_cleanup.cc
+++ b/context-runtime/test/unit/test_future_task_cleanup.cc
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Regression test: Future::~Future() must free the heap-allocated task object.
+ *
+ * Before the fix, ~Future() freed FutureShm but never called DelTask(), leaking
+ * the heap-allocated task object on every AsyncXxx().Wait() call.
+ *
+ * Strategy
+ * --------
+ * Measure glibc heap bytes in-use (mallinfo.uordblks) before and after running
+ * many AsyncCustom().Wait() calls.  Each call submits a task, waits for it,
+ * and lets the Future go out of scope.  If ~Future() does not call DelTask(),
+ * every task object is retained on the heap and uordblks grows linearly.
+ * With the fix, the tasks are freed and uordblks stays bounded.
+ *
+ * We validate both directions:
+ *   1. Total heap growth across N tasks stays below a tight per-task ceiling.
+ *   2. Heap usage after two equal-sized batches is the same (no monotonic
+ *      growth), measured after malloc_trim(0) forces freed pages back.
+ *
+ * Reproducer described in:
+ *   CTE_MEMORY_LEAK_REPORT.md – "Memory Leak in Future::~Future()"
+ */
+
+#include "../simple_test.h"
+#include "chimaera/chimaera.h"
+#include "chimaera/ipc_manager.h"
+#include "chimaera/MOD_NAME/MOD_NAME_client.h"
+#include "chimaera/MOD_NAME/MOD_NAME_tasks.h"
+
+#include <malloc.h>   // mallinfo / malloc_trim
+#include <cstring>
+#include <thread>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+// Distinct pool ID — must not collide with other test files.
+constexpr chi::PoolId kCleanupTestPoolId = chi::PoolId(777, 0);
+
+// Number of tasks per batch.
+static constexpr int kBatchSize = 500;
+
+// Maximum tolerated heap growth per completed task (bytes).
+// The pre-fix leak was the size of a full Task object + internal allocations
+// (thousands of bytes).  We allow 256 bytes to accommodate transient allocator
+// bookkeeping that isn't strictly per-task.
+static constexpr long kMaxBytesPerTask = 256;
+
+static bool g_initialized = false;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns mallinfo.uordblks — heap bytes currently in active use. */
+static long heap_in_use() {
+  struct mallinfo mi = mallinfo();
+  return (long)(unsigned int)mi.uordblks;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class FutureCleanupFixture {
+public:
+  FutureCleanupFixture() {
+    if (!g_initialized) {
+      bool ok = chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
+      if (ok) {
+        g_initialized = true;
+        SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+        std::this_thread::sleep_for(500ms);
+      }
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Future destructor frees task — heap does not grow across batches",
+          "[future][memory][regression]") {
+  FutureCleanupFixture fixture;
+  REQUIRE(g_initialized);
+
+  chimaera::MOD_NAME::Client client(kCleanupTestPoolId);
+  chi::PoolQuery pool_query = chi::PoolQuery::Dynamic();
+
+  auto create_task =
+      client.AsyncCreate(pool_query, "future_cleanup_test", kCleanupTestPoolId);
+  create_task.Wait();
+  client.pool_id_ = create_task->new_pool_id_;
+  REQUIRE(create_task->return_code_ == 0);
+
+  // Warm-up: let allocator reach steady state so transient bookkeeping doesn't
+  // pollute the measurement.
+  for (int i = 0; i < 50; ++i) {
+    auto t = client.AsyncCustom(pool_query, "warmup", 0);
+    t.Wait();
+  }
+  malloc_trim(0);  // return freed pages so measurement is clean
+
+  SECTION("Heap-in-use growth per task is below threshold") {
+    long before = heap_in_use();
+    INFO("Heap in-use before batch: " << before << " bytes");
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      // Future goes out of scope here — ~Future() must call DelTask().
+      auto task = client.AsyncCustom(pool_query, "data", i);
+      task.Wait();
+      REQUIRE(task->return_code_ == 0);
+    }
+
+    malloc_trim(0);
+    long after = heap_in_use();
+    INFO("Heap in-use after batch:  " << after << " bytes");
+
+    long growth = after - before;
+    long per_task = growth / kBatchSize;
+    INFO("Total heap growth: " << growth << " bytes  (" << per_task
+                               << " bytes/task)");
+    REQUIRE(per_task < kMaxBytesPerTask);
+  }
+
+  SECTION("Heap-in-use is stable across two equal batches (no monotonic leak)") {
+    // Run batch A, snapshot, run batch B, snapshot.  If tasks are leaked, the
+    // heap grows by (BatchSize * sizeof(task)) between snapshots.  If freed,
+    // the heap returns to roughly the same level.
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto task = client.AsyncCustom(pool_query, "batchA", i);
+      task.Wait();
+    }
+    malloc_trim(0);
+    long after_a = heap_in_use();
+    INFO("Heap after batch A: " << after_a << " bytes");
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto task = client.AsyncCustom(pool_query, "batchB", i);
+      task.Wait();
+    }
+    malloc_trim(0);
+    long after_b = heap_in_use();
+    INFO("Heap after batch B: " << after_b << " bytes");
+
+    // The delta between the two snapshots should not be proportional to batch
+    // size; allow only a small absolute slack for bookkeeping drift.
+    long delta = after_b - after_a;
+    long per_task = delta / kBatchSize;
+    INFO("Heap delta A→B: " << delta << " bytes  (" << per_task
+                            << " bytes/task)");
+    REQUIRE(per_task < kMaxBytesPerTask);
+  }
+}
+
+TEST_CASE(
+    "Future destructor: no crash on destruction of consumed Future",
+    "[future][memory][regression]") {
+  FutureCleanupFixture fixture;
+  REQUIRE(g_initialized);
+
+  chimaera::MOD_NAME::Client client(kCleanupTestPoolId);
+  chi::PoolQuery pool_query = chi::PoolQuery::Dynamic();
+
+  auto create_task =
+      client.AsyncCreate(pool_query, "future_null_test", kCleanupTestPoolId);
+  create_task.Wait();
+  client.pool_id_ = create_task->new_pool_id_;
+  REQUIRE(create_task->return_code_ == 0);
+
+  SECTION("Destroying many consumed Futures does not crash (no double-free)") {
+    // If ~Future() called DelTask() without the null-check guard, a double-free
+    // would crash here (ASAN would report heap-use-after-free).
+    REQUIRE_NOTHROW({
+      for (int i = 0; i < 200; ++i) {
+        auto task = client.AsyncCustom(pool_query, "nofree", i);
+        task.Wait();
+      }
+    });
+  }
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-transport-primitives/include/hermes_shm/lightbeam/shm_transport.h
+++ b/context-transport-primitives/include/hermes_shm/lightbeam/shm_transport.h
@@ -282,6 +282,7 @@ class ShmTransport
 #endif
   }
 
+ public:
   // SPSC ring buffer write (system-scope atomics for GPU/CPU visibility)
   HSHM_CROSS_FUN
   static void WriteTransfer(const char* data, size_t size, const LbmContext& ctx) {

--- a/context-transport-primitives/include/hermes_shm/memory/allocator/malloc_allocator.h
+++ b/context-transport-primitives/include/hermes_shm/memory/allocator/malloc_allocator.h
@@ -176,6 +176,13 @@ class _MallocAllocator : public Allocator {
     MallocPage *page = reinterpret_cast<MallocPage*>(
         reinterpret_cast<char*>(user_ptr) - sizeof(MallocPage));
 
+    // Safety guard: only free if this is our allocation.
+    // Non-HSHM pointers (e.g. ZMQ zero-copy recv buffers) won't have the
+    // magic header, so we skip them rather than corrupting the heap.
+    if (page->magic_ != MallocPage::MAGIC) {
+      return;
+    }
+
 #ifdef HSHM_ALLOC_TRACK_SIZE
     size_t size = page->page_size_ - sizeof(MallocPage);
     total_alloc_ -= size;

--- a/context-transport-primitives/test/unit/util/test_numbers.cc
+++ b/context-transport-primitives/test/unit/util/test_numbers.cc
@@ -72,9 +72,9 @@ TEST_CASE("BitWidth - Non-powers of two") {
 }
 
 TEST_CASE("BitWidth - equals FloorLog2 plus one for positive values") {
-  hshm::size_t values[] = {1, 2, 3, 5, 7, 9, 15, 17, 63, 64, 100, 1000,
+  size_t values[] = {1, 2, 3, 5, 7, 9, 15, 17, 63, 64, 100, 1000,
                             1ULL << 20, 1ULL << 32};
-  for (hshm::size_t v : values) {
+  for (size_t v : values) {
     REQUIRE(hshm::BitWidth(v) == hshm::FloorLog2(v) + 1);
   }
 }
@@ -113,9 +113,9 @@ TEST_CASE("FloorLog2 - Non-powers of two") {
 }
 
 TEST_CASE("FloorLog2 - Equals CeilLog2 for powers of two") {
-  hshm::size_t powers[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024,
+  size_t powers[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024,
                             1ULL << 20, 1ULL << 32};
-  for (hshm::size_t p : powers) {
+  for (size_t p : powers) {
     REQUIRE(hshm::FloorLog2(p) == hshm::CeilLog2(p));
   }
 }
@@ -159,28 +159,28 @@ TEST_CASE("CeilLog2 - Non-powers of two") {
 }
 
 TEST_CASE("CeilLog2 - Ceil is at least Floor for all values") {
-  hshm::size_t values[] = {1, 2, 3, 5, 7, 9, 15, 17, 63, 64, 100, 1000,
+  size_t values[] = {1, 2, 3, 5, 7, 9, 15, 17, 63, 64, 100, 1000,
                             1ULL << 20, 1ULL << 32};
-  for (hshm::size_t v : values) {
+  for (size_t v : values) {
     REQUIRE(hshm::CeilLog2(v) >= hshm::FloorLog2(v));
   }
 }
 
 TEST_CASE("CeilLog2 - Ceil exceeds Floor only for non-powers-of-two") {
-  hshm::size_t non_powers[] = {3, 5, 6, 7, 9, 10, 15, 17, 100, 1000};
-  for (hshm::size_t v : non_powers) {
+  size_t non_powers[] = {3, 5, 6, 7, 9, 10, 15, 17, 100, 1000};
+  for (size_t v : non_powers) {
     REQUIRE(hshm::CeilLog2(v) == hshm::FloorLog2(v) + 1);
   }
 }
 
 TEST_CASE("CeilLog2 - Large value 1ULL << 20") {
-  hshm::size_t v = 1ULL << 20;
+  size_t v = 1ULL << 20;
   REQUIRE(hshm::CeilLog2(v) == 20);
   REQUIRE(hshm::FloorLog2(v) == 20);
 }
 
 TEST_CASE("CeilLog2 - Large value 1ULL << 32") {
-  hshm::size_t v = 1ULL << 32;
+  size_t v = 1ULL << 32;
   REQUIRE(hshm::CeilLog2(v) == 32);
   REQUIRE(hshm::FloorLog2(v) == 32);
 }


### PR DESCRIPTION
Main fixes:
1. This fixes an issue where the data buffer for a `ReadTask` future is leaked, because a flag is unnecessarily cleared. By not clearing the flag, the data buffer is properly deallocated by the destructor.
2. Ensure that `FreeOffsetNoNullCheck` only frees data allocated by the allocator, not data from ZMQ.

Build fixes:
1. `hshm::size_t` still used in some places, despite being removed in 7ee9ce12f1c07f7bebbed60df79500d52e9cd175.
2. `{Write/Read}Transfer` methods were private, despite being used as public throughout.
3. `LaunchMegaKernel` was only defined in the GPU path; now an empty definition is provided in the non-GPU path.
4. Definitions in `ipc_manager.h` relating to the `RouteTask` method didn't match their implementation in `ipc_manager.cc`.

Regression tests were added to make sure that everything still works properly, and that the fixes address the issues it was intending to. 