### PR TITLE
fix: Reinterpret cast type aliasing issue

### DIFF
--- a/context-assimilation-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-assimilation-engine/core/src/autogen/core_lib_exec.cc
@@ -76,27 +76,27 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kParseOmni: {
       auto typed_task = task_ptr.template Cast<ParseOmniTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kProcessHdf5Dataset: {
       auto typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {
@@ -111,27 +111,27 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kParseOmni: {
       auto typed_task = task_ptr.template Cast<ParseOmniTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kProcessHdf5Dataset: {
       auto typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -155,31 +155,31 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::LocalLoadTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kParseOmni: {
       auto typed_task = task_ptr.template Cast<ParseOmniTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kProcessHdf5Dataset: {
       auto typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -203,31 +203,31 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::LocalSaveTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kParseOmni: {
       auto typed_task = task_ptr.template Cast<ParseOmniTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kProcessHdf5Dataset: {
       auto typed_task = task_ptr.template Cast<ProcessHdf5DatasetTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {

--- a/context-assimilation-engine/core/src/factory/binary_file_assimilator.cc
+++ b/context-assimilation-engine/core/src/factory/binary_file_assimilator.cc
@@ -170,7 +170,7 @@ chi::TaskResume BinaryFileAssimilator::Schedule(const AssimilationCtx& ctx,
                             ", offset=" + std::to_string(chunk_offset) + ">";
   size_t desc_size = description.size();
   auto desc_buffer = CHI_IPC->AllocateBuffer(desc_size);
-  std::memcpy(desc_buffer.ptr_, description.c_str(), desc_size);
+  std::memcpy(desc_buffer.get(), description.c_str(), desc_size);
 
   HLOG(kDebug, "BinaryFileAssimilator: Storing description blob: '{}'",
        description);
@@ -237,7 +237,7 @@ chi::TaskResume BinaryFileAssimilator::Schedule(const AssimilationCtx& ctx,
 
       // Allocate buffer in shared memory
       auto buffer_ptr = CHI_IPC->AllocateBuffer(current_chunk_size);
-      char* buffer = buffer_ptr.ptr_;
+      char* buffer = buffer_ptr.get();
 
       // Read chunk from file
       HLOG(kDebug,

--- a/context-assimilation-engine/core/src/factory/hdf5_file_assimilator.cc
+++ b/context-assimilation-engine/core/src/factory/hdf5_file_assimilator.cc
@@ -490,7 +490,7 @@ chi::TaskResume Hdf5FileAssimilator::ProcessDataset(
   HLOG(kDebug, "ProcessDataset: Tensor description: '{}'", description);
   size_t desc_size = description.size();
   auto desc_buffer = CHI_IPC->AllocateBuffer(desc_size);
-  std::memcpy(desc_buffer.ptr_, description.c_str(), desc_size);
+  std::memcpy(desc_buffer.get(), description.c_str(), desc_size);
 
   HLOG(kDebug,
        "ProcessDataset: Submitting description blob (size: {} bytes)...",
@@ -592,7 +592,7 @@ chi::TaskResume Hdf5FileAssimilator::ProcessDataset(
 
       // Allocate IPC buffer for this chunk and copy data
       auto chunk_buffer = CHI_IPC->AllocateBuffer(current_chunk_size);
-      std::memcpy(chunk_buffer.ptr_, dataset_buffer + bytes_processed,
+      std::memcpy(chunk_buffer.get(), dataset_buffer + bytes_processed,
                   current_chunk_size);
 
       // Submit PutBlob task asynchronously

--- a/context-assimilation-engine/test/unit/hdf5_assim/test_hdf5_assim.cc
+++ b/context-assimilation-engine/test/unit/hdf5_assim/test_hdf5_assim.cc
@@ -338,7 +338,7 @@ bool VerifyDatasetData(const std::string& file_path,
     }
 
     // Copy from shared memory to our local buffer
-    std::memcpy(cte_data.data() + bytes_read, blob_buffer.ptr_, blob_size);
+    std::memcpy(cte_data.data() + bytes_read, blob_buffer.get(), blob_size);
 
     // Free the shared memory buffer
     CHI_IPC->FreeBuffer(blob_buffer);

--- a/context-exploration-engine/api/src/context_interface.cc
+++ b/context-exploration-engine/api/src/context_interface.cc
@@ -293,7 +293,7 @@ std::vector<std::string> ContextInterface::ContextRetrieve(
     // Convert buffer to std::string
     std::string packed_context;
     if (buffer_offset > 0) {
-      packed_context.assign(context_buffer.ptr_, buffer_offset);
+      packed_context.assign(context_buffer.get(), buffer_offset);
       HLOG(kSuccess, "ContextRetrieve: Retrieved {} bytes of packed context", buffer_offset);
     }
 

--- a/context-runtime/benchmark/wrp_run_thrpt_benchmark.cc
+++ b/context-runtime/benchmark/wrp_run_thrpt_benchmark.cc
@@ -295,7 +295,7 @@ void IOWorkerThread(size_t thread_id, const BenchmarkConfig &config,
 
   // Allocate data buffer in shared memory for writes (full io_size)
   auto write_buffer = CHI_IPC->AllocateBuffer(config.io_size);
-  std::memset(write_buffer.ptr_, static_cast<int>(thread_id), config.io_size);
+  std::memset(write_buffer.get(), static_cast<int>(thread_id), config.io_size);
   HLOG(kInfo, "Allocate write buffer for thread {}", config.io_size);
 
   size_t local_ops = 0;

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -786,8 +786,9 @@ class IpcManager {
 
   /** Route a task: resolve pool query, determine local vs global.
    * If force_enqueue is true, always enqueue to the destination worker's lane
-   * (used by SendRuntime which cannot execute tasks directly). */
-  RouteResult RouteTask(Future<Task> &future, bool force_enqueue = false);
+   * (used by SendRuntime which cannot execute tasks directly).
+   * Returns true if the task was routed locally, false if sent over network. */
+  bool RouteTask(Future<Task> &future, bool force_enqueue = false);
 
   /** Resolve a pool query into concrete physical addresses */
   std::vector<PoolQuery> ResolvePoolQuery(const PoolQuery &query,
@@ -799,11 +800,13 @@ class IpcManager {
                    const std::vector<PoolQuery> &pool_queries);
 
   /** Route task locally.
-   * If force_enqueue is true, always enqueue even if dest == current worker. */
-  RouteResult RouteLocal(Future<Task> &future, bool force_enqueue = false);
+   * If force_enqueue is true, always enqueue even if dest == current worker.
+   * Returns true if the task was routed locally. */
+  bool RouteLocal(Future<Task> &future, bool force_enqueue = false);
 
-  /** Route task globally via network */
-  RouteResult RouteGlobal(Future<Task> &future,
+  /** Route task globally via network.
+   * Returns false (task was sent to network, not local). */
+  bool RouteGlobal(Future<Task> &future,
                    const std::vector<PoolQuery> &pool_queries);
 
 #if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -328,13 +328,13 @@ class IpcManager {
     // and generate a C++14 globally-sized deallocation call (operator delete
     // (void*, size_t)) — which would still trigger the ASan mismatch when the
     // object is a larger derived type.
-    task_ptr.ptr_->~TaskT();
-    void* raw = static_cast<void*>(task_ptr.ptr_);
+    task_ptr->~TaskT();
+    void* raw = static_cast<void*>(task_ptr.get());
     ::operator delete(raw);
 #else
     // GPU path: call destructor and free buffer
-    task_ptr.ptr_->~TaskT();
-    FreeBuffer(hipc::FullPtr<char>(reinterpret_cast<char *>(task_ptr.ptr_)));
+    task_ptr->~TaskT();
+    FreeBuffer(hipc::FullPtr<char>(reinterpret_cast<char *>(task_ptr.get())));
 #endif
   }
 
@@ -393,7 +393,7 @@ class IpcManager {
     }
 
     // Construct object using placement new
-    T *obj = new (buffer.ptr_) T(std::forward<Args>(args)...);
+    T *obj = new (buffer.get()) T(std::forward<Args>(args)...);
 
     // Return FullPtr<T> by reinterpreting the buffer's ptr and shm
     return buffer.Cast<T>();
@@ -424,12 +424,12 @@ class IpcManager {
     }
 
     // Construct FutureShm in-place
-    FutureShm *future_shm_ptr = new (buffer.ptr_) FutureShm();
+    FutureShm *future_shm_ptr = new (buffer.get()) FutureShm();
     future_shm_ptr->pool_id_ = task_ptr->pool_id_;
     future_shm_ptr->method_id_ = task_ptr->method_;
     future_shm_ptr->origin_ = FutureShm::FUTURE_CLIENT_SHM;
     future_shm_ptr->client_task_vaddr_ =
-        reinterpret_cast<uintptr_t>(task_ptr.ptr_);
+        reinterpret_cast<uintptr_t>(task_ptr.get());
     future_shm_ptr->input_.copy_space_size_ = copy_space_size;
     future_shm_ptr->flags_.SetBits(FutureShm::FUTURE_COPY_FROM_CLIENT);
 
@@ -465,7 +465,7 @@ class IpcManager {
     }
 
     // 2. Construct FutureShm — origin is SHM (worker treats identically)
-    FutureShm *future_shm = new (buffer.ptr_) FutureShm();
+    FutureShm *future_shm = new (buffer.get()) FutureShm();
     future_shm->pool_id_ = task_ptr->pool_id_;
     future_shm->method_id_ = task_ptr->method_;
     future_shm->origin_ = FutureShm::FUTURE_CLIENT_SHM;
@@ -519,7 +519,7 @@ class IpcManager {
       future_shm = reinterpret_cast<FutureShm *>(sptr.off_.load());
     } else {
       hipc::FullPtr<FutureShm> fshm = future.GetFutureShm();
-      future_shm = fshm.ptr_;
+      future_shm = fshm.get();
     }
 
     // Build LbmContext for output ring buffer
@@ -573,7 +573,7 @@ class IpcManager {
     }
 
     // 2. Construct FutureShm
-    FutureShm *future_shm = new (buffer.ptr_) FutureShm();
+    FutureShm *future_shm = new (buffer.get()) FutureShm();
     future_shm->pool_id_ = task_ptr->pool_id_;
     future_shm->method_id_ = task_ptr->method_;
     future_shm->origin_ = FutureShm::FUTURE_CLIENT_SHM;
@@ -588,7 +588,7 @@ class IpcManager {
     //    gpu::Worker resolves GPU→GPU FutureShm directly without base
     //    arithmetic.
     hipc::ShmPtr<FutureShm> fshmptr;
-    fshmptr.off_ = reinterpret_cast<size_t>(buffer.ptr_);
+    fshmptr.off_ = reinterpret_cast<size_t>(buffer.get());
     Future<TaskT> future(fshmptr, task_ptr);
     hshm::lbm::LbmContext ctx;
     ctx.copy_space = future_shm->copy_space;
@@ -648,10 +648,10 @@ class IpcManager {
     }
 
     // Initialize FutureShm fields
-    future_shm.ptr_->pool_id_ = task_ptr->pool_id_;
-    future_shm.ptr_->method_id_ = task_ptr->method_;
-    future_shm.ptr_->origin_ = FutureShm::FUTURE_CLIENT_SHM;
-    future_shm.ptr_->client_task_vaddr_ = 0;
+    future_shm->pool_id_ = task_ptr->pool_id_;
+    future_shm->method_id_ = task_ptr->method_;
+    future_shm->origin_ = FutureShm::FUTURE_CLIENT_SHM;
+    future_shm->client_task_vaddr_ = 0;
     // No copy_space in runtime path — ShmTransferInfo defaults are fine
 
     // Create Future with ShmPtr and task_ptr (no serialization)
@@ -840,11 +840,11 @@ class IpcManager {
     auto buffer = AllocateBuffer(alloc_size);
     if (buffer.IsNull()) return Future<TaskT>();
 
-    FutureShm *future_shm = new (buffer.ptr_) FutureShm();
+    FutureShm *future_shm = new (buffer.get()) FutureShm();
     future_shm->pool_id_ = task_ptr->pool_id_;
     future_shm->method_id_ = task_ptr->method_;
     future_shm->origin_ = FutureShm::FUTURE_CLIENT_SHM;
-    future_shm->client_task_vaddr_ = reinterpret_cast<uintptr_t>(task_ptr.ptr_);
+    future_shm->client_task_vaddr_ = reinterpret_cast<uintptr_t>(task_ptr.get());
     future_shm->input_.copy_space_size_ = copy_space_size;
     future_shm->flags_.SetBits(FutureShm::FUTURE_COPY_FROM_CLIENT);
 
@@ -868,7 +868,7 @@ class IpcManager {
     }
 
     SaveTaskArchive archive(MsgType::kSerializeIn, shm_send_transport_.get());
-    archive << (*task_ptr.ptr_);
+    archive << (*task_ptr.get());
     shm_send_transport_->Send(archive, ctx);
 
     return future;
@@ -889,12 +889,12 @@ class IpcManager {
     }
 
     // Set net_key for response routing (use task's address as unique key)
-    size_t net_key = reinterpret_cast<size_t>(task_ptr.ptr_);
+    size_t net_key = reinterpret_cast<size_t>(task_ptr.get());
     task_ptr->task_id_.net_key_ = net_key;
 
     // Serialize the task inputs using network archive
     SaveTaskArchive archive(MsgType::kSerializeIn, zmq_transport_.get());
-    archive << (*task_ptr.ptr_);
+    archive << (*task_ptr.get());
 
     // Allocate FutureShm via HSHM_MALLOC (no copy_space needed)
     size_t alloc_size = sizeof(FutureShm);
@@ -904,7 +904,7 @@ class IpcManager {
            alloc_size);
       return Future<TaskT>();
     }
-    FutureShm *future_shm = new (buffer.ptr_) FutureShm();
+    FutureShm *future_shm = new (buffer.get()) FutureShm();
 
     // Initialize FutureShm fields
     future_shm->pool_id_ = task_ptr->pool_id_;
@@ -1103,7 +1103,7 @@ class IpcManager {
     // Re-register in pending futures
     {
       std::lock_guard<std::mutex> lock(pending_futures_mutex_);
-      pending_zmq_futures_[net_key] = future_shm.ptr_;
+      pending_zmq_futures_[net_key] = future_shm.get();
     }
 
     // Re-send
@@ -1449,7 +1449,7 @@ class IpcManager {
       if (git != gpu_alloc_map_.end()) {
         size_t off = shm_ptr.off_.load();
         if (off < git->second.capacity) {
-          result.ptr_ = reinterpret_cast<T *>(git->second.data + off);
+          result.set_ptr(reinterpret_cast<T *>(git->second.data + off));
           result.shm_ = shm_ptr;
         }
       }
@@ -1556,7 +1556,7 @@ class IpcManager {
    * Get the network queue for direct access
    * @return Pointer to the network queue or nullptr if not initialized
    */
-  NetQueue *GetNetQueue() { return net_queue_.ptr_; }
+  NetQueue *GetNetQueue() { return net_queue_.get(); }
 
   /**
    * Get number of GPU queues
@@ -1571,7 +1571,7 @@ class IpcManager {
    */
   TaskQueue *GetGpuQueue(size_t gpu_id) {
     if (gpu_id < gpu_queues_.size()) {
-      return gpu_queues_[gpu_id].ptr_;
+      return gpu_queues_[gpu_id].get();
     }
     return nullptr;
   }
@@ -1598,7 +1598,7 @@ class IpcManager {
    */
   TaskQueue *GetToGpuQueue(size_t gpu_id) {
     if (gpu_id < to_gpu_queues_.size()) {
-      return to_gpu_queues_[gpu_id].ptr_;
+      return to_gpu_queues_[gpu_id].get();
     }
     return nullptr;
   }
@@ -1616,7 +1616,7 @@ class IpcManager {
    */
   TaskQueue *GetGpuToGpuQueue(size_t gpu_id) {
     if (gpu_id < gpu_to_gpu_queues_.size()) {
-      return gpu_to_gpu_queues_[gpu_id].ptr_;
+      return gpu_to_gpu_queues_[gpu_id].get();
     }
     return nullptr;
   }
@@ -1661,7 +1661,7 @@ class IpcManager {
     }
 
     // Construct FutureShm
-    FutureShm *future_shm = new (buffer.ptr_) FutureShm();
+    FutureShm *future_shm = new (buffer.get()) FutureShm();
     future_shm->pool_id_ = task_ptr->pool_id_;
     future_shm->method_id_ = task_ptr->method_;
     future_shm->origin_ = FutureShm::FUTURE_CLIENT_SHM;
@@ -1684,7 +1684,7 @@ class IpcManager {
     hshm::lbm::ShmTransport::Send(save_ar, ctx);
 
     // Push to CPU→GPU queue
-    auto &lane = to_gpu_queues_[gpu_id].ptr_->GetLane(0, 0);
+    auto &lane = to_gpu_queues_[gpu_id]->GetLane(0, 0);
     Future<Task> task_future(future.GetFutureShmPtr());
     lane.Push(task_future);
 
@@ -2278,7 +2278,7 @@ HSHM_CROSS_FUN bool Future<TaskT, AllocT>::Wait(float max_sec) {
   if (future_shm_.IsNull()) {
     return true;
   }
-  CHI_IPC->RecvGpu(*this, task_ptr_.ptr_);
+  CHI_IPC->RecvGpu(*this, task_ptr_.get());
   Destroy(true);
   return true;
 #else

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -815,6 +815,12 @@ class IpcManager {
   void RouteToGpu(const hipc::FullPtr<Task> &task_ptr, Container *container,
                   u32 gpu_id = 0);
 #endif
+  /** Launch the GPU megakernel. Returns true on success (or no GPUs present). */
+  bool LaunchMegakernel();
+  /** Pause the running GPU megakernel (no-op if no GPU support). */
+  void PauseMegakernel();
+  /** Resume a paused GPU megakernel (no-op if no GPU support). */
+  void ResumeMegakernel();
 
   /**
    * Send a task via SHM lightbeam transport

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -84,6 +84,12 @@ enum class NetQueuePriority : u32 {
   kClientSendIpc = 3,  ///< Priority 3: Client response via IPC
 };
 
+/** Result of RouteTask: whether task stays local (GPU/CPU) or goes over network */
+enum class RouteResult : u32 {
+  Local = 0,    ///< Task stays on the current processor (GPU stays on GPU)
+  Network = 1,  ///< Task must be sent over the network or CPU↔GPU boundary
+};
+
 /**
  * Network queue for storing Future<SendTask> objects
  * One lane with two priorities (SendIn and SendOut)

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -2249,8 +2249,7 @@ HSHM_CROSS_FUN Future<TaskT, AllocT>::~Future() {
       CHI_IPC->FreeBuffer(buffer_shm);
       future_shm_.SetNull();
     }
-    // Auto-free the task (only when consumed to avoid double-free
-    // from runtime-internal Future copies in event queues / RunContext)
+    // Free the heap-allocated task object
     DelTask();
   }
 }

--- a/context-runtime/include/chimaera/local_task_archives.h
+++ b/context-runtime/include/chimaera/local_task_archives.h
@@ -348,7 +348,7 @@ public:
     } else if (flags & BULK_XFER) {
       uint8_t mode = 1;
       serializer_ << mode;
-      serializer_.write_binary(reinterpret_cast<const char *>(ptr.ptr_), size);
+      serializer_.write_binary(reinterpret_cast<const char *>(ptr.get()), size);
     } else {
       uint8_t mode = 2;
       serializer_ << mode;
@@ -656,7 +656,7 @@ public:
     deserializer_ >> mode;
     if (mode == 1) {
       hipc::FullPtr<char> buf = HSHM_MALLOC->AllocateObjs<char>(size);
-      deserializer_.read_binary(buf.ptr_, size);
+      deserializer_.read_binary(buf.get(), size);
       ptr.off_ = buf.shm_.off_.load();
       ptr.alloc_id_ = buf.shm_.alloc_id_;
     } else if (mode == 2) {
@@ -687,15 +687,15 @@ public:
     deserializer_ >> mode;
     if (mode == 1) {
       hipc::FullPtr<char> buf = HSHM_MALLOC->AllocateObjs<char>(size);
-      deserializer_.read_binary(buf.ptr_, size);
+      deserializer_.read_binary(buf.get(), size);
       ptr.shm_.off_ = buf.shm_.off_.load();
       ptr.shm_.alloc_id_ = buf.shm_.alloc_id_;
-      ptr.ptr_ = reinterpret_cast<T *>(buf.ptr_);
+      ptr.set_ptr(reinterpret_cast<T *>(buf.get()));
     } else if (mode == 2) {
       hipc::FullPtr<char> buf = HSHM_MALLOC->AllocateObjs<char>(size);
       ptr.shm_.off_ = buf.shm_.off_.load();
       ptr.shm_.alloc_id_ = buf.shm_.alloc_id_;
-      ptr.ptr_ = reinterpret_cast<T *>(buf.ptr_);
+      ptr.set_ptr(reinterpret_cast<T *>(buf.get()));
     } else {
       size_t off = 0;
       u32 major = 0, minor = 0;

--- a/context-runtime/include/chimaera/task.h
+++ b/context-runtime/include/chimaera/task.h
@@ -559,7 +559,7 @@ class Future {
     // Manually initialize task_ptr_ to avoid FullPtr copy constructor bug on GPU
     // Copy shm_ directly, then reconstruct ptr_ from it
     task_ptr_.shm_ = task_ptr.shm_;
-    task_ptr_.ptr_ = task_ptr.ptr_;
+    task_ptr_.set_ptr(task_ptr.get());
   }
 
   /**
@@ -607,7 +607,7 @@ class Future {
         consumed_(false) {  // Copy is not consumed
     // Manually copy task_ptr_ to avoid FullPtr copy constructor bug on GPU
     task_ptr_.shm_ = other.task_ptr_.shm_;
-    task_ptr_.ptr_ = other.task_ptr_.ptr_;
+    task_ptr_.set_ptr(other.task_ptr_.get());
   }
 
   /**
@@ -619,7 +619,7 @@ class Future {
     if (this != &other) {
       // Manually copy task_ptr_ to avoid FullPtr copy assignment bug on GPU
       task_ptr_.shm_ = other.task_ptr_.shm_;
-      task_ptr_.ptr_ = other.task_ptr_.ptr_;
+      task_ptr_.set_ptr(other.task_ptr_.get());
       future_shm_ = other.future_shm_;
       parent_task_ = other.parent_task_;
       consumed_ = false;  // Copy is not consumed
@@ -637,7 +637,7 @@ class Future {
         consumed_(other.consumed_) {
     // Manually move task_ptr_ to avoid FullPtr move constructor bug on GPU
     task_ptr_.shm_ = other.task_ptr_.shm_;
-    task_ptr_.ptr_ = other.task_ptr_.ptr_;
+    task_ptr_.set_ptr(other.task_ptr_.get());
     other.task_ptr_.SetNull();
     other.parent_task_ = nullptr;
     other.consumed_ = false;
@@ -652,7 +652,7 @@ class Future {
     if (this != &other) {
       // Manually move task_ptr_ to avoid FullPtr move assignment bug on GPU
       task_ptr_.shm_ = other.task_ptr_.shm_;
-      task_ptr_.ptr_ = other.task_ptr_.ptr_;
+      task_ptr_.set_ptr(other.task_ptr_.get());
       future_shm_ = std::move(other.future_shm_);
       parent_task_ = other.parent_task_;
       consumed_ = other.consumed_;
@@ -668,7 +668,7 @@ class Future {
    * Get raw pointer to the task
    * @return Pointer to the task object
    */
-  HSHM_CROSS_FUN TaskT* get() const { return task_ptr_.ptr_; }
+  HSHM_CROSS_FUN TaskT* get() const { return task_ptr_.get(); }
 
   /**
    * Get the FullPtr to the task (non-const version)
@@ -686,13 +686,13 @@ class Future {
    * Dereference operator - access task members
    * @return Reference to the task object
    */
-  HSHM_CROSS_FUN TaskT& operator*() const { return *task_ptr_.ptr_; }
+  HSHM_CROSS_FUN TaskT& operator*() const { return *task_ptr_.get(); }
 
   /**
    * Arrow operator - access task members
    * @return Pointer to the task object
    */
-  HSHM_CROSS_FUN TaskT* operator->() const { return task_ptr_.ptr_; }
+  HSHM_CROSS_FUN TaskT* operator->() const { return task_ptr_.get(); }
 
   /**
    * Check if the task is complete

--- a/context-runtime/modules/MOD_NAME/include/chimaera/MOD_NAME/MOD_NAME_gpu_runtime.h
+++ b/context-runtime/modules/MOD_NAME/include/chimaera/MOD_NAME/MOD_NAME_gpu_runtime.h
@@ -43,9 +43,9 @@ class GpuRuntime : public chi::gpu::Container {
       if (task.IsNull()) {
         return hipc::FullPtr<chi::Task>::GetNull();
       }
-      new (task.ptr_) GpuSubmitTask();
+      new (task.get()) GpuSubmitTask();
       archive.SetMsgType(chi::LocalMsgType::kSerializeIn);
-      task.ptr_->SerializeIn(archive);
+      task->SerializeIn(archive);
       return task.template Cast<chi::Task>();
     }
     return hipc::FullPtr<chi::Task>::GetNull();

--- a/context-runtime/modules/MOD_NAME/include/chimaera/MOD_NAME/MOD_NAME_tasks.h
+++ b/context-runtime/modules/MOD_NAME/include/chimaera/MOD_NAME/MOD_NAME_tasks.h
@@ -141,7 +141,7 @@ struct CustomTask : public chi::Task {
    */
   void Copy(const hipc::FullPtr<CustomTask> &other) {
     HLOG(kInfo, "CustomTask::Copy() - ENTRY, this={}, other={}, this.data_.data()={}, other.data_.data()={}",
-         (void*)this, (void*)other.ptr_, (void*)data_.data(), (void*)other->data_.data());
+         (void*)this, (void*)other.get(), (void*)data_.data(), (void*)other->data_.data());
     // Copy base Task fields
     Task::Copy(other.template Cast<Task>());
     // Copy CustomTask-specific fields

--- a/context-runtime/modules/MOD_NAME/src/autogen/MOD_NAME_lib_exec.cc
+++ b/context-runtime/modules/MOD_NAME/src/autogen/MOD_NAME_lib_exec.cc
@@ -101,47 +101,47 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kCustom: {
       auto typed_task = task_ptr.template Cast<CustomTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kCoMutexTest: {
       auto typed_task = task_ptr.template Cast<CoMutexTestTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kCoRwLockTest: {
       auto typed_task = task_ptr.template Cast<CoRwLockTestTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kWaitTest: {
       auto typed_task = task_ptr.template Cast<WaitTestTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kTestLargeOutput: {
       auto typed_task = task_ptr.template Cast<TestLargeOutputTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGpuSubmit: {
       auto typed_task = task_ptr.template Cast<GpuSubmitTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {
@@ -156,47 +156,47 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kCustom: {
       auto typed_task = task_ptr.template Cast<CustomTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kCoMutexTest: {
       auto typed_task = task_ptr.template Cast<CoMutexTestTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kCoRwLockTest: {
       auto typed_task = task_ptr.template Cast<CoRwLockTestTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kWaitTest: {
       auto typed_task = task_ptr.template Cast<WaitTestTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kTestLargeOutput: {
       auto typed_task = task_ptr.template Cast<TestLargeOutputTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGpuSubmit: {
       auto typed_task = task_ptr.template Cast<GpuSubmitTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -220,55 +220,55 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::LocalLoadTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kCustom: {
       auto typed_task = task_ptr.template Cast<CustomTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kCoMutexTest: {
       auto typed_task = task_ptr.template Cast<CoMutexTestTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kCoRwLockTest: {
       auto typed_task = task_ptr.template Cast<CoRwLockTestTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kWaitTest: {
       auto typed_task = task_ptr.template Cast<WaitTestTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kTestLargeOutput: {
       auto typed_task = task_ptr.template Cast<TestLargeOutputTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGpuSubmit: {
       auto typed_task = task_ptr.template Cast<GpuSubmitTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -292,55 +292,55 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::LocalSaveTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kCustom: {
       auto typed_task = task_ptr.template Cast<CustomTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kCoMutexTest: {
       auto typed_task = task_ptr.template Cast<CoMutexTestTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kCoRwLockTest: {
       auto typed_task = task_ptr.template Cast<CoRwLockTestTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kWaitTest: {
       auto typed_task = task_ptr.template Cast<WaitTestTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kTestLargeOutput: {
       auto typed_task = task_ptr.template Cast<TestLargeOutputTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGpuSubmit: {
       auto typed_task = task_ptr.template Cast<GpuSubmitTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {

--- a/context-runtime/modules/MOD_NAME/test/test_gpu_submission_gpu.cc
+++ b/context-runtime/modules/MOD_NAME/test/test_gpu_submission_gpu.cc
@@ -74,7 +74,7 @@ __global__ void gpu_submit_task_kernel(chi::IpcManagerGpu gpu_info,
   task = CHI_IPC->NewTask<chimaera::MOD_NAME::GpuSubmitTask>(
                       task_id, pool_id, query, 0, test_value);
 
-  if (task.ptr_ == nullptr) {
+  if (task.get() == nullptr) {
     *result = -1;  // NewTask failed
     return;
   }
@@ -268,7 +268,7 @@ extern "C" int run_cpu_to_gpu_test(chi::PoolId pool_id,
 
   // Poll for FUTURE_COMPLETE
   auto fshm_full = future.GetFutureShm();
-  chi::FutureShm *fshm = fshm_full.ptr_;
+  chi::FutureShm *fshm = fshm_full.get();
   int attempts = 0;
   while (!fshm->flags_.Any(chi::FutureShm::FUTURE_COMPLETE)) {
     std::this_thread::sleep_for(std::chrono::microseconds(100));
@@ -286,7 +286,7 @@ extern "C" int run_cpu_to_gpu_test(chi::PoolId pool_id,
   chi::LocalLoadTaskArchive load_ar;
   hshm::lbm::ShmTransport::Recv(load_ar, ctx);
   load_ar.SetMsgType(chi::LocalMsgType::kSerializeOut);
-  task.ptr_->SerializeOut(load_ar);
+  task->SerializeOut(load_ar);
 
   *out_result_value = task->result_value_;
   return 1;  // Success
@@ -349,7 +349,7 @@ extern "C" int run_gpu_to_cpu_test(chi::PoolId pool_id,
   CHI_IPC->RegisterGpuAllocator(backend_id, gpu_backend.data_,
                                  gpu_backend.data_capacity_);
 
-  chi::IpcManagerGpu gpu_info(gpu_backend, gpu_queue_ptr.ptr_);
+  chi::IpcManagerGpu gpu_info(gpu_backend, gpu_queue_ptr.get());
 
   int *d_result = hshm::GpuApi::Malloc<int>(sizeof(int));
   chi::u32 *d_rv = hshm::GpuApi::Malloc<chi::u32>(sizeof(chi::u32));
@@ -474,7 +474,7 @@ extern "C" int run_async_gpu_submit_to_local_cpu_test(
   CHI_IPC->RegisterGpuAllocator(backend_id, gpu_backend.data_,
                                  gpu_backend.data_capacity_);
 
-  chi::IpcManagerGpu gpu_info(gpu_backend, gpu_queue_ptr.ptr_);
+  chi::IpcManagerGpu gpu_info(gpu_backend, gpu_queue_ptr.get());
 
   int *d_result = hshm::GpuApi::Malloc<int>(sizeof(int));
   chi::u32 *d_rv = hshm::GpuApi::Malloc<chi::u32>(sizeof(chi::u32));

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -381,7 +381,7 @@ void Runtime::SendIn(hipc::FullPtr<chi::Task> origin_task,
 
   // Pre-allocate send_map_key using origin_task pointer
   // This ensures consistent net_key across all replicas
-  size_t send_map_key = size_t(origin_task.ptr_);
+  size_t send_map_key = size_t(origin_task.get());
 
   // Add the origin task to send_map before creating copies
   // Note: No lock needed - single net worker processes all Send/Recv tasks

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -635,11 +635,11 @@ void Runtime::SendOut(hipc::FullPtr<chi::Task> origin_task) {
 
   HLOG(kDebug, "[SendOut] Task {}", origin_task->task_id_);
 
-  // Clear TASK_DATA_OWNER before deferred deletion so the destructor
-  // doesn't try to FreeBuffer on transport-allocated data
-  origin_task->ClearFlags(TASK_DATA_OWNER);
-
-  // Defer task deletion to next invocation for zero-copy send safety
+  // Defer task deletion to next invocation for zero-copy send safety.
+  // TASK_DATA_OWNER is intentionally left set so that task destructors
+  // (e.g. ~ReadTask) can free BULK_EXPOSE-allocated buffers.  The
+  // MallocAllocator magic-guard in FreeOffsetNoNullCheck makes FreeBuffer
+  // a safe no-op for any ZMQ zero-copy pointer that lacks the header.
   deferred_deletes.push_back(origin_task);
 }
 
@@ -1231,11 +1231,10 @@ chi::TaskResume Runtime::ClientSend(hipc::FullPtr<ClientSendTask> task,
         HLOG(kError, "ClientSend: lightbeam Send failed: {}", rc);
       }
 
-      // Clear TASK_DATA_OWNER before deferred deletion so the destructor
-      // doesn't try to FreeBuffer on transport-allocated data
-      origin_task->ClearFlags(TASK_DATA_OWNER);
-
-      // Defer task deletion to next invocation for zero-copy send safety
+      // TASK_DATA_OWNER is intentionally left set so that task destructors
+      // (e.g. ~ReadTask) can free BULK_EXPOSE-allocated buffers.  The
+      // MallocAllocator magic-guard makes FreeBuffer a safe no-op for any
+      // non-HSHM pointer.
       deferred_deletes.push_back(origin_task);
 
       did_work = true;

--- a/context-runtime/modules/admin/src/autogen/admin_lib_exec.cc
+++ b/context-runtime/modules/admin/src/autogen/admin_lib_exec.cc
@@ -202,132 +202,132 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetOrCreatePool: {
       auto typed_task = task_ptr.template Cast<admin::GetOrCreatePoolTask<admin::CreateParams>>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroyPool: {
       auto typed_task = task_ptr.template Cast<DestroyPoolTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kStopRuntime: {
       auto typed_task = task_ptr.template Cast<StopRuntimeTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kFlush: {
       auto typed_task = task_ptr.template Cast<FlushTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kSend: {
       auto typed_task = task_ptr.template Cast<SendTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRecv: {
       auto typed_task = task_ptr.template Cast<RecvTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kClientConnect: {
       auto typed_task = task_ptr.template Cast<ClientConnectTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kSubmitBatch: {
       auto typed_task = task_ptr.template Cast<SubmitBatchTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kWreapDeadIpcs: {
       auto typed_task = task_ptr.template Cast<WreapDeadIpcsTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kClientRecv: {
       auto typed_task = task_ptr.template Cast<ClientRecvTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kClientSend: {
       auto typed_task = task_ptr.template Cast<ClientSendTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRegisterMemory: {
       auto typed_task = task_ptr.template Cast<RegisterMemoryTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRestartContainers: {
       auto typed_task = task_ptr.template Cast<RestartContainersTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kAddNode: {
       auto typed_task = task_ptr.template Cast<AddNodeTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kChangeAddressTable: {
       auto typed_task = task_ptr.template Cast<ChangeAddressTableTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMigrateContainers: {
       auto typed_task = task_ptr.template Cast<MigrateContainersTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kHeartbeat: {
       auto typed_task = task_ptr.template Cast<HeartbeatTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kHeartbeatProbe: {
       auto typed_task = task_ptr.template Cast<HeartbeatProbeTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kProbeRequest: {
       auto typed_task = task_ptr.template Cast<ProbeRequestTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRecoverContainers: {
       auto typed_task = task_ptr.template Cast<RecoverContainersTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kSystemMonitor: {
       auto typed_task = task_ptr.template Cast<SystemMonitorTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kAnnounceShutdown: {
       auto typed_task = task_ptr.template Cast<AnnounceShutdownTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRegisterGpuContainer: {
       auto typed_task = task_ptr.template Cast<RegisterGpuContainerTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {
@@ -342,132 +342,132 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetOrCreatePool: {
       auto typed_task = task_ptr.template Cast<admin::GetOrCreatePoolTask<admin::CreateParams>>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroyPool: {
       auto typed_task = task_ptr.template Cast<DestroyPoolTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kStopRuntime: {
       auto typed_task = task_ptr.template Cast<StopRuntimeTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kFlush: {
       auto typed_task = task_ptr.template Cast<FlushTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kSend: {
       auto typed_task = task_ptr.template Cast<SendTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRecv: {
       auto typed_task = task_ptr.template Cast<RecvTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kClientConnect: {
       auto typed_task = task_ptr.template Cast<ClientConnectTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kSubmitBatch: {
       auto typed_task = task_ptr.template Cast<SubmitBatchTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kWreapDeadIpcs: {
       auto typed_task = task_ptr.template Cast<WreapDeadIpcsTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kClientRecv: {
       auto typed_task = task_ptr.template Cast<ClientRecvTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kClientSend: {
       auto typed_task = task_ptr.template Cast<ClientSendTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRegisterMemory: {
       auto typed_task = task_ptr.template Cast<RegisterMemoryTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRestartContainers: {
       auto typed_task = task_ptr.template Cast<RestartContainersTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kAddNode: {
       auto typed_task = task_ptr.template Cast<AddNodeTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kChangeAddressTable: {
       auto typed_task = task_ptr.template Cast<ChangeAddressTableTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMigrateContainers: {
       auto typed_task = task_ptr.template Cast<MigrateContainersTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kHeartbeat: {
       auto typed_task = task_ptr.template Cast<HeartbeatTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kHeartbeatProbe: {
       auto typed_task = task_ptr.template Cast<HeartbeatProbeTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kProbeRequest: {
       auto typed_task = task_ptr.template Cast<ProbeRequestTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRecoverContainers: {
       auto typed_task = task_ptr.template Cast<RecoverContainersTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kSystemMonitor: {
       auto typed_task = task_ptr.template Cast<SystemMonitorTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kAnnounceShutdown: {
       auto typed_task = task_ptr.template Cast<AnnounceShutdownTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRegisterGpuContainer: {
       auto typed_task = task_ptr.template Cast<RegisterGpuContainerTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -491,156 +491,156 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::LocalLoadTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetOrCreatePool: {
       auto typed_task = task_ptr.template Cast<admin::GetOrCreatePoolTask<admin::CreateParams>>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroyPool: {
       auto typed_task = task_ptr.template Cast<DestroyPoolTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kStopRuntime: {
       auto typed_task = task_ptr.template Cast<StopRuntimeTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kFlush: {
       auto typed_task = task_ptr.template Cast<FlushTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kSend: {
       auto typed_task = task_ptr.template Cast<SendTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRecv: {
       auto typed_task = task_ptr.template Cast<RecvTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kClientConnect: {
       auto typed_task = task_ptr.template Cast<ClientConnectTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kSubmitBatch: {
       auto typed_task = task_ptr.template Cast<SubmitBatchTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kWreapDeadIpcs: {
       auto typed_task = task_ptr.template Cast<WreapDeadIpcsTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kClientRecv: {
       auto typed_task = task_ptr.template Cast<ClientRecvTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kClientSend: {
       auto typed_task = task_ptr.template Cast<ClientSendTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRegisterMemory: {
       auto typed_task = task_ptr.template Cast<RegisterMemoryTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRestartContainers: {
       auto typed_task = task_ptr.template Cast<RestartContainersTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kAddNode: {
       auto typed_task = task_ptr.template Cast<AddNodeTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kChangeAddressTable: {
       auto typed_task = task_ptr.template Cast<ChangeAddressTableTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMigrateContainers: {
       auto typed_task = task_ptr.template Cast<MigrateContainersTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kHeartbeat: {
       auto typed_task = task_ptr.template Cast<HeartbeatTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kHeartbeatProbe: {
       auto typed_task = task_ptr.template Cast<HeartbeatProbeTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kProbeRequest: {
       auto typed_task = task_ptr.template Cast<ProbeRequestTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRecoverContainers: {
       auto typed_task = task_ptr.template Cast<RecoverContainersTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kSystemMonitor: {
       auto typed_task = task_ptr.template Cast<SystemMonitorTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kAnnounceShutdown: {
       auto typed_task = task_ptr.template Cast<AnnounceShutdownTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRegisterGpuContainer: {
       auto typed_task = task_ptr.template Cast<RegisterGpuContainerTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -664,156 +664,156 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::LocalSaveTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetOrCreatePool: {
       auto typed_task = task_ptr.template Cast<admin::GetOrCreatePoolTask<admin::CreateParams>>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroyPool: {
       auto typed_task = task_ptr.template Cast<DestroyPoolTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kStopRuntime: {
       auto typed_task = task_ptr.template Cast<StopRuntimeTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kFlush: {
       auto typed_task = task_ptr.template Cast<FlushTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kSend: {
       auto typed_task = task_ptr.template Cast<SendTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRecv: {
       auto typed_task = task_ptr.template Cast<RecvTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kClientConnect: {
       auto typed_task = task_ptr.template Cast<ClientConnectTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kSubmitBatch: {
       auto typed_task = task_ptr.template Cast<SubmitBatchTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kWreapDeadIpcs: {
       auto typed_task = task_ptr.template Cast<WreapDeadIpcsTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kClientRecv: {
       auto typed_task = task_ptr.template Cast<ClientRecvTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kClientSend: {
       auto typed_task = task_ptr.template Cast<ClientSendTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRegisterMemory: {
       auto typed_task = task_ptr.template Cast<RegisterMemoryTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRestartContainers: {
       auto typed_task = task_ptr.template Cast<RestartContainersTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kAddNode: {
       auto typed_task = task_ptr.template Cast<AddNodeTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kChangeAddressTable: {
       auto typed_task = task_ptr.template Cast<ChangeAddressTableTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMigrateContainers: {
       auto typed_task = task_ptr.template Cast<MigrateContainersTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kHeartbeat: {
       auto typed_task = task_ptr.template Cast<HeartbeatTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kHeartbeatProbe: {
       auto typed_task = task_ptr.template Cast<HeartbeatProbeTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kProbeRequest: {
       auto typed_task = task_ptr.template Cast<ProbeRequestTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRecoverContainers: {
       auto typed_task = task_ptr.template Cast<RecoverContainersTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kSystemMonitor: {
       auto typed_task = task_ptr.template Cast<SystemMonitorTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kAnnounceShutdown: {
       auto typed_task = task_ptr.template Cast<AnnounceShutdownTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRegisterGpuContainer: {
       auto typed_task = task_ptr.template Cast<RegisterGpuContainerTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {

--- a/context-runtime/modules/bdev/src/autogen/bdev_lib_exec.cc
+++ b/context-runtime/modules/bdev/src/autogen/bdev_lib_exec.cc
@@ -95,42 +95,42 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kAllocateBlocks: {
       auto typed_task = task_ptr.template Cast<AllocateBlocksTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kFreeBlocks: {
       auto typed_task = task_ptr.template Cast<FreeBlocksTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kWrite: {
       auto typed_task = task_ptr.template Cast<WriteTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRead: {
       auto typed_task = task_ptr.template Cast<ReadTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetStats: {
       auto typed_task = task_ptr.template Cast<GetStatsTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {
@@ -145,42 +145,42 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kAllocateBlocks: {
       auto typed_task = task_ptr.template Cast<AllocateBlocksTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kFreeBlocks: {
       auto typed_task = task_ptr.template Cast<FreeBlocksTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kWrite: {
       auto typed_task = task_ptr.template Cast<WriteTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRead: {
       auto typed_task = task_ptr.template Cast<ReadTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetStats: {
       auto typed_task = task_ptr.template Cast<GetStatsTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -204,49 +204,49 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::LocalLoadTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kAllocateBlocks: {
       auto typed_task = task_ptr.template Cast<AllocateBlocksTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kFreeBlocks: {
       auto typed_task = task_ptr.template Cast<FreeBlocksTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kWrite: {
       auto typed_task = task_ptr.template Cast<WriteTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRead: {
       auto typed_task = task_ptr.template Cast<ReadTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetStats: {
       auto typed_task = task_ptr.template Cast<GetStatsTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -270,49 +270,49 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::LocalSaveTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kAllocateBlocks: {
       auto typed_task = task_ptr.template Cast<AllocateBlocksTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kFreeBlocks: {
       auto typed_task = task_ptr.template Cast<FreeBlocksTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kWrite: {
       auto typed_task = task_ptr.template Cast<WriteTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRead: {
       auto typed_task = task_ptr.template Cast<ReadTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetStats: {
       auto typed_task = task_ptr.template Cast<GetStatsTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {

--- a/context-runtime/modules/bdev/src/bdev_runtime.cc
+++ b/context-runtime/modules/bdev/src/bdev_runtime.cc
@@ -668,7 +668,7 @@ chi::TaskResume Runtime::WriteToFile(hipc::FullPtr<WriteTask> task,
     if (remaining == 0) break;
     chi::u64 block_write_size = std::min(remaining, block.size_);
 
-    void *block_data = data_ptr.ptr_ + data_offset;
+    void *block_data = data_ptr.get() + data_offset;
 
     if (io_ctx == nullptr || !io_ctx->is_initialized_ || !io_ctx->async_io_) {
       HLOG(kError, "WriteToFile called with invalid I/O context");
@@ -731,7 +731,7 @@ chi::TaskResume Runtime::ReadFromFile(hipc::FullPtr<ReadTask> task,
     if (remaining == 0) break;
     chi::u64 block_read_size = std::min(remaining, block.size_);
 
-    void *block_data = data_ptr.ptr_ + data_offset;
+    void *block_data = data_ptr.get() + data_offset;
 
     if (io_ctx == nullptr || !io_ctx->is_initialized_ || !io_ctx->async_io_) {
       HLOG(kError, "ReadFromFile called with invalid I/O context");
@@ -899,7 +899,7 @@ void Runtime::WriteToRam(hipc::FullPtr<WriteTask> task) {
     }
 
     // Simple memory copy
-    memcpy(ram_buffer_ + block.offset_, data_ptr.ptr_ + data_offset,
+    memcpy(ram_buffer_ + block.offset_, data_ptr.get() + data_offset,
            block_write_size);
 
     // Update counters
@@ -956,7 +956,7 @@ void Runtime::ReadFromRam(hipc::FullPtr<ReadTask> task) {
     }
 
     // Copy data from RAM buffer to task output
-    memcpy(data_ptr.ptr_ + data_offset, ram_buffer_ + block.offset_,
+    memcpy(data_ptr.get() + data_offset, ram_buffer_ + block.offset_,
            block_read_size);
 
     // Update counters

--- a/context-runtime/modules/bdev/test/test_bdev_chimod.cc
+++ b/context-runtime/modules/bdev/test/test_bdev_chimod.cc
@@ -466,7 +466,7 @@ TEST_CASE("bdev_write_read_basic", "[bdev][io][basic]") {
       // Write data - allocate buffer and copy data
       auto write_buffer = CHI_IPC->AllocateBuffer(write_data.size());
       REQUIRE_FALSE(write_buffer.IsNull());
-      memcpy(write_buffer.ptr_, write_data.data(), write_data.size());
+      memcpy(write_buffer.get(), write_data.data(), write_data.size());
 
       auto write_task = client.AsyncWrite(
           pool_query, WrapBlock(block),
@@ -499,7 +499,7 @@ TEST_CASE("bdev_write_read_basic", "[bdev][io][basic]") {
 
       // Convert read data back to vector for verification
       std::vector<hshm::u8> read_data(read_task->bytes_read_);
-      memcpy(read_data.data(), read_buffer.ptr_, read_task->bytes_read_);
+      memcpy(read_data.data(), read_buffer.get(), read_task->bytes_read_);
 
       // Verify data matches
       for (size_t j = 0; j < write_data.size(); ++j) {
@@ -551,7 +551,7 @@ TEST_CASE("bdev_async_operations", "[bdev][async][io]") {
       // Async write - allocate buffer and copy data
       auto async_write_buffer = CHI_IPC->AllocateBuffer(write_data.size());
       REQUIRE_FALSE(async_write_buffer.IsNull());
-      memcpy(async_write_buffer.ptr_, write_data.data(), write_data.size());
+      memcpy(async_write_buffer.get(), write_data.data(), write_data.size());
 
       auto write_task = client.AsyncWrite(
           pool_query, WrapBlock(block),
@@ -575,7 +575,7 @@ TEST_CASE("bdev_async_operations", "[bdev][async][io]") {
 
       // Verify data - copy from buffer to check
       std::vector<hshm::u8> async_read_data(read_task->bytes_read_);
-      memcpy(async_read_data.data(), async_read_buffer.ptr_,
+      memcpy(async_read_data.data(), async_read_buffer.get(),
              read_task->bytes_read_);
 
       REQUIRE(async_read_data.size() == write_data.size());
@@ -653,7 +653,7 @@ TEST_CASE("bdev_performance_metrics", "[bdev][performance][metrics]") {
       // Allocate buffers for data1 write
       auto data1_write_buffer = CHI_IPC->AllocateBuffer(data1.size());
       REQUIRE_FALSE(data1_write_buffer.IsNull());
-      memcpy(data1_write_buffer.ptr_, data1.data(), data1.size());
+      memcpy(data1_write_buffer.get(), data1.data(), data1.size());
 
       auto write_task1 = client.AsyncWrite(
           pool_query, WrapBlock(block1),
@@ -665,7 +665,7 @@ TEST_CASE("bdev_performance_metrics", "[bdev][performance][metrics]") {
       // Allocate buffers for data2 write
       auto data2_write_buffer = CHI_IPC->AllocateBuffer(data2.size());
       REQUIRE_FALSE(data2_write_buffer.IsNull());
-      memcpy(data2_write_buffer.ptr_, data2.data(), data2.size());
+      memcpy(data2_write_buffer.get(), data2.data(), data2.size());
 
       auto write_task2 = client.AsyncWrite(
           pool_query, WrapBlock(block2),
@@ -826,7 +826,7 @@ TEST_CASE("bdev_ram_allocation_and_io", "[bdev][ram][io]") {
     // Write data to RAM - allocate buffer and copy data
     auto write_buffer = CHI_IPC->AllocateBuffer(write_data.size());
     REQUIRE_FALSE(write_buffer.IsNull());
-    memcpy(write_buffer.ptr_, write_data.data(), write_data.size());
+    memcpy(write_buffer.get(), write_data.data(), write_data.size());
 
     auto write_task = bdev_client.AsyncWrite(
         pool_query, WrapBlock(block),
@@ -849,7 +849,7 @@ TEST_CASE("bdev_ram_allocation_and_io", "[bdev][ram][io]") {
 
     // Convert read data back to vector for verification
     std::vector<hshm::u8> read_data(read_task->bytes_read_);
-    memcpy(read_data.data(), read_buffer.ptr_, read_task->bytes_read_);
+    memcpy(read_data.data(), read_buffer.get(), read_task->bytes_read_);
 
     // Verify data integrity
     bool data_matches =
@@ -928,7 +928,7 @@ TEST_CASE("bdev_ram_large_blocks", "[bdev][ram][large]") {
       // Write and read - allocate buffers
       auto test_write_buffer = CHI_IPC->AllocateBuffer(test_data.size());
       REQUIRE_FALSE(test_write_buffer.IsNull());
-      memcpy(test_write_buffer.ptr_, test_data.data(), test_data.size());
+      memcpy(test_write_buffer.get(), test_data.data(), test_data.size());
 
       // Pass all allocated blocks to Write
       auto write_task = bdev_client.AsyncWrite(
@@ -953,7 +953,7 @@ TEST_CASE("bdev_ram_large_blocks", "[bdev][ram][large]") {
 
       // Convert read data back to vector for verification
       std::vector<hshm::u8> read_data(read_task->bytes_read_);
-      memcpy(read_data.data(), test_read_buffer.ptr_, read_task->bytes_read_);
+      memcpy(read_data.data(), test_read_buffer.get(), read_task->bytes_read_);
 
       // Verify critical points in the data
       for (size_t j = 0; j < read_data.size(); j += 1024) {
@@ -1011,7 +1011,7 @@ TEST_CASE("bdev_ram_bounds_checking", "[bdev][ram][bounds]") {
     // Write should fail with bounds check - allocate buffer
     auto error_write_buffer = CHI_IPC->AllocateBuffer(test_data.size());
     REQUIRE_FALSE(error_write_buffer.IsNull());
-    memcpy(error_write_buffer.ptr_, test_data.data(), test_data.size());
+    memcpy(error_write_buffer.get(), test_data.data(), test_data.size());
 
     auto write_task = bdev_client.AsyncWrite(
         pool_query, WrapBlock(out_of_bounds_block),
@@ -1034,7 +1034,7 @@ TEST_CASE("bdev_ram_bounds_checking", "[bdev][ram][bounds]") {
     // Convert read data back to vector (should be empty due to error)
     std::vector<hshm::u8> read_data(read_task->bytes_read_);
     if (read_task->bytes_read_ > 0) {
-      memcpy(read_data.data(), error_read_buffer.ptr_, read_task->bytes_read_);
+      memcpy(read_data.data(), error_read_buffer.get(), read_task->bytes_read_);
     }
     REQUIRE(read_data.empty());  // Should fail
 
@@ -1118,7 +1118,7 @@ TEST_CASE("bdev_file_vs_ram_comparison", "[bdev][file][ram][comparison]") {
     // Allocate buffer for file write
     auto file_write_buffer = CHI_IPC->AllocateBuffer(test_data.size());
     REQUIRE_FALSE(file_write_buffer.IsNull());
-    memcpy(file_write_buffer.ptr_, test_data.data(), test_data.size());
+    memcpy(file_write_buffer.get(), test_data.data(), test_data.size());
 
     // Write to file backend and measure time
     auto file_write_start = std::chrono::high_resolution_clock::now();
@@ -1135,7 +1135,7 @@ TEST_CASE("bdev_file_vs_ram_comparison", "[bdev][file][ram][comparison]") {
     // Allocate buffer for ram write
     auto ram_write_buffer = CHI_IPC->AllocateBuffer(test_data.size());
     REQUIRE_FALSE(ram_write_buffer.IsNull());
-    memcpy(ram_write_buffer.ptr_, test_data.data(), test_data.size());
+    memcpy(ram_write_buffer.get(), test_data.data(), test_data.size());
 
     auto ram_write_start = std::chrono::high_resolution_clock::now();
     auto ram_write_task = ram_client.AsyncWrite(
@@ -1166,7 +1166,7 @@ TEST_CASE("bdev_file_vs_ram_comparison", "[bdev][file][ram][comparison]") {
 
     // Convert read data back to vector
     std::vector<hshm::u8> file_read_data(file_read_task->bytes_read_);
-    memcpy(file_read_data.data(), file_read_buffer.ptr_,
+    memcpy(file_read_data.data(), file_read_buffer.get(),
            file_read_task->bytes_read_);
 
     // Allocate buffer for ram read
@@ -1186,7 +1186,7 @@ TEST_CASE("bdev_file_vs_ram_comparison", "[bdev][file][ram][comparison]") {
 
     // Convert read data back to vector
     std::vector<hshm::u8> ram_read_data(ram_read_task->bytes_read_);
-    memcpy(ram_read_data.data(), ram_read_buffer.ptr_,
+    memcpy(ram_read_data.data(), ram_read_buffer.get(),
            ram_read_task->bytes_read_);
 
     REQUIRE(file_read_data.size() == test_size);
@@ -1293,7 +1293,7 @@ void run_bdev_file_explicit_backend_test(const char *mode_name) {
     std::vector<hshm::u8> test_data(k4KB, 0x42 + i);
     auto final_write_buffer = CHI_IPC->AllocateBuffer(test_data.size());
     REQUIRE_FALSE(final_write_buffer.IsNull());
-    memcpy(final_write_buffer.ptr_, test_data.data(), test_data.size());
+    memcpy(final_write_buffer.get(), test_data.data(), test_data.size());
 
     auto write_task = bdev_client.AsyncWrite(
         pool_query, WrapBlock(block),
@@ -1317,7 +1317,7 @@ void run_bdev_file_explicit_backend_test(const char *mode_name) {
 
     // Verify data
     std::vector<hshm::u8> read_data(read_task->bytes_read_);
-    memcpy(read_data.data(), final_read_buffer.ptr_, read_task->bytes_read_);
+    memcpy(read_data.data(), final_read_buffer.get(), read_task->bytes_read_);
     bool data_ok =
         std::equal(test_data.begin(), test_data.end(), read_data.begin());
     HLOG(kInfo,
@@ -1483,7 +1483,7 @@ TEST_CASE("bdev_parallel_io_operations", "[bdev][parallel][io]") {
 
       // Allocate write buffer in shared memory
       auto write_buffer = CHI_IPC->AllocateBuffer(io_size);
-      std::memset(write_buffer.ptr_, static_cast<int>(thread_id), io_size);
+      std::memset(write_buffer.get(), static_cast<int>(thread_id), io_size);
 
       // Perform I/O operations with DirectHash
       for (size_t i = 0; i < ops_per_thread; i++) {
@@ -1662,7 +1662,7 @@ TEST_CASE("bdev_force_net_flag", "[bdev][network][force_net]") {
            "[bdev_force_net_flag] Iteration {}: Allocating write buffer...", i);
       auto write_buffer = CHI_IPC->AllocateBuffer(write_data.size());
       REQUIRE_FALSE(write_buffer.IsNull());
-      memcpy(write_buffer.ptr_, write_data.data(), write_data.size());
+      memcpy(write_buffer.get(), write_data.data(), write_data.size());
       HLOG(kInfo,
            "[bdev_force_net_flag] Iteration {}: Write buffer allocated and "
            "filled",
@@ -1779,7 +1779,7 @@ TEST_CASE("bdev_force_net_flag", "[bdev][network][force_net]") {
 
       // Verify data integrity
       std::vector<hshm::u8> read_data(read_task->bytes_read_);
-      memcpy(read_data.data(), read_buffer.ptr_, read_task->bytes_read_);
+      memcpy(read_data.data(), read_buffer.get(), read_task->bytes_read_);
       REQUIRE(read_data.size() == write_data.size());
 
       for (size_t j = 0; j < write_data.size(); ++j) {

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -800,6 +800,14 @@ void IpcManager::ResumeMegakernel() {
 #endif
 }
 
+void IpcManager::PauseGpuOrchestrator() {
+  PauseMegakernel();
+}
+
+void IpcManager::ResumeGpuOrchestrator() {
+  ResumeMegakernel();
+}
+
 bool IpcManager::ClientInitQueues() {
   if (!main_allocator_) {
     return false;

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -725,27 +725,6 @@ bool IpcManager::ServerInitGpuQueues() {
   }
 }
 
-bool IpcManager::LaunchMegakernel() {
-  int num_gpus = hshm::GpuApi::GetDeviceCount();
-  if (num_gpus == 0) {
-    return true;  // No GPUs, nothing to do
-  }
-
-  ConfigManager *config = CHI_CONFIG_MANAGER;
-  u32 blocks = config->GetGpuBlocks();
-  u32 threads_per_block = config->GetGpuThreadsPerBlock();
-
-  auto *launcher = new MegakernelLauncher();
-  if (!launcher->Launch(gpu_megakernel_info_, blocks, threads_per_block)) {
-    HLOG(kError, "Failed to launch megakernel");
-    delete launcher;
-    return false;
-  }
-
-  megakernel_launcher_ = launcher;
-  return true;
-}
-
 void IpcManager::FinalizeMegakernel() {
   if (megakernel_launcher_) {
     auto *launcher = static_cast<MegakernelLauncher *>(megakernel_launcher_);
@@ -777,6 +756,29 @@ void IpcManager::RegisterMegakernelContainer(const PoolId &pool_id,
 }
 
 #endif
+
+bool IpcManager::LaunchMegakernel() {
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
+  int num_gpus = hshm::GpuApi::GetDeviceCount();
+  if (num_gpus == 0) {
+    return true;  // No GPUs, nothing to do
+  }
+
+  ConfigManager *config = CHI_CONFIG_MANAGER;
+  u32 blocks = config->GetGpuBlocks();
+  u32 threads_per_block = config->GetGpuThreadsPerBlock();
+
+  auto *launcher = new MegakernelLauncher();
+  if (!launcher->Launch(gpu_megakernel_info_, blocks, threads_per_block)) {
+    HLOG(kError, "Failed to launch megakernel");
+    delete launcher;
+    return false;
+  }
+
+  megakernel_launcher_ = launcher;
+#endif
+  return true;
+}
 
 void IpcManager::PauseMegakernel() {
 #if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -399,7 +399,7 @@ void IpcManager::ServerFinalize() {
 // Template methods (NewTask, DelTask, AllocateBuffer, Enqueue) are implemented
 // inline in the header
 
-TaskQueue *IpcManager::GetTaskQueue() { return worker_queues_.ptr_; }
+TaskQueue *IpcManager::GetTaskQueue() { return worker_queues_.get(); }
 
 bool IpcManager::IsInitialized() const { return is_initialized_; }
 
@@ -711,9 +711,9 @@ bool IpcManager::ServerInitGpuQueues() {
     if (num_gpus > 0) {
       gpu_megakernel_info_.backend =
           static_cast<hipc::MemoryBackend &>(*megakernel_backends_[0]);
-      gpu_megakernel_info_.to_gpu_queue = to_gpu_queues_[0].ptr_;
-      gpu_megakernel_info_.from_gpu_queue = gpu_queues_[0].ptr_;
-      gpu_megakernel_info_.gpu_to_gpu_queue = gpu_to_gpu_queues_[0].ptr_;
+      gpu_megakernel_info_.to_gpu_queue = to_gpu_queues_[0].get();
+      gpu_megakernel_info_.from_gpu_queue = gpu_queues_[0].get();
+      gpu_megakernel_info_.gpu_to_gpu_queue = gpu_to_gpu_queues_[0].get();
       gpu_megakernel_info_.queue_backend_base = gpu_backends_[0]->data_;
       gpu_megakernel_info_.gpu_queue_depth = queue_depth;
     }

--- a/context-runtime/src/pool_manager.cc
+++ b/context-runtime/src/pool_manager.cc
@@ -431,7 +431,7 @@ TaskResume PoolManager::CreatePool(FullPtr<Task> task, RunContext* run_ctx) {
   // Cast generic Task to BaseCreateTask to access pool operation parameters
   auto* create_task = reinterpret_cast<
       chimaera::admin::BaseCreateTask<chimaera::admin::CreateParams>*>(
-      task.ptr_);
+      task.get());
 
   // Debug: Log do_compose_ value after cast
   HLOG(kDebug, "PoolManager::CreatePool: After cast, do_compose_={}, is_admin_={}",

--- a/context-runtime/src/task_archive.cc
+++ b/context-runtime/src/task_archive.cc
@@ -111,10 +111,10 @@ void LoadTaskArchive::bulk(hipc::ShmPtr<> &ptr, size_t size, uint32_t flags) {
         // the ShmPtr (which checks offset) rather than alloc_id_.
         if (!ptr.IsNull()) {
           hipc::FullPtr<char> dst = CHI_IPC->ToFullPtr(ptr).template Cast<char>();
-          char *src = recv[current_bulk_index_].data.ptr_;
+          char *src = recv[current_bulk_index_].data.get();
           size_t copy_size = recv[current_bulk_index_].size;
-          if (dst.ptr_ && src) {
-            memcpy(dst.ptr_, src, copy_size);
+          if (dst.get() && src) {
+            memcpy(dst.get(), src, copy_size);
           }
         } else {
           // No original buffer — zero-copy, point directly at recv buffer

--- a/context-runtime/src/types.cc
+++ b/context-runtime/src/types.cc
@@ -67,7 +67,7 @@ LockOwnerId GetCurrentLockOwnerId() {
   Worker *worker = CHI_CUR_WORKER;
   if (!worker) return id;
   FullPtr<Task> task = worker->GetCurrentTask();
-  if (task.ptr_ == nullptr) return id;
+  if (task.get() == nullptr) return id;
   id.worker_id_ = worker->GetId();
   id.pid_ = task->task_id_.pid_;
   id.tid_ = task->task_id_.tid_;

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -112,7 +112,7 @@ bool Worker::Init() {
           ->template NewObj<hshm::ipc::mpsc_ring_buffer<
               Future<Task, CHI_MAIN_ALLOC_T>, hshm::ipc::MallocAllocator>>(
               HSHM_MALLOC, EVENT_QUEUE_DEPTH)
-          .ptr_;
+          .get();
 
   // Get scheduler from IpcManager (IpcManager is the single owner)
   scheduler_ = CHI_IPC->GetScheduler();

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -88,6 +88,17 @@ set(CLIENT_RETRY_TEST_SOURCES
   test_client_retry.cc
 )
 
+# Future task cleanup regression test
+set(FUTURE_TASK_CLEANUP_TEST_TARGET chimaera_future_task_cleanup_tests)
+set(FUTURE_TASK_CLEANUP_TEST_SOURCES
+  test_future_task_cleanup.cc
+)
+
+# BULK_EXPOSE buffer cleanup regression test
+set(BULK_EXPOSE_CLEANUP_TEST_TARGET chimaera_bulk_expose_cleanup_tests)
+set(BULK_EXPOSE_CLEANUP_TEST_SOURCES
+  test_bulk_expose_cleanup.cc
+)
 
 # GPU IPC AllocateBuffer test executable (only if CUDA or HIP is enabled)
 set(IPC_ALLOCATE_BUFFER_GPU_TEST_TARGET test_ipc_allocate_buffer_gpu)
@@ -296,6 +307,56 @@ set_target_properties(${STREAMING_TEST_TARGET} PROPERTIES
 )
 
 set_target_properties(${STREAMING_TEST_TARGET} PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# Create Future task cleanup regression test executable
+add_executable(${FUTURE_TASK_CLEANUP_TEST_TARGET} ${FUTURE_TASK_CLEANUP_TEST_SOURCES})
+
+target_include_directories(${FUTURE_TASK_CLEANUP_TEST_TARGET} PRIVATE
+  ${CHIMAERA_ROOT}/include
+  ${CHIMAERA_ROOT}/test  # For simple_test.h
+  ${CHIMAERA_ROOT}/modules/MOD_NAME/include  # For MOD_NAME client and tasks
+)
+
+target_link_libraries(${FUTURE_TASK_CLEANUP_TEST_TARGET}
+  chimaera_cxx               # Main Chimaera library
+  chimaera_MOD_NAME_client   # MOD_NAME client
+  chimaera_MOD_NAME_runtime  # MOD_NAME runtime
+  hshm::cxx                  # HermesShm library
+  ${CMAKE_THREAD_LIBS_INIT}  # Threading support
+)
+
+set_target_properties(${FUTURE_TASK_CLEANUP_TEST_TARGET} PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+)
+
+set_target_properties(${FUTURE_TASK_CLEANUP_TEST_TARGET} PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+# Create BULK_EXPOSE cleanup regression test executable
+add_executable(${BULK_EXPOSE_CLEANUP_TEST_TARGET} ${BULK_EXPOSE_CLEANUP_TEST_SOURCES})
+
+target_include_directories(${BULK_EXPOSE_CLEANUP_TEST_TARGET} PRIVATE
+  ${CHIMAERA_ROOT}/include
+  ${CHIMAERA_ROOT}/test  # For simple_test.h
+  ${CHIMAERA_ROOT}/modules/bdev/include
+  ${CHIMAERA_ROOT}/modules/admin/include
+)
+
+target_link_libraries(${BULK_EXPOSE_CLEANUP_TEST_TARGET}
+  chimaera_cxx               # Main Chimaera library
+  chimaera_bdev_client        # Bdev module client
+  chimaera_admin_client       # Admin module client
+  hshm::cxx                  # HermesShm library
+  ${CMAKE_THREAD_LIBS_INIT}  # Threading support
+)
+
+set_target_properties(${BULK_EXPOSE_CLEANUP_TEST_TARGET} PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
 
@@ -754,6 +815,30 @@ if(WRP_CORE_ENABLE_TESTS)
     TIMEOUT 180
   )
 
+  # Future task cleanup regression tests
+  add_test(
+    NAME cr_future_task_cleanup_tests
+    COMMAND ${FUTURE_TASK_CLEANUP_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_future_task_cleanup_tests PROPERTIES
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+    TIMEOUT 120
+    LABELS "regression;memory"
+  )
+
+  # BULK_EXPOSE cleanup regression tests
+  add_test(
+    NAME cr_bulk_expose_cleanup_tests
+    COMMAND ${BULK_EXPOSE_CLEANUP_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_bulk_expose_cleanup_tests PROPERTIES
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+    TIMEOUT 120
+    LABELS "regression;memory"
+  )
+
   # External Client Tests
   # NOTE: Each test case must run in its own process because CHIMAERA_INIT has
   # a static guard that prevents re-initialization. Running all tests in one
@@ -1083,6 +1168,8 @@ install(TARGETS
   ${AUTOGEN_COVERAGE_TEST_TARGET}
   ${STREAMING_TEST_TARGET}
   ${EXTERNAL_CLIENT_TEST_TARGET}
+  ${FUTURE_TASK_CLEANUP_TEST_TARGET}
+  ${BULK_EXPOSE_CLEANUP_TEST_TARGET}
   ${RUNTIME_CLEANUP_TEST_TARGET}
   ${IPC_ERRORS_TEST_TARGET}
   ${IPC_TRANSPORT_MODES_TEST_TARGET}

--- a/context-runtime/test/unit/test_autogen_coverage.cc
+++ b/context-runtime/test/unit/test_autogen_coverage.cc
@@ -340,7 +340,7 @@ TEST_CASE("Autogen - Admin Aggregate", "[autogen][admin][aggregate]") {
 
     hipc::FullPtr<chi::Task> origin_ptr = origin_task.template Cast<chi::Task>();
     hipc::FullPtr<chi::Task> replica_ptr = replica_task.template Cast<chi::Task>();
-    origin_ptr.ptr_->Aggregate(replica_ptr.template Cast<chi::Task>());
+    origin_ptr->Aggregate(replica_ptr.template Cast<chi::Task>());
 
     INFO("Aggregate for FlushTask completed");
     CHI_IPC->DelTask(origin_task);
@@ -362,7 +362,7 @@ TEST_CASE("Autogen - Admin Aggregate", "[autogen][admin][aggregate]") {
 
     hipc::FullPtr<chi::Task> origin_ptr = origin_task.template Cast<chi::Task>();
     hipc::FullPtr<chi::Task> replica_ptr = replica_task.template Cast<chi::Task>();
-    origin_ptr.ptr_->Aggregate(replica_ptr.template Cast<chi::Task>());
+    origin_ptr->Aggregate(replica_ptr.template Cast<chi::Task>());
 
     INFO("Aggregate for MonitorTask completed");
     CHI_IPC->DelTask(origin_task);
@@ -701,7 +701,7 @@ TEST_CASE("Autogen - Admin StopRuntimeTask coverage", "[autogen][admin][stoprunt
       // Test Aggregate
       auto replica_task = container->NewTask(chimaera::admin::Method::kStopRuntime);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
+        new_task->Aggregate(replica_task.template Cast<chi::Task>());
         INFO("Aggregate for StopRuntimeTask succeeded");
         CHI_IPC->DelTask(replica_task);
       }
@@ -753,7 +753,7 @@ TEST_CASE("Autogen - Admin DestroyPoolTask coverage", "[autogen][admin][destroyp
       // Aggregate
       auto replica_task = container->NewTask(chimaera::admin::Method::kDestroyPool);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
+        new_task->Aggregate(replica_task.template Cast<chi::Task>());
         INFO("Aggregate for DestroyPoolTask succeeded");
         CHI_IPC->DelTask(replica_task);
       }
@@ -790,7 +790,7 @@ TEST_CASE("Autogen - Admin SubmitBatchTask coverage", "[autogen][admin][submitba
       // Aggregate
       auto replica_task = container->NewTask(chimaera::admin::Method::kSubmitBatch);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
+        new_task->Aggregate(replica_task.template Cast<chi::Task>());
         INFO("Aggregate for SubmitBatchTask succeeded");
         CHI_IPC->DelTask(replica_task);
       }
@@ -827,7 +827,7 @@ TEST_CASE("Autogen - Admin CreateTask and DestroyTask coverage", "[autogen][admi
       // Aggregate
       auto replica_task = container->NewTask(chimaera::admin::Method::kCreate);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
+        new_task->Aggregate(replica_task.template Cast<chi::Task>());
         INFO("Aggregate for CreateTask succeeded");
         CHI_IPC->DelTask(replica_task);
       }
@@ -851,7 +851,7 @@ TEST_CASE("Autogen - Admin CreateTask and DestroyTask coverage", "[autogen][admi
       // Aggregate
       auto replica_task = container->NewTask(chimaera::admin::Method::kDestroy);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
+        new_task->Aggregate(replica_task.template Cast<chi::Task>());
         INFO("Aggregate for DestroyTask succeeded");
         CHI_IPC->DelTask(replica_task);
       }
@@ -888,7 +888,7 @@ TEST_CASE("Autogen - Admin GetOrCreatePoolTask coverage", "[autogen][admin][geto
       // Aggregate
       auto replica_task = container->NewTask(chimaera::admin::Method::kGetOrCreatePool);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
+        new_task->Aggregate(replica_task.template Cast<chi::Task>());
         INFO("Aggregate for GetOrCreatePoolTask succeeded");
         CHI_IPC->DelTask(replica_task);
       }
@@ -925,7 +925,7 @@ TEST_CASE("Autogen - Admin SendTask and RecvTask coverage", "[autogen][admin][se
       // Aggregate
       auto replica_task = container->NewTask(chimaera::admin::Method::kSend);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
+        new_task->Aggregate(replica_task.template Cast<chi::Task>());
         INFO("Aggregate for SendTask succeeded");
         CHI_IPC->DelTask(replica_task);
       }
@@ -949,7 +949,7 @@ TEST_CASE("Autogen - Admin SendTask and RecvTask coverage", "[autogen][admin][se
       // Aggregate
       auto replica_task = container->NewTask(chimaera::admin::Method::kRecv);
       if (!replica_task.IsNull()) {
-        new_task.ptr_->Aggregate(replica_task.template Cast<chi::Task>());
+        new_task->Aggregate(replica_task.template Cast<chi::Task>());
         INFO("Aggregate for RecvTask succeeded");
         CHI_IPC->DelTask(replica_task);
       }
@@ -2881,7 +2881,7 @@ TEST_CASE("Autogen - Admin Container advanced operations", "[autogen][admin][con
     auto task1a = admin_container->NewTask(chimaera::admin::Method::kFlush);
     auto task1b = admin_container->NewTask(chimaera::admin::Method::kFlush);
     if (!task1a.IsNull() && !task1b.IsNull()) {
-      task1a.ptr_->Aggregate(task1b.template Cast<chi::Task>());
+      task1a->Aggregate(task1b.template Cast<chi::Task>());
       INFO("Admin Container Aggregate for Flush completed");
       CHI_IPC->DelTask(task1a);
       CHI_IPC->DelTask(task1b);
@@ -2890,7 +2890,7 @@ TEST_CASE("Autogen - Admin Container advanced operations", "[autogen][admin][con
     auto task2a = admin_container->NewTask(chimaera::admin::Method::kClientConnect);
     auto task2b = admin_container->NewTask(chimaera::admin::Method::kClientConnect);
     if (!task2a.IsNull() && !task2b.IsNull()) {
-      task2a.ptr_->Aggregate(task2b.template Cast<chi::Task>());
+      task2a->Aggregate(task2b.template Cast<chi::Task>());
       INFO("Admin Container Aggregate for ClientConnect completed");
       CHI_IPC->DelTask(task2a);
       CHI_IPC->DelTask(task2b);
@@ -4201,7 +4201,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kCreate);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kCreate);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for Create completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -4212,7 +4212,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kDestroy);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kDestroy);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for Destroy completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -4223,7 +4223,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kStopRuntime);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kStopRuntime);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for StopRuntime completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -4234,7 +4234,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kDestroyPool);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kDestroyPool);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for DestroyPool completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -4245,7 +4245,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kGetOrCreatePool);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kGetOrCreatePool);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for GetOrCreatePool completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -4256,7 +4256,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kSubmitBatch);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kSubmitBatch);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for SubmitBatch completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -4267,7 +4267,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kSend);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kSend);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for Send completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -4278,7 +4278,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kRecv);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kRecv);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for Recv completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -4289,7 +4289,7 @@ TEST_CASE("Autogen - Admin Aggregate comprehensive", "[autogen][admin][aggregate
     auto t1 = admin_container->NewTask(chimaera::admin::Method::kMonitor);
     auto t2 = admin_container->NewTask(chimaera::admin::Method::kMonitor);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       INFO("Admin Aggregate for Monitor completed");
       CHI_IPC->DelTask(t1);
       CHI_IPC->DelTask(t2);
@@ -6101,7 +6101,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_c.IsNull() && !t2_c.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_c.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_c.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_c);
       CHI_IPC->DelTask(t2_c);
     }
@@ -6112,7 +6112,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_d.IsNull() && !t2_d.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_d.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_d.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_d);
       CHI_IPC->DelTask(t2_d);
     }
@@ -6123,7 +6123,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_r.IsNull() && !t2_r.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_r.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_r.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_r);
       CHI_IPC->DelTask(t2_r);
     }
@@ -6134,7 +6134,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_u.IsNull() && !t2_u.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_u.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_u.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_u);
       CHI_IPC->DelTask(t2_u);
     }
@@ -6145,7 +6145,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_l.IsNull() && !t2_l.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_l.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_l.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_l);
       CHI_IPC->DelTask(t2_l);
     }
@@ -6156,7 +6156,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_p.IsNull() && !t2_p.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_p.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_p.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_p);
       CHI_IPC->DelTask(t2_p);
     }
@@ -6167,7 +6167,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_g.IsNull() && !t2_g.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_g.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_g.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_g);
       CHI_IPC->DelTask(t2_g);
     }
@@ -6178,7 +6178,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_st.IsNull() && !t2_st.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_st.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_st.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_st);
       CHI_IPC->DelTask(t2_st);
     }
@@ -6189,7 +6189,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_gt.IsNull() && !t2_gt.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_gt.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_gt.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_gt);
       CHI_IPC->DelTask(t2_gt);
     }
@@ -6200,7 +6200,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_re.IsNull() && !t2_re.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_re.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_re.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_re);
       CHI_IPC->DelTask(t2_re);
     }
@@ -6211,7 +6211,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_db.IsNull() && !t2_db.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_db.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_db.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_db);
       CHI_IPC->DelTask(t2_db);
     }
@@ -6222,7 +6222,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_dt.IsNull() && !t2_dt.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_dt.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_dt.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_dt);
       CHI_IPC->DelTask(t2_dt);
     }
@@ -6233,7 +6233,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_ts.IsNull() && !t2_ts.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_ts.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_ts.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_ts);
       CHI_IPC->DelTask(t2_ts);
     }
@@ -6244,7 +6244,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_tl.IsNull() && !t2_tl.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_tl.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_tl.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_tl);
       CHI_IPC->DelTask(t2_tl);
     }
@@ -6255,7 +6255,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_sc.IsNull() && !t2_sc.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_sc.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_sc.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_sc);
       CHI_IPC->DelTask(t2_sc);
     }
@@ -6266,7 +6266,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_bs.IsNull() && !t2_bs.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_bs.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_bs.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_bs);
       CHI_IPC->DelTask(t2_bs);
     }
@@ -6277,7 +6277,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_cb.IsNull() && !t2_cb.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_cb.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_cb.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_cb);
       CHI_IPC->DelTask(t2_cb);
     }
@@ -6288,7 +6288,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_tq.IsNull() && !t2_tq.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_tq.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_tq.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_tq);
       CHI_IPC->DelTask(t2_tq);
     }
@@ -6299,7 +6299,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     if (!t1_bq.IsNull() && !t2_bq.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_bq.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_bq.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_bq);
       CHI_IPC->DelTask(t2_bq);
     }
@@ -6308,7 +6308,7 @@ TEST_CASE("Autogen - CTE Runtime Container Methods", "[autogen][cte][runtime]") 
     auto t1_unk = ipc_manager->NewTask<chi::Task>();
     auto t2_unk = ipc_manager->NewTask<chi::Task>();
     if (!t1_unk.IsNull() && !t2_unk.IsNull()) {
-      t1_unk.ptr_->Aggregate(t2_unk.template Cast<chi::Task>());
+      t1_unk->Aggregate(t2_unk.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_unk);
       CHI_IPC->DelTask(t2_unk);
     }
@@ -6554,7 +6554,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_c.IsNull() && !t2_c.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_c.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_c.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_c);
       CHI_IPC->DelTask(t2_c);
     }
@@ -6564,7 +6564,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_d.IsNull() && !t2_d.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_d.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_d.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_d);
       CHI_IPC->DelTask(t2_d);
     }
@@ -6574,7 +6574,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_a.IsNull() && !t2_a.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_a.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_a.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_a);
       CHI_IPC->DelTask(t2_a);
     }
@@ -6584,7 +6584,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_f.IsNull() && !t2_f.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_f.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_f.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_f);
       CHI_IPC->DelTask(t2_f);
     }
@@ -6594,7 +6594,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_w.IsNull() && !t2_w.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_w.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_w.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_w);
       CHI_IPC->DelTask(t2_w);
     }
@@ -6604,7 +6604,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_r.IsNull() && !t2_r.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_r.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_r.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_r);
       CHI_IPC->DelTask(t2_r);
     }
@@ -6614,7 +6614,7 @@ TEST_CASE("Autogen - Bdev Runtime Container Methods", "[autogen][bdev][runtime]"
     if (!t1_s.IsNull() && !t2_s.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_s.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_s.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_s);
       CHI_IPC->DelTask(t2_s);
     }
@@ -6913,7 +6913,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     if (!t1_c.IsNull() && !t2_c.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_c.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_c.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_c);
       CHI_IPC->DelTask(t2_c);
     }
@@ -6922,7 +6922,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     auto t1_d = ipc_manager->NewTask<chi::Task>();
     auto t2_d = ipc_manager->NewTask<chi::Task>();
     if (!t1_d.IsNull() && !t2_d.IsNull()) {
-      t1_d.ptr_->Aggregate(t2_d.template Cast<chi::Task>());
+      t1_d->Aggregate(t2_d.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_d);
       CHI_IPC->DelTask(t2_d);
     }
@@ -6933,7 +6933,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     if (!t1_p.IsNull() && !t2_p.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_p.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_p.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_p);
       CHI_IPC->DelTask(t2_p);
     }
@@ -6944,7 +6944,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     if (!t1_h.IsNull() && !t2_h.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_h.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_h.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_h);
       CHI_IPC->DelTask(t2_h);
     }
@@ -6953,7 +6953,7 @@ TEST_CASE("Autogen - CAE Runtime Container Methods", "[autogen][cae][runtime]") 
     auto t1_u = ipc_manager->NewTask<chi::Task>();
     auto t2_u = ipc_manager->NewTask<chi::Task>();
     if (!t1_u.IsNull() && !t2_u.IsNull()) {
-      t1_u.ptr_->Aggregate(t2_u.template Cast<chi::Task>());
+      t1_u->Aggregate(t2_u.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_u);
       CHI_IPC->DelTask(t2_u);
     }
@@ -7498,7 +7498,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_c.IsNull() && !t2_c.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_c.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_c.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_c);
       CHI_IPC->DelTask(t2_c);
     }
@@ -7509,7 +7509,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_d.IsNull() && !t2_d.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_d.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_d.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_d);
       CHI_IPC->DelTask(t2_d);
     }
@@ -7520,7 +7520,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_cu.IsNull() && !t2_cu.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_cu.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_cu.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_cu);
       CHI_IPC->DelTask(t2_cu);
     }
@@ -7531,7 +7531,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_cm.IsNull() && !t2_cm.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_cm.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_cm.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_cm);
       CHI_IPC->DelTask(t2_cm);
     }
@@ -7542,7 +7542,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_cr.IsNull() && !t2_cr.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_cr.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_cr.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_cr);
       CHI_IPC->DelTask(t2_cr);
     }
@@ -7553,7 +7553,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     if (!t1_w.IsNull() && !t2_w.IsNull()) {
       hipc::FullPtr<chi::Task> ptr1 = t1_w.template Cast<chi::Task>();
       hipc::FullPtr<chi::Task> ptr2 = t2_w.template Cast<chi::Task>();
-      ptr1.ptr_->Aggregate(ptr2.template Cast<chi::Task>());
+      ptr1->Aggregate(ptr2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_w);
       CHI_IPC->DelTask(t2_w);
     }
@@ -7562,7 +7562,7 @@ TEST_CASE("Autogen - MOD_NAME Runtime Container Methods", "[autogen][mod_name][r
     auto t1_u = ipc_manager->NewTask<chi::Task>();
     auto t2_u = ipc_manager->NewTask<chi::Task>();
     if (!t1_u.IsNull() && !t2_u.IsNull()) {
-      t1_u.ptr_->Aggregate(t2_u.template Cast<chi::Task>());
+      t1_u->Aggregate(t2_u.template Cast<chi::Task>());
       CHI_IPC->DelTask(t1_u);
       CHI_IPC->DelTask(t2_u);
     }
@@ -8758,7 +8758,7 @@ TEST_CASE("Autogen - Bdev Container NewCopyTask coverage", "[autogen][bdev][cont
     auto task1 = container->NewTask(chimaera::bdev::Method::kWrite);
     auto task2 = container->NewTask(chimaera::bdev::Method::kWrite);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
+      task1->Aggregate(task2.template Cast<chi::Task>());
       INFO("Aggregate for WriteTask succeeded");
       CHI_IPC->DelTask(task1);
       CHI_IPC->DelTask(task2);
@@ -8810,7 +8810,7 @@ TEST_CASE("Autogen - Admin Container NewCopyTask coverage", "[autogen][admin][co
     auto task1 = container->NewTask(chimaera::admin::Method::kSend);
     auto task2 = container->NewTask(chimaera::admin::Method::kSend);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
+      task1->Aggregate(task2.template Cast<chi::Task>());
       INFO("Aggregate for SendTask succeeded");
       CHI_IPC->DelTask(task1);
       CHI_IPC->DelTask(task2);
@@ -8821,7 +8821,7 @@ TEST_CASE("Autogen - Admin Container NewCopyTask coverage", "[autogen][admin][co
     auto task1 = container->NewTask(chimaera::admin::Method::kRecv);
     auto task2 = container->NewTask(chimaera::admin::Method::kRecv);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
+      task1->Aggregate(task2.template Cast<chi::Task>());
       INFO("Aggregate for RecvTask succeeded");
       CHI_IPC->DelTask(task1);
       CHI_IPC->DelTask(task2);
@@ -8873,7 +8873,7 @@ TEST_CASE("Autogen - CTE Container NewCopyTask coverage", "[autogen][cte][contai
     auto task1 = container->NewTask(wrp_cte::core::Method::kGetBlob);
     auto task2 = container->NewTask(wrp_cte::core::Method::kGetBlob);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
+      task1->Aggregate(task2.template Cast<chi::Task>());
       INFO("Aggregate for GetBlobTask succeeded");
       CHI_IPC->DelTask(task1);
       CHI_IPC->DelTask(task2);
@@ -9360,7 +9360,7 @@ TEST_CASE("Autogen - CAE Container Aggregate coverage", "[autogen][cae][containe
     auto task1 = container->NewTask(wrp_cae::core::Method::kCreate);
     auto task2 = container->NewTask(wrp_cae::core::Method::kCreate);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
+      task1->Aggregate(task2.template Cast<chi::Task>());
       INFO("Aggregate for CreateTask succeeded");
       CHI_IPC->DelTask(task1);
       CHI_IPC->DelTask(task2);
@@ -9371,7 +9371,7 @@ TEST_CASE("Autogen - CAE Container Aggregate coverage", "[autogen][cae][containe
     auto task1 = container->NewTask(wrp_cae::core::Method::kParseOmni);
     auto task2 = container->NewTask(wrp_cae::core::Method::kParseOmni);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
+      task1->Aggregate(task2.template Cast<chi::Task>());
       INFO("Aggregate for ParseOmniTask succeeded");
       CHI_IPC->DelTask(task1);
       CHI_IPC->DelTask(task2);
@@ -9382,7 +9382,7 @@ TEST_CASE("Autogen - CAE Container Aggregate coverage", "[autogen][cae][containe
     auto task1 = container->NewTask(wrp_cae::core::Method::kProcessHdf5Dataset);
     auto task2 = container->NewTask(wrp_cae::core::Method::kProcessHdf5Dataset);
     if (!task1.IsNull() && !task2.IsNull()) {
-      task1.ptr_->Aggregate(task2.template Cast<chi::Task>());
+      task1->Aggregate(task2.template Cast<chi::Task>());
       INFO("Aggregate for ProcessHdf5DatasetTask succeeded");
       CHI_IPC->DelTask(task1);
       CHI_IPC->DelTask(task2);
@@ -9643,7 +9643,7 @@ TEST_CASE("Autogen - Admin WreapDeadIpcs Container Methods", "[autogen][admin][w
     auto t1 = container->NewTask(chimaera::admin::Method::kWreapDeadIpcs);
     auto t2 = container->NewTask(chimaera::admin::Method::kWreapDeadIpcs);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -10028,7 +10028,7 @@ TEST_CASE("Autogen - CTE GetTargetInfo Container Methods", "[autogen][cte][getta
     auto t1 = cte_runtime.NewTask(wrp_cte::core::Method::kGetTargetInfo);
     auto t2 = cte_runtime.NewTask(wrp_cte::core::Method::kGetTargetInfo);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -10255,7 +10255,7 @@ TEST_CASE("Autogen - Admin Default Case Coverage", "[autogen][admin][default]") 
     auto t1 = container->NewTask(chimaera::admin::Method::kFlush);
     auto t2 = container->NewTask(chimaera::admin::Method::kFlush);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -10349,7 +10349,7 @@ TEST_CASE("Autogen - Bdev Default Case Coverage", "[autogen][bdev][default]") {
     auto t1 = bdev_runtime.NewTask(chimaera::bdev::Method::kGetStats);
     auto t2 = bdev_runtime.NewTask(chimaera::bdev::Method::kGetStats);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -10474,7 +10474,7 @@ TEST_CASE("Autogen - CTE Default Case Coverage", "[autogen][cte][default]") {
     auto t1 = cte_runtime.NewTask(wrp_cte::core::Method::kGetTagSize);
     auto t2 = cte_runtime.NewTask(wrp_cte::core::Method::kGetTagSize);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -11060,7 +11060,7 @@ TEST_CASE("Autogen - Admin Container StopRuntime", "[autogen][admin][container][
     auto t1 = admin_runtime.NewTask(chimaera::admin::Method::kStopRuntime);
     auto t2 = admin_runtime.NewTask(chimaera::admin::Method::kStopRuntime);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -11071,7 +11071,7 @@ TEST_CASE("Autogen - Admin Container StopRuntime", "[autogen][admin][container][
     auto t1 = admin_runtime.NewTask(chimaera::admin::Method::kSend);
     auto t2 = admin_runtime.NewTask(chimaera::admin::Method::kSend);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -11082,7 +11082,7 @@ TEST_CASE("Autogen - Admin Container StopRuntime", "[autogen][admin][container][
     auto t1 = admin_runtime.NewTask(chimaera::admin::Method::kRecv);
     auto t2 = admin_runtime.NewTask(chimaera::admin::Method::kRecv);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -11093,7 +11093,7 @@ TEST_CASE("Autogen - Admin Container StopRuntime", "[autogen][admin][container][
     auto t1 = admin_runtime.NewTask(chimaera::admin::Method::kWreapDeadIpcs);
     auto t2 = admin_runtime.NewTask(chimaera::admin::Method::kWreapDeadIpcs);
     if (!t1.IsNull() && !t2.IsNull()) {
-      t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+      t1->Aggregate(t2.template Cast<chi::Task>());
       CHI_IPC->DelTask(t2);
     }
     if (!t1.IsNull()) CHI_IPC->DelTask(t1);
@@ -12131,7 +12131,7 @@ TEST_CASE("Autogen - IpcManager memory operations", "[autogen][ipcmanager][memor
     auto buf = ipc->AllocateBuffer(1024);
     if (!buf.IsNull()) {
       // Write to buffer to verify it's valid
-      memset(buf.ptr_, 0xAA, 1024);
+      memset(buf.get(), 0xAA, 1024);
       ipc->FreeBuffer(buf);
       INFO("AllocateBuffer/FreeBuffer completed");
     } else {
@@ -12403,7 +12403,7 @@ TEST_CASE("Autogen - CTE Container NewCopyTask dispatch", "[autogen][cte][contai
       auto t1 = cte_runtime.NewTask(method);
       auto t2 = cte_runtime.NewTask(method);
       if (!t1.IsNull() && !t2.IsNull()) {
-        t1.ptr_->Aggregate(t2.template Cast<chi::Task>());
+        t1->Aggregate(t2.template Cast<chi::Task>());
         CHI_IPC->DelTask(t2);
       }
       if (!t1.IsNull()) {
@@ -14380,7 +14380,7 @@ TEST_CASE("Autogen - MOD_NAME LocalLoadTask remaining methods", "[autogen][mod_n
       // Manually serialize using the task's SerializeIn to generate matching data
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::MOD_NAME::CustomTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::MOD_NAME::Method::kCustom);
       if (!loaded.IsNull()) {
@@ -14398,7 +14398,7 @@ TEST_CASE("Autogen - MOD_NAME LocalLoadTask remaining methods", "[autogen][mod_n
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::MOD_NAME::CreateTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::MOD_NAME::Method::kCreate);
       if (!loaded.IsNull()) {
@@ -14416,7 +14416,7 @@ TEST_CASE("Autogen - MOD_NAME LocalLoadTask remaining methods", "[autogen][mod_n
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::admin::DestroyPoolTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::MOD_NAME::Method::kDestroy);
       if (!loaded.IsNull()) {
@@ -14441,7 +14441,7 @@ TEST_CASE("Autogen - Admin LocalLoadTask remaining methods", "[autogen][admin][l
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::admin::CreateTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::admin::Method::kCreate);
       if (!loaded.IsNull()) {
@@ -14459,7 +14459,7 @@ TEST_CASE("Autogen - Admin LocalLoadTask remaining methods", "[autogen][admin][l
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::admin::DestroyPoolTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::admin::Method::kDestroy);
       if (!loaded.IsNull()) {
@@ -14477,7 +14477,7 @@ TEST_CASE("Autogen - Admin LocalLoadTask remaining methods", "[autogen][admin][l
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::admin::GetOrCreatePoolTask<chimaera::admin::CreateParams>>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::admin::Method::kGetOrCreatePool);
       if (!loaded.IsNull()) {
@@ -14495,7 +14495,7 @@ TEST_CASE("Autogen - Admin LocalLoadTask remaining methods", "[autogen][admin][l
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::admin::DestroyPoolTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::admin::Method::kDestroyPool);
       if (!loaded.IsNull()) {
@@ -14513,7 +14513,7 @@ TEST_CASE("Autogen - Admin LocalLoadTask remaining methods", "[autogen][admin][l
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::admin::SubmitBatchTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::admin::Method::kSubmitBatch);
       if (!loaded.IsNull()) {
@@ -14538,7 +14538,7 @@ TEST_CASE("Autogen - Bdev LocalLoadTask remaining methods", "[autogen][bdev][loc
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::admin::GetOrCreatePoolTask<chimaera::bdev::CreateParams>>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::bdev::Method::kCreate);
       if (!loaded.IsNull()) {
@@ -14556,7 +14556,7 @@ TEST_CASE("Autogen - Bdev LocalLoadTask remaining methods", "[autogen][bdev][loc
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::admin::DestroyPoolTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::bdev::Method::kDestroy);
       if (!loaded.IsNull()) {
@@ -14574,7 +14574,7 @@ TEST_CASE("Autogen - Bdev LocalLoadTask remaining methods", "[autogen][bdev][loc
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::bdev::FreeBlocksTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::bdev::Method::kFreeBlocks);
       if (!loaded.IsNull()) {
@@ -14592,7 +14592,7 @@ TEST_CASE("Autogen - Bdev LocalLoadTask remaining methods", "[autogen][bdev][loc
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::bdev::WriteTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::bdev::Method::kWrite);
       if (!loaded.IsNull()) {
@@ -14610,7 +14610,7 @@ TEST_CASE("Autogen - Bdev LocalLoadTask remaining methods", "[autogen][bdev][loc
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<chimaera::bdev::ReadTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
 
       auto loaded = rt.NewTask(chimaera::bdev::Method::kRead);
       if (!loaded.IsNull()) {
@@ -14632,7 +14632,7 @@ TEST_CASE("Autogen - Bdev LocalLoadTask remaining methods", "[autogen][bdev][loc
     if (!task.IsNull()) { \
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn); \
       auto typed = task.template Cast<task_type>(); \
-      typed.ptr_->SerializeIn(save_archive); \
+      typed->SerializeIn(save_archive); \
       auto loaded = cte_rt.NewTask(method_enum); \
       if (!loaded.IsNull()) { \
         chi::LocalLoadTaskArchive load_archive(save_archive.GetData()); \
@@ -14659,7 +14659,7 @@ TEST_CASE("Autogen - CTE LocalLoadTask remaining methods", "[autogen][cte][local
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cte::core::GetOrCreateTagTask<wrp_cte::core::CreateParams>>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       auto loaded = cte_rt.NewTask(wrp_cte::core::Method::kGetOrCreateTag);
       if (!loaded.IsNull()) {
         chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
@@ -14694,7 +14694,7 @@ TEST_CASE("Autogen - CAE LocalLoadTask all methods", "[autogen][cae][localload][
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cae::core::CreateTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       auto loaded = rt.NewTask(wrp_cae::core::Method::kCreate);
       if (!loaded.IsNull()) {
         chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
@@ -14711,7 +14711,7 @@ TEST_CASE("Autogen - CAE LocalLoadTask all methods", "[autogen][cae][localload][
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cae::core::DestroyTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       auto loaded = rt.NewTask(wrp_cae::core::Method::kDestroy);
       if (!loaded.IsNull()) {
         chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
@@ -14728,7 +14728,7 @@ TEST_CASE("Autogen - CAE LocalLoadTask all methods", "[autogen][cae][localload][
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cae::core::ParseOmniTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       auto loaded = rt.NewTask(wrp_cae::core::Method::kParseOmni);
       if (!loaded.IsNull()) {
         chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
@@ -14745,7 +14745,7 @@ TEST_CASE("Autogen - CAE LocalLoadTask all methods", "[autogen][cae][localload][
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cae::core::ProcessHdf5DatasetTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       auto loaded = rt.NewTask(wrp_cae::core::Method::kProcessHdf5Dataset);
       if (!loaded.IsNull()) {
         chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
@@ -14771,7 +14771,7 @@ TEST_CASE("Autogen - CAE LocalAllocLoadTask all methods", "[autogen][cae][locala
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cae::core::CreateTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
       auto loaded = rt.LocalAllocLoadTask(wrp_cae::core::Method::kCreate, load_archive);
       if (!loaded.IsNull()) {
@@ -14787,7 +14787,7 @@ TEST_CASE("Autogen - CAE LocalAllocLoadTask all methods", "[autogen][cae][locala
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cae::core::DestroyTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
       auto loaded = rt.LocalAllocLoadTask(wrp_cae::core::Method::kDestroy, load_archive);
       if (!loaded.IsNull()) {
@@ -14803,7 +14803,7 @@ TEST_CASE("Autogen - CAE LocalAllocLoadTask all methods", "[autogen][cae][locala
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cae::core::ParseOmniTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
       auto loaded = rt.LocalAllocLoadTask(wrp_cae::core::Method::kParseOmni, load_archive);
       if (!loaded.IsNull()) {
@@ -14819,7 +14819,7 @@ TEST_CASE("Autogen - CAE LocalAllocLoadTask all methods", "[autogen][cae][locala
     if (!task.IsNull()) {
       chi::LocalSaveTaskArchive save_archive(chi::LocalMsgType::kSerializeIn);
       auto typed = task.template Cast<wrp_cae::core::ProcessHdf5DatasetTask>();
-      typed.ptr_->SerializeIn(save_archive);
+      typed->SerializeIn(save_archive);
       chi::LocalLoadTaskArchive load_archive(save_archive.GetData());
       auto loaded = rt.LocalAllocLoadTask(wrp_cae::core::Method::kProcessHdf5Dataset, load_archive);
       if (!loaded.IsNull()) {

--- a/context-runtime/test/unit/test_bulk_expose_cleanup.cc
+++ b/context-runtime/test/unit/test_bulk_expose_cleanup.cc
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Regression test: BULK_EXPOSE buffer allocated by the server during
+ * ReadTask deserialization must be freed when the task is deleted.
+ *
+ * Before the fix, SendOut() cleared TASK_DATA_OWNER before deferred
+ * deletion, so ~ReadTask() never freed the AllocateBuffer'd data.
+ * Each AsyncRead leaked the server-side BULK_EXPOSE buffer.
+ *
+ * Strategy
+ * --------
+ * Uses TASK_FORCE_NET to force the network serialization path even in
+ * embedded mode. This ensures the task goes through:
+ *   Send -> ZMQ -> RecvIn (sets TASK_DATA_OWNER, BULK_EXPOSE alloc)
+ *   -> Run -> SendOut (deferred delete with destructor freeing buffer)
+ *
+ * Because TASK_FORCE_NET with embedded mode creates a FutureShm with
+ * origin=SHM (rather than TCP), we must patch the origin to TCP so
+ * ~Future properly calls CleanupResponseArchive for ZMQ recv buffers.
+ *
+ * Measures glibc heap growth via mallinfo() to detect the leak.
+ */
+
+#include "../simple_test.h"
+#include "chimaera/chimaera.h"
+#include "chimaera/ipc_manager.h"
+#include "chimaera/bdev/bdev_client.h"
+#include "chimaera/bdev/bdev_tasks.h"
+
+#include <malloc.h>
+#include <cstring>
+#include <thread>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+static constexpr chi::PoolId kTestPoolId = chi::PoolId(888, 0);
+static constexpr chi::u64 kRamSize = 16 * 1024 * 1024;  // 16MB
+static constexpr chi::u64 kBlockSize = 4096;             // 4KB
+static constexpr chi::u64 kIoSize = 64 * 1024;           // 64KB read size
+static constexpr int kBatchSize = 200;
+static constexpr long kMaxBytesPerRead = 512;  // generous ceiling
+
+static bool g_initialized = false;
+
+/** Wrap a single block into the vector form ReadTask expects. */
+static inline chi::priv::vector<chimaera::bdev::Block> WrapBlock(
+    const chimaera::bdev::Block &block) {
+  chi::priv::vector<chimaera::bdev::Block> blocks(HSHM_MALLOC);
+  blocks.push_back(block);
+  return blocks;
+}
+
+/** Returns mallinfo.uordblks - heap bytes currently in active use. */
+static long heap_in_use() {
+  struct mallinfo mi = mallinfo();
+  return (long)(unsigned int)mi.uordblks;
+}
+
+/** Send a ReadTask with TASK_FORCE_NET so it goes through the network
+ *  serialization path (RecvIn -> BULK_EXPOSE alloc -> SendOut).
+ *  Patches origin to TCP so ~Future calls CleanupResponseArchive. */
+static chi::Future<chimaera::bdev::ReadTask> SendForceNetRead(
+    chimaera::bdev::Client &client,
+    const chimaera::bdev::Block &block,
+    hipc::ShmPtr<> data,
+    size_t size) {
+  auto *ipc = CHI_IPC;
+  auto task_ptr = ipc->NewTask<chimaera::bdev::ReadTask>(
+      chi::CreateTaskId(), client.pool_id_, chi::PoolQuery::Local(),
+      WrapBlock(block), data, size);
+  task_ptr->SetFlags(TASK_FORCE_NET);
+  auto future = ipc->Send(task_ptr);
+  // Patch origin from SHM to TCP so ~Future calls CleanupResponseArchive
+  // for the ZMQ recv buffers created by TASK_FORCE_NET loopback.
+  auto fs = future.GetFutureShm();
+  if (!fs.IsNull()) {
+    fs->origin_ = chi::FutureShm::FUTURE_CLIENT_TCP;
+  }
+  return future;
+}
+
+class BulkExposeFixture {
+ public:
+  BulkExposeFixture() {
+    if (!g_initialized) {
+      bool ok = chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
+      if (ok) {
+        g_initialized = true;
+        SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+        std::this_thread::sleep_for(500ms);
+      }
+    }
+  }
+};
+
+TEST_CASE("BULK_EXPOSE buffer freed after ReadTask (TASK_FORCE_NET)",
+          "[bdev][memory][regression]") {
+  BulkExposeFixture fixture;
+  REQUIRE(g_initialized);
+
+  HLOG(kInfo, "Creating RAM bdev pool...");
+
+  // Create RAM bdev pool
+  chimaera::bdev::Client client(kTestPoolId);
+  auto create_task = client.AsyncCreate(
+      chi::PoolQuery::Dynamic(), "bulk_expose_test", kTestPoolId,
+      chimaera::bdev::BdevType::kRam, kRamSize);
+  create_task.Wait();
+  HLOG(kInfo, "create_task done, return_code={}", create_task->return_code_);
+  REQUIRE(create_task->return_code_ == 0);
+  client.pool_id_ = create_task->new_pool_id_;
+
+  // Allocate a block
+  auto alloc_task = client.AsyncAllocateBlocks(
+      chi::PoolQuery::Local(), kBlockSize);
+  alloc_task.Wait();
+  REQUIRE(alloc_task->return_code_ == 0);
+  REQUIRE(alloc_task->blocks_.size() > 0);
+  chimaera::bdev::Block block = alloc_task->blocks_[0];
+
+  // Write test data so reads return real data (use TASK_FORCE_NET too)
+  {
+    auto write_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+    REQUIRE_FALSE(write_buffer.IsNull());
+    memset(write_buffer.ptr_, 0xAB, kIoSize);
+    auto *ipc = CHI_IPC;
+    auto write_task_ptr = ipc->NewTask<chimaera::bdev::WriteTask>(
+        chi::CreateTaskId(), client.pool_id_, chi::PoolQuery::Local(),
+        WrapBlock(block), write_buffer.shm_.template Cast<void>(), kIoSize);
+    write_task_ptr->SetFlags(TASK_FORCE_NET);
+    auto write_task = ipc->Send(write_task_ptr);
+    write_task.Wait();
+    REQUIRE(write_task->return_code_ == 0);
+    CHI_IPC->FreeBuffer(write_buffer);
+  }
+
+  HLOG(kInfo, "Warm-up reads...");
+
+  // Warm-up: let allocator reach steady state
+  for (int i = 0; i < 20; ++i) {
+    auto read_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+    REQUIRE_FALSE(read_buffer.IsNull());
+    auto read_task = SendForceNetRead(
+        client, block, read_buffer.shm_.template Cast<void>(), kIoSize);
+    read_task.Wait();
+    CHI_IPC->FreeBuffer(read_buffer);
+  }
+  malloc_trim(0);
+
+  HLOG(kInfo, "Starting heap measurement...");
+
+  SECTION("Heap growth per read is below threshold") {
+    long before = heap_in_use();
+    INFO("Heap in-use before batch: " << before << " bytes");
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto read_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+      REQUIRE_FALSE(read_buffer.IsNull());
+      auto read_task = SendForceNetRead(
+          client, block, read_buffer.shm_.template Cast<void>(), kIoSize);
+      read_task.Wait();
+      REQUIRE(read_task->return_code_ == 0);
+      CHI_IPC->FreeBuffer(read_buffer);
+    }
+
+    malloc_trim(0);
+    long after = heap_in_use();
+    INFO("Heap in-use after batch:  " << after << " bytes");
+
+    long growth = after - before;
+    long per_read = growth / kBatchSize;
+    INFO("Total heap growth: " << growth << " bytes  (" << per_read
+                               << " bytes/read)");
+    REQUIRE(per_read < kMaxBytesPerRead);
+  }
+
+  SECTION("Heap stable across two read batches (no monotonic leak)") {
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto read_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+      auto read_task = SendForceNetRead(
+          client, block, read_buffer.shm_.template Cast<void>(), kIoSize);
+      read_task.Wait();
+      CHI_IPC->FreeBuffer(read_buffer);
+    }
+    malloc_trim(0);
+    long after_a = heap_in_use();
+    INFO("Heap after batch A: " << after_a << " bytes");
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto read_buffer = CHI_IPC->AllocateBuffer(kIoSize);
+      auto read_task = SendForceNetRead(
+          client, block, read_buffer.shm_.template Cast<void>(), kIoSize);
+      read_task.Wait();
+      CHI_IPC->FreeBuffer(read_buffer);
+    }
+    malloc_trim(0);
+    long after_b = heap_in_use();
+    INFO("Heap after batch B: " << after_b << " bytes");
+
+    long delta = after_b - after_a;
+    long per_read = delta / kBatchSize;
+    INFO("Heap delta A->B: " << delta << " bytes  (" << per_read
+                             << " bytes/read)");
+    REQUIRE(per_read < kMaxBytesPerRead);
+  }
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-runtime/test/unit/test_bulk_expose_cleanup.cc
+++ b/context-runtime/test/unit/test_bulk_expose_cleanup.cc
@@ -155,7 +155,7 @@ TEST_CASE("BULK_EXPOSE buffer freed after ReadTask (TASK_FORCE_NET)",
   {
     auto write_buffer = CHI_IPC->AllocateBuffer(kIoSize);
     REQUIRE_FALSE(write_buffer.IsNull());
-    memset(write_buffer.ptr_, 0xAB, kIoSize);
+    memset(write_buffer.get(), 0xAB, kIoSize);
     auto *ipc = CHI_IPC;
     auto write_task_ptr = ipc->NewTask<chimaera::bdev::WriteTask>(
         chi::CreateTaskId(), client.pool_id_, chi::PoolQuery::Local(),

--- a/context-runtime/test/unit/test_future_task_cleanup.cc
+++ b/context-runtime/test/unit/test_future_task_cleanup.cc
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Regression test: Future::~Future() must free the heap-allocated task object.
+ *
+ * Before the fix, ~Future() freed FutureShm but never called DelTask(), leaking
+ * the heap-allocated task object on every AsyncXxx().Wait() call.
+ *
+ * Strategy
+ * --------
+ * Measure glibc heap bytes in-use (mallinfo.uordblks) before and after running
+ * many AsyncCustom().Wait() calls.  Each call submits a task, waits for it,
+ * and lets the Future go out of scope.  If ~Future() does not call DelTask(),
+ * every task object is retained on the heap and uordblks grows linearly.
+ * With the fix, the tasks are freed and uordblks stays bounded.
+ *
+ * We validate both directions:
+ *   1. Total heap growth across N tasks stays below a tight per-task ceiling.
+ *   2. Heap usage after two equal-sized batches is the same (no monotonic
+ *      growth), measured after malloc_trim(0) forces freed pages back.
+ *
+ * Reproducer described in:
+ *   CTE_MEMORY_LEAK_REPORT.md – "Memory Leak in Future::~Future()"
+ */
+
+#include "../simple_test.h"
+#include "chimaera/chimaera.h"
+#include "chimaera/ipc_manager.h"
+#include "chimaera/MOD_NAME/MOD_NAME_client.h"
+#include "chimaera/MOD_NAME/MOD_NAME_tasks.h"
+
+#include <malloc.h>   // mallinfo / malloc_trim
+#include <cstring>
+#include <thread>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+// Distinct pool ID — must not collide with other test files.
+constexpr chi::PoolId kCleanupTestPoolId = chi::PoolId(777, 0);
+
+// Number of tasks per batch.
+static constexpr int kBatchSize = 500;
+
+// Maximum tolerated heap growth per completed task (bytes).
+// The pre-fix leak was the size of a full Task object + internal allocations
+// (thousands of bytes).  We allow 256 bytes to accommodate transient allocator
+// bookkeeping that isn't strictly per-task.
+static constexpr long kMaxBytesPerTask = 256;
+
+static bool g_initialized = false;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns mallinfo.uordblks — heap bytes currently in active use. */
+static long heap_in_use() {
+  struct mallinfo mi = mallinfo();
+  return (long)(unsigned int)mi.uordblks;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class FutureCleanupFixture {
+public:
+  FutureCleanupFixture() {
+    if (!g_initialized) {
+      bool ok = chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
+      if (ok) {
+        g_initialized = true;
+        SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+        std::this_thread::sleep_for(500ms);
+      }
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Future destructor frees task — heap does not grow across batches",
+          "[future][memory][regression]") {
+  FutureCleanupFixture fixture;
+  REQUIRE(g_initialized);
+
+  chimaera::MOD_NAME::Client client(kCleanupTestPoolId);
+  chi::PoolQuery pool_query = chi::PoolQuery::Dynamic();
+
+  auto create_task =
+      client.AsyncCreate(pool_query, "future_cleanup_test", kCleanupTestPoolId);
+  create_task.Wait();
+  client.pool_id_ = create_task->new_pool_id_;
+  REQUIRE(create_task->return_code_ == 0);
+
+  // Warm-up: let allocator reach steady state so transient bookkeeping doesn't
+  // pollute the measurement.
+  for (int i = 0; i < 50; ++i) {
+    auto t = client.AsyncCustom(pool_query, "warmup", 0);
+    t.Wait();
+  }
+  malloc_trim(0);  // return freed pages so measurement is clean
+
+  SECTION("Heap-in-use growth per task is below threshold") {
+    long before = heap_in_use();
+    INFO("Heap in-use before batch: " << before << " bytes");
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      // Future goes out of scope here — ~Future() must call DelTask().
+      auto task = client.AsyncCustom(pool_query, "data", i);
+      task.Wait();
+      REQUIRE(task->return_code_ == 0);
+    }
+
+    malloc_trim(0);
+    long after = heap_in_use();
+    INFO("Heap in-use after batch:  " << after << " bytes");
+
+    long growth = after - before;
+    long per_task = growth / kBatchSize;
+    INFO("Total heap growth: " << growth << " bytes  (" << per_task
+                               << " bytes/task)");
+    REQUIRE(per_task < kMaxBytesPerTask);
+  }
+
+  SECTION("Heap-in-use is stable across two equal batches (no monotonic leak)") {
+    // Run batch A, snapshot, run batch B, snapshot.  If tasks are leaked, the
+    // heap grows by (BatchSize * sizeof(task)) between snapshots.  If freed,
+    // the heap returns to roughly the same level.
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto task = client.AsyncCustom(pool_query, "batchA", i);
+      task.Wait();
+    }
+    malloc_trim(0);
+    long after_a = heap_in_use();
+    INFO("Heap after batch A: " << after_a << " bytes");
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      auto task = client.AsyncCustom(pool_query, "batchB", i);
+      task.Wait();
+    }
+    malloc_trim(0);
+    long after_b = heap_in_use();
+    INFO("Heap after batch B: " << after_b << " bytes");
+
+    // The delta between the two snapshots should not be proportional to batch
+    // size; allow only a small absolute slack for bookkeeping drift.
+    long delta = after_b - after_a;
+    long per_task = delta / kBatchSize;
+    INFO("Heap delta A→B: " << delta << " bytes  (" << per_task
+                            << " bytes/task)");
+    REQUIRE(per_task < kMaxBytesPerTask);
+  }
+}
+
+TEST_CASE(
+    "Future destructor: no crash on destruction of consumed Future",
+    "[future][memory][regression]") {
+  FutureCleanupFixture fixture;
+  REQUIRE(g_initialized);
+
+  chimaera::MOD_NAME::Client client(kCleanupTestPoolId);
+  chi::PoolQuery pool_query = chi::PoolQuery::Dynamic();
+
+  auto create_task =
+      client.AsyncCreate(pool_query, "future_null_test", kCleanupTestPoolId);
+  create_task.Wait();
+  client.pool_id_ = create_task->new_pool_id_;
+  REQUIRE(create_task->return_code_ == 0);
+
+  SECTION("Destroying many consumed Futures does not crash (no double-free)") {
+    // If ~Future() called DelTask() without the null-check guard, a double-free
+    // would crash here (ASAN would report heap-use-after-free).
+    REQUIRE_NOTHROW({
+      for (int i = 0; i < 200; ++i) {
+        auto task = client.AsyncCustom(pool_query, "nofree", i);
+        task.Wait();
+      }
+    });
+  }
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-runtime/test/unit/test_ipc_allocate_buffer.cc
+++ b/context-runtime/test/unit/test_ipc_allocate_buffer.cc
@@ -67,13 +67,13 @@ TEST_CASE("CHI_IPC AllocateBuffer basic functionality",
         ipc_manager->AllocateBuffer(buffer_size);
 
     REQUIRE_FALSE(buffer_ptr.IsNull());
-    REQUIRE(buffer_ptr.ptr_ != nullptr);
+    REQUIRE(buffer_ptr.get() != nullptr);
 
     // Test basic memory access
-    memset(buffer_ptr.ptr_, 0xAA, buffer_size);
+    memset(buffer_ptr.get(), 0xAA, buffer_size);
 
     // Verify data was written
-    unsigned char* byte_ptr = reinterpret_cast<unsigned char*>(buffer_ptr.ptr_);
+    unsigned char* byte_ptr = reinterpret_cast<unsigned char*>(buffer_ptr.get());
     for (size_t i = 0; i < buffer_size; ++i) {
       REQUIRE(byte_ptr[i] == 0xAA);
     }
@@ -85,17 +85,17 @@ TEST_CASE("CHI_IPC AllocateBuffer basic functionality",
         ipc_manager->AllocateBuffer(buffer_size);
 
     REQUIRE_FALSE(char_buffer.IsNull());
-    REQUIRE(char_buffer.ptr_ != nullptr);
+    REQUIRE(char_buffer.get() != nullptr);
 
     // Test typed buffer access
     const char* test_string = "CHI_IPC AllocateBuffer test";
     size_t test_len = strlen(test_string);
     REQUIRE(test_len < buffer_size);
 
-    strncpy(char_buffer.ptr_, test_string, buffer_size - 1);
-    char_buffer.ptr_[buffer_size - 1] = '\0';
+    strncpy(char_buffer.get(), test_string, buffer_size - 1);
+    char_buffer[buffer_size - 1] = '\0';
 
-    REQUIRE(strcmp(char_buffer.ptr_, test_string) == 0);
+    REQUIRE(strcmp(char_buffer.get(), test_string) == 0);
   }
 
   SECTION("Allocate integer buffer") {
@@ -103,10 +103,10 @@ TEST_CASE("CHI_IPC AllocateBuffer basic functionality",
     hipc::FullPtr<char> buffer = ipc_manager->AllocateBuffer(num_ints);
 
     REQUIRE_FALSE(buffer.IsNull());
-    REQUIRE(buffer.ptr_ != nullptr);
+    REQUIRE(buffer.get() != nullptr);
 
     // Cast to int pointer for testing
-    int* int_buffer = reinterpret_cast<int*>(buffer.ptr_);
+    int* int_buffer = reinterpret_cast<int*>(buffer.get());
 
     // Test integer array operations
     for (size_t i = 0; i < 100; ++i) {
@@ -163,14 +163,14 @@ TEST_CASE("CHI_IPC AllocateBuffer size variations",
           ipc_manager->AllocateBuffer(size);
 
       REQUIRE_FALSE(buffer.IsNull());
-      REQUIRE(buffer.ptr_ != nullptr);
+      REQUIRE(buffer.get() != nullptr);
 
       // Test memory access at boundaries
-      buffer.ptr_[0] = 0x01;         // First byte
-      buffer.ptr_[size - 1] = static_cast<char>(0xFF);  // Last byte
+      buffer[0] = 0x01;         // First byte
+      buffer[size - 1] = static_cast<char>(0xFF);  // Last byte
 
-      REQUIRE(buffer.ptr_[0] == 0x01);
-      REQUIRE(static_cast<unsigned char>(buffer.ptr_[size - 1]) == 0xFF);
+      REQUIRE(buffer[0] == 0x01);
+      REQUIRE(static_cast<unsigned char>(buffer[size - 1]) == 0xFF);
     }
   }
 
@@ -208,20 +208,20 @@ TEST_CASE("CHI_IPC AllocateBuffer multiple allocations",
     // Write unique data to each buffer
     for (size_t i = 0; i < num_buffers; ++i) {
       std::string test_data = "Buffer " + std::to_string(i);
-      strncpy(buffers[i].ptr_, test_data.c_str(), buffer_size - 1);
-      buffers[i].ptr_[buffer_size - 1] = '\0';
+      strncpy(buffers[i].get(), test_data.c_str(), buffer_size - 1);
+      buffers[i][buffer_size - 1] = '\0';
     }
 
     // Verify data integrity
     for (size_t i = 0; i < num_buffers; ++i) {
       std::string expected = "Buffer " + std::to_string(i);
-      REQUIRE(strcmp(buffers[i].ptr_, expected.c_str()) == 0);
+      REQUIRE(strcmp(buffers[i].get(), expected.c_str()) == 0);
     }
 
     // Verify all buffers have different addresses
     for (size_t i = 0; i < num_buffers; ++i) {
       for (size_t j = i + 1; j < num_buffers; ++j) {
-        REQUIRE(buffers[i].ptr_ != buffers[j].ptr_);
+        REQUIRE(buffers[i].get() != buffers[j].get());
       }
     }
   }
@@ -245,14 +245,14 @@ TEST_CASE("CHI_IPC AllocateBuffer client vs runtime behavior",
 
     hipc::FullPtr<char> buffer = ipc_manager->AllocateBuffer(100);
     REQUIRE_FALSE(buffer.IsNull());
-    REQUIRE(buffer.ptr_ != nullptr);
+    REQUIRE(buffer.get() != nullptr);
 
     // Test basic functionality
-    buffer.ptr_[0] = 42;
-    buffer.ptr_[99] = 84;
+    buffer[0] = 42;
+    buffer[99] = 84;
 
-    REQUIRE(buffer.ptr_[0] == 42);
-    REQUIRE(buffer.ptr_[99] == 84);
+    REQUIRE(buffer[0] == 42);
+    REQUIRE(buffer[99] == 84);
   }
 }
 
@@ -274,9 +274,9 @@ TEST_CASE("CHI_IPC AllocateBuffer memory alignment",
     REQUIRE_FALSE(double_buffer.IsNull());
 
     // Check pointer alignment (implementation dependent)
-    uintptr_t char_addr = reinterpret_cast<uintptr_t>(char_buffer.ptr_);
-    uintptr_t int_addr = reinterpret_cast<uintptr_t>(int_buffer.ptr_);
-    uintptr_t double_addr = reinterpret_cast<uintptr_t>(double_buffer.ptr_);
+    uintptr_t char_addr = reinterpret_cast<uintptr_t>(char_buffer.get());
+    uintptr_t int_addr = reinterpret_cast<uintptr_t>(int_buffer.get());
+    uintptr_t double_addr = reinterpret_cast<uintptr_t>(double_buffer.get());
 
     // int should be aligned to at least 4 bytes
     REQUIRE((int_addr % alignof(int)) == 0);
@@ -308,14 +308,14 @@ TEST_CASE("CHI_IPC AllocateBuffer documentation examples",
         ipc_manager->AllocateBuffer(buffer_size);
 
     REQUIRE_FALSE(buffer_ptr.IsNull());
-    REQUIRE(buffer_ptr.ptr_ != nullptr);
+    REQUIRE(buffer_ptr.get() != nullptr);
 
     // Use the buffer (example: copy data into it)
     const char* source_data = "Documentation example data";
     size_t data_size = strlen(source_data) + 1;
     REQUIRE(data_size <= buffer_size);
 
-    void* buffer_data = buffer_ptr.ptr_;
+    void* buffer_data = buffer_ptr.get();
     memcpy(buffer_data, source_data, data_size);
 
     // Verify the copy
@@ -326,10 +326,10 @@ TEST_CASE("CHI_IPC AllocateBuffer documentation examples",
         ipc_manager->AllocateBuffer(buffer_size);
     REQUIRE_FALSE(char_buffer.IsNull());
 
-    strncpy(char_buffer.ptr_, "example data", buffer_size - 1);
-    char_buffer.ptr_[buffer_size - 1] = '\0';
+    strncpy(char_buffer.get(), "example data", buffer_size - 1);
+    char_buffer[buffer_size - 1] = '\0';
 
-    REQUIRE(strcmp(char_buffer.ptr_, "example data") == 0);
+    REQUIRE(strcmp(char_buffer.get(), "example data") == 0);
 
     // The buffer will be automatically freed when buffer_ptr goes out of scope
     // or when explicitly deallocated by the framework

--- a/context-runtime/test/unit/test_ipc_allocate_buffer_gpu.cc
+++ b/context-runtime/test/unit/test_ipc_allocate_buffer_gpu.cc
@@ -190,13 +190,13 @@ __global__ void test_gpu_allocate_buffer_kernel(
     // Write pattern to buffer
     char pattern = (char)(thread_id + 1);
     for (size_t i = 0; i < alloc_size; ++i) {
-      buffer.ptr_[i] = pattern;
+      buffer[i] = pattern;
     }
 
     // Verify pattern
     bool pattern_ok = true;
     for (size_t i = 0; i < alloc_size; ++i) {
-      if (buffer.ptr_[i] != pattern) {
+      if (buffer[i] != pattern) {
         pattern_ok = false;
         break;
       }
@@ -204,7 +204,7 @@ __global__ void test_gpu_allocate_buffer_kernel(
 
     results[thread_id] = pattern_ok ? 0 : 2;  // 2=verification failed
     allocated_sizes[thread_id] = alloc_size;
-    allocated_ptrs[thread_id] = buffer.ptr_;
+    allocated_ptrs[thread_id] = buffer.get();
   }
 
   __syncthreads();
@@ -232,7 +232,7 @@ __global__ void test_gpu_to_full_ptr_kernel(
   // Write test data
   char test_value = (char)(thread_id + 42);
   for (size_t i = 0; i < alloc_size; ++i) {
-    buffer.ptr_[i] = test_value;
+    buffer[i] = test_value;
   }
 
   // Get a ShmPtr and convert back to FullPtr
@@ -249,7 +249,7 @@ __global__ void test_gpu_to_full_ptr_kernel(
   // Verify the recovered pointer works
   bool data_ok = true;
   for (size_t i = 0; i < alloc_size; ++i) {
-    if (recovered.ptr_[i] != test_value) {
+    if (recovered[i] != test_value) {
       data_ok = false;
       break;
     }
@@ -284,7 +284,7 @@ __global__ void test_gpu_multiple_allocs_kernel(
       return;
     }
 
-    local_ptrs[i] = buffer.ptr_;
+    local_ptrs[i] = buffer.get();
 
     // Initialize with unique pattern
     char pattern = (char)(thread_id * num_allocs + i);
@@ -506,10 +506,10 @@ __global__ void test_gpu_ipc_manager_gpu_alloc_kernel(
   // Write and verify
   char pattern = (char)(thread_id + 1);
   for (int i = 0; i < 64; ++i) {
-    buffer.ptr_[i] = pattern;
+    buffer[i] = pattern;
   }
   for (int i = 0; i < 64; ++i) {
-    if (buffer.ptr_[i] != pattern) {
+    if (buffer[i] != pattern) {
       results[thread_id] = 2;
       __syncthreads();
       return;
@@ -608,7 +608,7 @@ __global__ void test_gpu_send_recv_roundtrip_kernel(
     }
 
     // Receive output via RecvGpu (reads ring buffer, then waits for FUTURE_COMPLETE)
-    CHI_IPC->RecvGpu(future, task.ptr_);
+    CHI_IPC->RecvGpu(future, task.get());
 
     // Check deserialized output (CPU should have set result_value_ = test_value * 2)
     if (task->result_value_ == test_value * 2) {
@@ -882,7 +882,7 @@ TEST_CASE("GPU IPC IpcManagerGpu per-thread allocators",
         queue_allocator, 1, 1, 256);
     REQUIRE(!gpu_queue.IsNull());
 
-    chi::IpcManagerGpu gpu_info(gpu_backend, gpu_queue.ptr_);
+    chi::IpcManagerGpu gpu_info(gpu_backend, gpu_queue.get());
 
     int *d_result = hshm::GpuApi::Malloc<int>(sizeof(int));
     int h_result_init = -999;
@@ -894,7 +894,7 @@ TEST_CASE("GPU IPC IpcManagerGpu per-thread allocators",
     test_gpu_send_serialization_kernel<<<1, 1>>>(gpu_info, d_result);
 
     // CPU polls queue until a Future is available
-    auto &lane = gpu_queue.ptr_->GetLane(0, 0);
+    auto &lane = gpu_queue->GetLane(0, 0);
     chi::Future<chi::Task> popped_future;
     while (!lane.Pop(popped_future)) {
       // Spin until GPU pushes the future
@@ -961,7 +961,7 @@ TEST_CASE("GPU IPC IpcManagerGpu per-thread allocators",
         queue_allocator, 1, 1, 256);
     REQUIRE(!gpu_queue.IsNull());
 
-    chi::IpcManagerGpu gpu_info(gpu_backend, gpu_queue.ptr_);
+    chi::IpcManagerGpu gpu_info(gpu_backend, gpu_queue.get());
 
     int *d_result = hshm::GpuApi::Malloc<int>(sizeof(int));
     int h_result_init = -999;
@@ -973,7 +973,7 @@ TEST_CASE("GPU IPC IpcManagerGpu per-thread allocators",
     test_gpu_send_recv_roundtrip_kernel<<<1, 1>>>(gpu_info, d_result);
 
     // CPU polls queue
-    auto &lane = gpu_queue.ptr_->GetLane(0, 0);
+    auto &lane = gpu_queue->GetLane(0, 0);
     chi::Future<chi::Task> popped_future;
     while (!lane.Pop(popped_future)) {}
 

--- a/context-runtime/test/unit/test_ipc_transport_modes.cc
+++ b/context-runtime/test/unit/test_ipc_transport_modes.cc
@@ -102,7 +102,7 @@ void SubmitTasksForMode(const std::string &mode_name) {
   // Write 1MB
   auto write_buffer = CHI_IPC->AllocateBuffer(write_data.size());
   REQUIRE_FALSE(write_buffer.IsNull());
-  memcpy(write_buffer.ptr_, write_data.data(), write_data.size());
+  memcpy(write_buffer.get(), write_data.data(), write_data.size());
   auto write_task = client.AsyncWrite(
       chi::PoolQuery::Local(), WrapBlock(block),
       write_buffer.shm_.template Cast<void>().template Cast<void>(),
@@ -129,7 +129,7 @@ void SubmitTasksForMode(const std::string &mode_name) {
   REQUIRE_FALSE(data_ptr.IsNull());
   size_t actual_read = read_task->bytes_read_;
   std::vector<hshm::u8> read_data(actual_read);
-  memcpy(read_data.data(), data_ptr.ptr_, actual_read);
+  memcpy(read_data.data(), data_ptr.get(), actual_read);
   size_t verify_size = std::min(actual_written, actual_read);
 
   for (size_t i = 0; i < verify_size; ++i) {

--- a/context-runtime/test/unit/test_local_task_archive.cc
+++ b/context-runtime/test/unit/test_local_task_archive.cc
@@ -119,7 +119,7 @@ TEST_CASE("LocalTaskArchive: Serialize FullPtr with bulk()", "[local_task_archiv
   hipc::FullPtr<char> full_ptr;
   full_ptr.shm_.off_ = 54321;
   full_ptr.shm_.alloc_id_ = hipc::AllocatorId(3, 4);
-  full_ptr.ptr_ = reinterpret_cast<char *>(0xDEADBEEF);
+  full_ptr.set_ptr(reinterpret_cast<char *>(0xDEADBEEF));
 
   size_t data_size = 2048;
   uint32_t flags = 1;

--- a/context-runtime/test/unit/test_mpi_bdev_transport.cc
+++ b/context-runtime/test/unit/test_mpi_bdev_transport.cc
@@ -150,7 +150,7 @@ bool RunBdevIoTest(int rank, const std::string& mode_name, size_t io_size) {
     HLOG(kError, "[Rank {}] AllocateBuffer for write failed", rank);
     return false;
   }
-  memcpy(write_buffer.ptr_, write_data.data(), write_data.size());
+  memcpy(write_buffer.get(), write_data.data(), write_data.size());
   auto write_task = client.AsyncWrite(
       chi::PoolQuery::Local(), WrapBlock(block),
       write_buffer.shm_.template Cast<void>().template Cast<void>(),
@@ -196,11 +196,11 @@ bool RunBdevIoTest(int rank, const std::string& mode_name, size_t io_size) {
 
   int mismatches = 0;
   for (size_t i = 0; i < verify_size; ++i) {
-    if (static_cast<hshm::u8>(data_ptr.ptr_[i]) != write_data[i]) {
+    if (static_cast<hshm::u8>(data_ptr[i]) != write_data[i]) {
       mismatches++;
       if (mismatches <= 3) {
         HLOG(kError, "[Rank {}] Mismatch at byte {}: got {} expected {}", rank, i,
-             (int)(hshm::u8)data_ptr.ptr_[i], (int)write_data[i]);
+             (int)(hshm::u8)data_ptr[i], (int)write_data[i]);
       }
     }
   }

--- a/context-runtime/test/unit/test_per_process_shm.cc
+++ b/context-runtime/test/unit/test_per_process_shm.cc
@@ -187,14 +187,14 @@ TEST_CASE("Per-process shared memory AllocateBuffer medium sizes",
     hipc::FullPtr<char> buffer = ipc_manager->AllocateBuffer(k100MB);
 
     REQUIRE_FALSE(buffer.IsNull());
-    REQUIRE(buffer.ptr_ != nullptr);
+    REQUIRE(buffer.get() != nullptr);
 
     // Test memory access at boundaries
-    buffer.ptr_[0] = 0x01;
-    buffer.ptr_[k100MB - 1] = static_cast<char>(0xFF);
+    buffer[0] = 0x01;
+    buffer[k100MB - 1] = static_cast<char>(0xFF);
 
-    REQUIRE(buffer.ptr_[0] == 0x01);
-    REQUIRE(static_cast<unsigned char>(buffer.ptr_[k100MB - 1]) == 0xFF);
+    REQUIRE(buffer[0] == 0x01);
+    REQUIRE(static_cast<unsigned char>(buffer[k100MB - 1]) == 0xFF);
 
     INFO("Successfully allocated 100MB buffer");
   }
@@ -203,14 +203,14 @@ TEST_CASE("Per-process shared memory AllocateBuffer medium sizes",
     hipc::FullPtr<char> buffer = ipc_manager->AllocateBuffer(k500MB);
 
     REQUIRE_FALSE(buffer.IsNull());
-    REQUIRE(buffer.ptr_ != nullptr);
+    REQUIRE(buffer.get() != nullptr);
 
     // Test memory access at boundaries
-    buffer.ptr_[0] = static_cast<char>(0xAA);
-    buffer.ptr_[k500MB - 1] = static_cast<char>(0xBB);
+    buffer[0] = static_cast<char>(0xAA);
+    buffer[k500MB - 1] = static_cast<char>(0xBB);
 
-    REQUIRE(static_cast<unsigned char>(buffer.ptr_[0]) == 0xAA);
-    REQUIRE(static_cast<unsigned char>(buffer.ptr_[k500MB - 1]) == 0xBB);
+    REQUIRE(static_cast<unsigned char>(buffer[0]) == 0xAA);
+    REQUIRE(static_cast<unsigned char>(buffer[k500MB - 1]) == 0xBB);
 
     INFO("Successfully allocated 500MB buffer");
   }
@@ -240,16 +240,16 @@ TEST_CASE("Per-process shared memory AllocateBuffer exceeding 1GB",
     INFO("Allocation took " << duration.count() << " ms");
 
     REQUIRE_FALSE(buffer.IsNull());
-    REQUIRE(buffer.ptr_ != nullptr);
+    REQUIRE(buffer.get() != nullptr);
 
     // Test memory access at multiple points in the buffer
-    buffer.ptr_[0] = 'A';
-    buffer.ptr_[k1GB] = 'B';  // Past the 1GB mark
-    buffer.ptr_[k1_5GB - 1] = 'Z';
+    buffer[0] = 'A';
+    buffer[k1GB] = 'B';  // Past the 1GB mark
+    buffer[k1_5GB - 1] = 'Z';
 
-    REQUIRE(buffer.ptr_[0] == 'A');
-    REQUIRE(buffer.ptr_[k1GB] == 'B');
-    REQUIRE(buffer.ptr_[k1_5GB - 1] == 'Z');
+    REQUIRE(buffer[0] == 'A');
+    REQUIRE(buffer[k1GB] == 'B');
+    REQUIRE(buffer[k1_5GB - 1] == 'Z');
 
     INFO("Successfully allocated and accessed 1.5GB buffer");
   }
@@ -280,20 +280,20 @@ TEST_CASE("Per-process shared memory multiple large allocations",
 
     // Verify all buffers are usable and have different addresses
     for (size_t i = 0; i < buffers.size(); ++i) {
-      buffers[i].ptr_[0] = static_cast<char>(i);
-      buffers[i].ptr_[600ULL * k1MB - 1] = static_cast<char>(i + 100);
+      buffers[i][0] = static_cast<char>(i);
+      buffers[i][600ULL * k1MB - 1] = static_cast<char>(i + 100);
     }
 
     // Verify data integrity
     for (size_t i = 0; i < buffers.size(); ++i) {
-      REQUIRE(buffers[i].ptr_[0] == static_cast<char>(i));
-      REQUIRE(buffers[i].ptr_[600ULL * k1MB - 1] == static_cast<char>(i + 100));
+      REQUIRE(buffers[i][0] == static_cast<char>(i));
+      REQUIRE(buffers[i][600ULL * k1MB - 1] == static_cast<char>(i + 100));
     }
 
     // Verify all buffers have different addresses
     for (size_t i = 0; i < buffers.size(); ++i) {
       for (size_t j = i + 1; j < buffers.size(); ++j) {
-        REQUIRE(buffers[i].ptr_ != buffers[j].ptr_);
+        REQUIRE(buffers[i].get() != buffers[j].get());
       }
     }
 
@@ -338,20 +338,20 @@ TEST_CASE("Per-process shared memory allocation patterns",
 
     // Verify all small buffers
     for (size_t i = 0; i < small_buffers.size(); ++i) {
-      small_buffers[i].ptr_[0] = static_cast<char>(i);
-      REQUIRE(small_buffers[i].ptr_[0] == static_cast<char>(i));
+      small_buffers[i][0] = static_cast<char>(i);
+      REQUIRE(small_buffers[i][0] == static_cast<char>(i));
     }
 
     // Verify large buffers
-    large_buffers[0].ptr_[0] = 'X';
-    large_buffers[0].ptr_[k500MB - 1] = 'Y';
-    large_buffers[1].ptr_[0] = 'A';
-    large_buffers[1].ptr_[k500MB - 1] = 'B';
+    large_buffers[0][0] = 'X';
+    large_buffers[0][k500MB - 1] = 'Y';
+    large_buffers[1][0] = 'A';
+    large_buffers[1][k500MB - 1] = 'B';
 
-    REQUIRE(large_buffers[0].ptr_[0] == 'X');
-    REQUIRE(large_buffers[0].ptr_[k500MB - 1] == 'Y');
-    REQUIRE(large_buffers[1].ptr_[0] == 'A');
-    REQUIRE(large_buffers[1].ptr_[k500MB - 1] == 'B');
+    REQUIRE(large_buffers[0][0] == 'X');
+    REQUIRE(large_buffers[0][k500MB - 1] == 'Y');
+    REQUIRE(large_buffers[1][0] == 'A');
+    REQUIRE(large_buffers[1][k500MB - 1] == 'B');
 
     INFO("Mixed allocation pattern test passed");
   }
@@ -370,8 +370,8 @@ TEST_CASE("Per-process shared memory FreeBuffer",
     REQUIRE_FALSE(buffer.IsNull());
 
     // Write some data
-    buffer.ptr_[0] = 'T';
-    buffer.ptr_[k100MB - 1] = 'E';
+    buffer[0] = 'T';
+    buffer[k100MB - 1] = 'E';
 
     // Free the buffer
     ipc_manager->FreeBuffer(buffer);
@@ -394,8 +394,8 @@ TEST_CASE("Per-process shared memory FreeBuffer",
     REQUIRE_FALSE(buffer2.IsNull());
 
     // Verify new buffer is usable
-    buffer2.ptr_[0] = 'R';
-    REQUIRE(buffer2.ptr_[0] == 'R');
+    buffer2[0] = 'R';
+    REQUIRE(buffer2[0] == 'R');
 
     INFO("Allocate-free-allocate cycle passed");
   }
@@ -414,22 +414,22 @@ TEST_CASE("Per-process shared memory ToFullPtr conversion",
     REQUIRE_FALSE(original.IsNull());
 
     // Get the raw pointer
-    char* raw_ptr = original.ptr_;
+    char* raw_ptr = original.get();
 
     // Convert back to FullPtr
     hipc::FullPtr<char> converted = ipc_manager->ToFullPtr(raw_ptr);
 
     // Should get the same pointer back
     REQUIRE_FALSE(converted.IsNull());
-    REQUIRE(converted.ptr_ == raw_ptr);
+    REQUIRE(converted.get() == raw_ptr);
 
     // Write via original, read via converted
-    original.ptr_[0] = 'X';
-    REQUIRE(converted.ptr_[0] == 'X');
+    original[0] = 'X';
+    REQUIRE(converted[0] == 'X');
 
     // Write via converted, read via original
-    converted.ptr_[100] = 'Y';
-    REQUIRE(original.ptr_[100] == 'Y');
+    converted[100] = 'Y';
+    REQUIRE(original[100] == 'Y');
 
     INFO("ToFullPtr conversion test passed");
   }
@@ -456,8 +456,8 @@ TEST_CASE("Per-process shared memory stress test",
       REQUIRE_FALSE(buffer.IsNull());
 
       // Touch the buffer to ensure it's really allocated
-      buffer.ptr_[0] = static_cast<char>(i & 0xFF);
-      buffer.ptr_[alloc_size - 1] = static_cast<char>((i + 1) & 0xFF);
+      buffer[0] = static_cast<char>(i & 0xFF);
+      buffer[alloc_size - 1] = static_cast<char>((i + 1) & 0xFF);
 
       buffers.push_back(buffer);
     }
@@ -470,8 +470,8 @@ TEST_CASE("Per-process shared memory stress test",
 
     // Verify all data is intact
     for (size_t i = 0; i < num_allocs; ++i) {
-      REQUIRE(static_cast<unsigned char>(buffers[i].ptr_[0]) == (i & 0xFF));
-      REQUIRE(static_cast<unsigned char>(buffers[i].ptr_[alloc_size - 1]) == ((i + 1) & 0xFF));
+      REQUIRE(static_cast<unsigned char>(buffers[i][0]) == (i & 0xFF));
+      REQUIRE(static_cast<unsigned char>(buffers[i][alloc_size - 1]) == ((i + 1) & 0xFF));
     }
 
     INFO("Stress test with " << num_allocs << " allocations passed");

--- a/context-runtime/util/chimaera_cmd_refresh_repo.cc
+++ b/context-runtime/util/chimaera_cmd_refresh_repo.cc
@@ -374,7 +374,7 @@ class ChiModGenerator {
       std::string task_type = GetTaskTypeName(method.method_name, chimod_name);
       oss << "    case Method::" << method.constant_name << ": {\n";
       oss << "      auto typed_task = task_ptr.template Cast<" << task_type << ">();\n";
-      oss << "      archive << *typed_task.ptr_;\n";
+      oss << "      archive << *typed_task;\n";
       oss << "      break;\n";
       oss << "    }\n";
     }
@@ -395,7 +395,7 @@ class ChiModGenerator {
       std::string task_type = GetTaskTypeName(method.method_name, chimod_name);
       oss << "    case Method::" << method.constant_name << ": {\n";
       oss << "      auto typed_task = task_ptr.template Cast<" << task_type << ">();\n";
-      oss << "      archive >> *typed_task.ptr_;\n";
+      oss << "      archive >> *typed_task;\n";
       oss << "      break;\n";
       oss << "    }\n";
     }
@@ -425,7 +425,7 @@ class ChiModGenerator {
       oss << "    case Method::" << method.constant_name << ": {\n";
       oss << "      auto typed_task = task_ptr.template Cast<" << task_type << ">();\n";
       oss << "      // Use archive operator which respects msg_type\n";
-      oss << "      archive >> *typed_task.ptr_;\n";
+      oss << "      archive >> *typed_task;\n";
       oss << "      break;\n";
       oss << "    }\n";
     }
@@ -455,7 +455,7 @@ class ChiModGenerator {
       oss << "    case Method::" << method.constant_name << ": {\n";
       oss << "      auto typed_task = task_ptr.template Cast<" << task_type << ">();\n";
       oss << "      // Use archive operator which respects msg_type\n";
-      oss << "      archive << *typed_task.ptr_;\n";
+      oss << "      archive << *typed_task;\n";
       oss << "      break;\n";
       oss << "    }\n";
     }

--- a/context-transfer-engine/adapter/adios2/iowarp_engine.cc
+++ b/context-transfer-engine/adapter/adios2/iowarp_engine.cc
@@ -319,7 +319,7 @@ void IowarpEngine::DoPutDeferred_(const adios2::core::Variable<T> &variable,
 
     // Allocate shared memory buffer and copy data
     auto buffer = ipc_manager->AllocateBuffer(data_size);
-    if (buffer.ptr_ == nullptr) {
+    if (buffer.get() == nullptr) {
       throw std::runtime_error(
           "IowarpEngine::DoPutDeferred_: Failed to allocate buffer");
     }
@@ -330,7 +330,7 @@ void IowarpEngine::DoPutDeferred_(const adios2::core::Variable<T> &variable,
           "IowarpEngine::DoPutDeferred_: values pointer is null");
     }
 
-    std::memcpy(buffer.ptr_, values, data_size);
+    std::memcpy(buffer.get(), values, data_size);
 
     auto task = current_tag_->AsyncPutBlob(
         blob_name, buffer.shm_.template Cast<void>(), data_size, 0, 1.0f);

--- a/context-transfer-engine/adapter/filesystem/filesystem.h
+++ b/context-transfer-engine/adapter/filesystem/filesystem.h
@@ -420,7 +420,7 @@ public:
         // For now, just use the requested size
         get_size += task.orig_size_;
         // TODO: CTE may handle data copying differently
-        // memcpy(task.orig_data_, data.ptr_, task.orig_size_);
+        // memcpy(task.orig_data_, data.get(), task.orig_size_);
         CHI_IPC->DelTask(task.task_);
       }
       fstask->io_status_.size_ = get_size;

--- a/context-transfer-engine/benchmark/wrp_cte_bench.cc
+++ b/context-transfer-engine/benchmark/wrp_cte_bench.cc
@@ -210,7 +210,7 @@ class CTEBenchmark {
 
     // Allocate shared memory buffer
     auto shm_buffer = CHI_IPC->AllocateBuffer(io_size_);
-    std::memset(shm_buffer.ptr_, thread_id & 0xFF, io_size_);
+    std::memset(shm_buffer.get(), thread_id & 0xFF, io_size_);
     hipc::ShmPtr<> shm_ptr = shm_buffer.shm_.template Cast<void>();
 
     // Create one tag per thread
@@ -289,7 +289,7 @@ class CTEBenchmark {
 
     // Populate data using Put operations
     for (int i = 0; i < io_count_; ++i) {
-      std::memset(put_shm.ptr_, (thread_id + i) & 0xFF, io_size_);
+      std::memset(put_shm.get(), (thread_id + i) & 0xFF, io_size_);
       std::string blob_name = "blob_" + std::to_string(i);
       auto task = cte_client->AsyncPutBlob(tag_id, blob_name, 0, io_size_,
                                            put_ptr, 0.8f);
@@ -352,7 +352,7 @@ class CTEBenchmark {
     // Allocate shared memory buffers
     auto put_shm = CHI_IPC->AllocateBuffer(io_size_);
     auto get_shm = CHI_IPC->AllocateBuffer(io_size_);
-    std::memset(put_shm.ptr_, thread_id & 0xFF, io_size_);
+    std::memset(put_shm.get(), thread_id & 0xFF, io_size_);
     hipc::ShmPtr<> put_ptr = put_shm.shm_.template Cast<void>();
     hipc::ShmPtr<> get_ptr = get_shm.shm_.template Cast<void>();
 

--- a/context-transfer-engine/benchmark/wrp_cte_score_bench.cc
+++ b/context-transfer-engine/benchmark/wrp_cte_score_bench.cc
@@ -300,7 +300,7 @@ class CTEScoreBenchmark {
 
     // Allocate shared memory buffer for Put operations
     auto shm_buffer = CHI_IPC->AllocateBuffer(kBlobSize);
-    std::memset(shm_buffer.ptr_, rank_ & 0xFF, kBlobSize);
+    std::memset(shm_buffer.get(), rank_ & 0xFF, kBlobSize);
     hipc::ShmPtr<> shm_ptr = shm_buffer.shm_.template Cast<void>();
 
     auto *cte_client = WRP_CTE_CLIENT;

--- a/context-transfer-engine/compressor/src/autogen/compressor_lib_exec.cc
+++ b/context-transfer-engine/compressor/src/autogen/compressor_lib_exec.cc
@@ -83,32 +83,32 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDynamicSchedule: {
       auto typed_task = task_ptr.template Cast<DynamicScheduleTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kCompress: {
       auto typed_task = task_ptr.template Cast<CompressTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDecompress: {
       auto typed_task = task_ptr.template Cast<DecompressTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {
@@ -123,32 +123,32 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDynamicSchedule: {
       auto typed_task = task_ptr.template Cast<DynamicScheduleTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kCompress: {
       auto typed_task = task_ptr.template Cast<CompressTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDecompress: {
       auto typed_task = task_ptr.template Cast<DecompressTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -172,37 +172,37 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::LocalLoadTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDynamicSchedule: {
       auto typed_task = task_ptr.template Cast<DynamicScheduleTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kCompress: {
       auto typed_task = task_ptr.template Cast<CompressTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDecompress: {
       auto typed_task = task_ptr.template Cast<DecompressTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -226,37 +226,37 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::LocalSaveTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDynamicSchedule: {
       auto typed_task = task_ptr.template Cast<DynamicScheduleTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kCompress: {
       auto typed_task = task_ptr.template Cast<CompressTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDecompress: {
       auto typed_task = task_ptr.template Cast<DecompressTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {

--- a/context-transfer-engine/compressor/src/compressor_runtime.cc
+++ b/context-transfer-engine/compressor/src/compressor_runtime.cc
@@ -522,7 +522,7 @@ chi::TaskResume Runtime::DynamicSchedule(
     // Convert ShmPtr to raw pointer via FullPtr
     auto blob_fullptr =
         CHI_IPC->ToFullPtr<char>(task->blob_data_.template Cast<char>());
-    void* chunk_data = blob_fullptr.ptr_;
+    void* chunk_data = blob_fullptr.get();
     Context& context = task->context_;
 
     // Initialize tracing if enabled
@@ -688,7 +688,7 @@ chi::TaskResume Runtime::Compress(hipc::FullPtr<CompressTask> task,
     // Convert ShmPtr to raw pointer via FullPtr
     auto input_fullptr =
         CHI_IPC->ToFullPtr<char>(task->blob_data_.template Cast<char>());
-    char* input_ptr = input_fullptr.ptr_;
+    char* input_ptr = input_fullptr.get();
     bool success = compressor->Compress(compressed_buffer.data(),
                                         compressed_size, input_ptr, input_size);
 
@@ -725,10 +725,10 @@ chi::TaskResume Runtime::Compress(hipc::FullPtr<CompressTask> task,
       // Write compression header
       CompressionHeader header(context.compress_lib_, context.compress_preset_,
                                input_size);
-      std::memcpy(compressed_shm.ptr_, &header, header_size);
+      std::memcpy(compressed_shm.get(), &header, header_size);
 
       // Write compressed data after header
-      std::memcpy(compressed_shm.ptr_ + header_size, compressed_buffer.data(),
+      std::memcpy(compressed_shm.get() + header_size, compressed_buffer.data(),
                   compressed_size);
 
       // Call PutBlob with header + compressed data
@@ -823,7 +823,7 @@ chi::TaskResume Runtime::Decompress(hipc::FullPtr<DecompressTask> task,
     }
 
     // Check for compression header
-    auto* header = reinterpret_cast<CompressionHeader*>(temp_buffer.ptr_);
+    auto* header = reinterpret_cast<CompressionHeader*>(temp_buffer.get());
     size_t header_size = sizeof(CompressionHeader);
 
     if (header->IsValid()) {
@@ -862,7 +862,7 @@ chi::TaskResume Runtime::Decompress(hipc::FullPtr<DecompressTask> task,
       auto decompress_start = std::chrono::high_resolution_clock::now();
 
       // Get compressed data (after header)
-      char* compressed_data = temp_buffer.ptr_ + header_size;
+      char* compressed_data = temp_buffer.get() + header_size;
       size_t compressed_size = expected_size - header_size;
 
       // Decompress to output buffer
@@ -870,7 +870,7 @@ chi::TaskResume Runtime::Decompress(hipc::FullPtr<DecompressTask> task,
           CHI_IPC->ToFullPtr<char>(task->blob_data_.template Cast<char>());
       size_t decompressed_size = original_size;
       bool success =
-          decompressor->Decompress(output_fullptr.ptr_, decompressed_size,
+          decompressor->Decompress(output_fullptr.get(), decompressed_size,
                                    compressed_data, compressed_size);
 
       auto decompress_end = std::chrono::high_resolution_clock::now();
@@ -906,7 +906,7 @@ chi::TaskResume Runtime::Decompress(hipc::FullPtr<DecompressTask> task,
       // Copy directly to output buffer
       auto output_fullptr =
           CHI_IPC->ToFullPtr<char>(task->blob_data_.template Cast<char>());
-      std::memcpy(output_fullptr.ptr_, temp_buffer.ptr_, expected_size);
+      std::memcpy(output_fullptr.get(), temp_buffer.get(), expected_size);
       CHI_IPC->FreeBuffer(temp_buffer);
 
       task->output_size_ = expected_size;

--- a/context-transfer-engine/compressor/test/synthetic_workload.cc
+++ b/context-transfer-engine/compressor/test/synthetic_workload.cc
@@ -374,7 +374,7 @@ int main(int argc, char** argv) {
       // Copy data to shared memory
       const char* chunk_ptr = reinterpret_cast<const char*>(
           data_buffer.data() + bytes_written / sizeof(float));
-      std::memcpy(shm_buffer.ptr_, chunk_ptr, chunk_size);
+      std::memcpy(shm_buffer.get(), chunk_ptr, chunk_size);
 
       // Convert ShmPtr<char> to ShmPtr<void> for async put
       hipc::ShmPtr<> shm_ptr(shm_buffer.shm_);

--- a/context-transfer-engine/compressor/test/test_compressor_functional.cc
+++ b/context-transfer-engine/compressor/test/test_compressor_functional.cc
@@ -202,7 +202,7 @@ struct CTETestFixture {
   hipc::FullPtr<char> AllocateAndCopyData(const std::vector<char>& data) {
     auto shm_buffer = CHI_IPC->AllocateBuffer(data.size());
     if (!shm_buffer.IsNull()) {
-      std::memcpy(shm_buffer.ptr_, data.data(), data.size());
+      std::memcpy(shm_buffer.get(), data.data(), data.size());
     }
     return shm_buffer;
   }
@@ -213,7 +213,7 @@ struct CTETestFixture {
   std::vector<char> ReadFromSharedMemory(hipc::FullPtr<char>& buffer, size_t size) {
     std::vector<char> data(size);
     if (!buffer.IsNull()) {
-      std::memcpy(data.data(), buffer.ptr_, size);
+      std::memcpy(data.data(), buffer.get(), size);
     }
     return data;
   }

--- a/context-transfer-engine/compressor/test/wrp_cte_compress_bench.cc
+++ b/context-transfer-engine/compressor/test/wrp_cte_compress_bench.cc
@@ -607,7 +607,7 @@ class CTECompressBenchmark {
 
       // Generate data
       generator.FillBuffer(data.data(), transfer_size_);
-      std::memcpy(shm_buffer.ptr_, data.data(), transfer_size_);
+      std::memcpy(shm_buffer.get(), data.data(), transfer_size_);
 
       // Create tag and blob names
       std::string tag_name = "compress_tag_t" + std::to_string(thread_id) +
@@ -801,7 +801,7 @@ class CTECompressBenchmark {
 
       // Generate data
       generator.FillBuffer(data.data(), transfer_size_);
-      std::memcpy(shm_buffer.ptr_, data.data(), transfer_size_);
+      std::memcpy(shm_buffer.get(), data.data(), transfer_size_);
 
       std::string tag_name = "compress_putget_tag_t" + std::to_string(thread_id) +
                              "_i" + std::to_string(i);

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -197,122 +197,122 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRegisterTarget: {
       auto typed_task = task_ptr.template Cast<RegisterTargetTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kUnregisterTarget: {
       auto typed_task = task_ptr.template Cast<UnregisterTargetTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kListTargets: {
       auto typed_task = task_ptr.template Cast<ListTargetsTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kStatTargets: {
       auto typed_task = task_ptr.template Cast<StatTargetsTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetOrCreateTag: {
       auto typed_task = task_ptr.template Cast<core::GetOrCreateTagTask<core::CreateParams>>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kPutBlob: {
       auto typed_task = task_ptr.template Cast<PutBlobTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetBlob: {
       auto typed_task = task_ptr.template Cast<GetBlobTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kReorganizeBlob: {
       auto typed_task = task_ptr.template Cast<ReorganizeBlobTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDelBlob: {
       auto typed_task = task_ptr.template Cast<DelBlobTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDelTag: {
       auto typed_task = task_ptr.template Cast<DelTagTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetTagSize: {
       auto typed_task = task_ptr.template Cast<GetTagSizeTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kPollTelemetryLog: {
       auto typed_task = task_ptr.template Cast<PollTelemetryLogTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetBlobScore: {
       auto typed_task = task_ptr.template Cast<GetBlobScoreTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetBlobSize: {
       auto typed_task = task_ptr.template Cast<GetBlobSizeTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetContainedBlobs: {
       auto typed_task = task_ptr.template Cast<GetContainedBlobsTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetBlobInfo: {
       auto typed_task = task_ptr.template Cast<GetBlobInfoTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kTagQuery: {
       auto typed_task = task_ptr.template Cast<TagQueryTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kBlobQuery: {
       auto typed_task = task_ptr.template Cast<BlobQueryTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetTargetInfo: {
       auto typed_task = task_ptr.template Cast<GetTargetInfoTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kFlushMetadata: {
       auto typed_task = task_ptr.template Cast<FlushMetadataTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kFlushData: {
       auto typed_task = task_ptr.template Cast<FlushDataTask>();
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {
@@ -327,122 +327,122 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
   switch (method) {
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRegisterTarget: {
       auto typed_task = task_ptr.template Cast<RegisterTargetTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kUnregisterTarget: {
       auto typed_task = task_ptr.template Cast<UnregisterTargetTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kListTargets: {
       auto typed_task = task_ptr.template Cast<ListTargetsTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kStatTargets: {
       auto typed_task = task_ptr.template Cast<StatTargetsTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetOrCreateTag: {
       auto typed_task = task_ptr.template Cast<core::GetOrCreateTagTask<core::CreateParams>>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kPutBlob: {
       auto typed_task = task_ptr.template Cast<PutBlobTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetBlob: {
       auto typed_task = task_ptr.template Cast<GetBlobTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kReorganizeBlob: {
       auto typed_task = task_ptr.template Cast<ReorganizeBlobTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDelBlob: {
       auto typed_task = task_ptr.template Cast<DelBlobTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDelTag: {
       auto typed_task = task_ptr.template Cast<DelTagTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetTagSize: {
       auto typed_task = task_ptr.template Cast<GetTagSizeTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kPollTelemetryLog: {
       auto typed_task = task_ptr.template Cast<PollTelemetryLogTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetBlobScore: {
       auto typed_task = task_ptr.template Cast<GetBlobScoreTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetBlobSize: {
       auto typed_task = task_ptr.template Cast<GetBlobSizeTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetContainedBlobs: {
       auto typed_task = task_ptr.template Cast<GetContainedBlobsTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetBlobInfo: {
       auto typed_task = task_ptr.template Cast<GetBlobInfoTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kTagQuery: {
       auto typed_task = task_ptr.template Cast<TagQueryTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kBlobQuery: {
       auto typed_task = task_ptr.template Cast<BlobQueryTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetTargetInfo: {
       auto typed_task = task_ptr.template Cast<GetTargetInfoTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kFlushMetadata: {
       auto typed_task = task_ptr.template Cast<FlushMetadataTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kFlushData: {
       auto typed_task = task_ptr.template Cast<FlushDataTask>();
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -466,145 +466,145 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::LocalLoadTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kRegisterTarget: {
       auto typed_task = task_ptr.template Cast<RegisterTargetTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kUnregisterTarget: {
       auto typed_task = task_ptr.template Cast<UnregisterTargetTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kListTargets: {
       auto typed_task = task_ptr.template Cast<ListTargetsTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kStatTargets: {
       auto typed_task = task_ptr.template Cast<StatTargetsTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetOrCreateTag: {
       auto typed_task = task_ptr.template Cast<core::GetOrCreateTagTask<core::CreateParams>>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kPutBlob: {
       auto typed_task = task_ptr.template Cast<PutBlobTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetBlob: {
       auto typed_task = task_ptr.template Cast<GetBlobTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kReorganizeBlob: {
       auto typed_task = task_ptr.template Cast<ReorganizeBlobTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDelBlob: {
       auto typed_task = task_ptr.template Cast<DelBlobTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kDelTag: {
       auto typed_task = task_ptr.template Cast<DelTagTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetTagSize: {
       auto typed_task = task_ptr.template Cast<GetTagSizeTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kPollTelemetryLog: {
       auto typed_task = task_ptr.template Cast<PollTelemetryLogTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetBlobScore: {
       auto typed_task = task_ptr.template Cast<GetBlobScoreTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetBlobSize: {
       auto typed_task = task_ptr.template Cast<GetBlobSizeTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetContainedBlobs: {
       auto typed_task = task_ptr.template Cast<GetContainedBlobsTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetBlobInfo: {
       auto typed_task = task_ptr.template Cast<GetBlobInfoTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kTagQuery: {
       auto typed_task = task_ptr.template Cast<TagQueryTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kBlobQuery: {
       auto typed_task = task_ptr.template Cast<BlobQueryTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kGetTargetInfo: {
       auto typed_task = task_ptr.template Cast<GetTargetInfoTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kFlushMetadata: {
       auto typed_task = task_ptr.template Cast<FlushMetadataTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     case Method::kFlushData: {
       auto typed_task = task_ptr.template Cast<FlushDataTask>();
       // Use archive operator which respects msg_type
-      archive >> *typed_task.ptr_;
+      archive >> *typed_task;
       break;
     }
     default: {
@@ -628,145 +628,145 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::LocalSaveTaskArchive& archive,
     case Method::kCreate: {
       auto typed_task = task_ptr.template Cast<CreateTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDestroy: {
       auto typed_task = task_ptr.template Cast<DestroyTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kMonitor: {
       auto typed_task = task_ptr.template Cast<MonitorTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kRegisterTarget: {
       auto typed_task = task_ptr.template Cast<RegisterTargetTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kUnregisterTarget: {
       auto typed_task = task_ptr.template Cast<UnregisterTargetTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kListTargets: {
       auto typed_task = task_ptr.template Cast<ListTargetsTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kStatTargets: {
       auto typed_task = task_ptr.template Cast<StatTargetsTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetOrCreateTag: {
       auto typed_task = task_ptr.template Cast<core::GetOrCreateTagTask<core::CreateParams>>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kPutBlob: {
       auto typed_task = task_ptr.template Cast<PutBlobTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetBlob: {
       auto typed_task = task_ptr.template Cast<GetBlobTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kReorganizeBlob: {
       auto typed_task = task_ptr.template Cast<ReorganizeBlobTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDelBlob: {
       auto typed_task = task_ptr.template Cast<DelBlobTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kDelTag: {
       auto typed_task = task_ptr.template Cast<DelTagTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetTagSize: {
       auto typed_task = task_ptr.template Cast<GetTagSizeTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kPollTelemetryLog: {
       auto typed_task = task_ptr.template Cast<PollTelemetryLogTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetBlobScore: {
       auto typed_task = task_ptr.template Cast<GetBlobScoreTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetBlobSize: {
       auto typed_task = task_ptr.template Cast<GetBlobSizeTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetContainedBlobs: {
       auto typed_task = task_ptr.template Cast<GetContainedBlobsTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetBlobInfo: {
       auto typed_task = task_ptr.template Cast<GetBlobInfoTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kTagQuery: {
       auto typed_task = task_ptr.template Cast<TagQueryTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kBlobQuery: {
       auto typed_task = task_ptr.template Cast<BlobQueryTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kGetTargetInfo: {
       auto typed_task = task_ptr.template Cast<GetTargetInfoTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kFlushMetadata: {
       auto typed_task = task_ptr.template Cast<FlushMetadataTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     case Method::kFlushData: {
       auto typed_task = task_ptr.template Cast<FlushDataTask>();
       // Use archive operator which respects msg_type
-      archive << *typed_task.ptr_;
+      archive << *typed_task;
       break;
     }
     default: {

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1257,7 +1257,7 @@ chi::TaskResume Runtime::DelTag(hipc::FullPtr<DelTagTask> task,
       }
 
       // Wait for all async DelBlob operations in this batch to complete
-      for (auto task : async_tasks) {
+      for (auto &task : async_tasks) {
         co_await task;
 
         // Check if DelBlob succeeded

--- a/context-transfer-engine/core/src/tag.cc
+++ b/context-transfer-engine/core/src/tag.cc
@@ -62,7 +62,7 @@ void Tag::PutBlob(const std::string &blob_name, const char *data, size_t data_si
   }
 
   // Copy data to shared memory
-  memcpy(shm_fullptr.ptr_, data, data_size);
+  memcpy(shm_fullptr.get(), data, data_size);
 
   // Convert to hipc::ShmPtr<> for API call
   hipc::ShmPtr<> shm_ptr(shm_fullptr.shm_);
@@ -90,7 +90,7 @@ void Tag::PutBlob(const std::string &blob_name, const hipc::ShmPtr<> &data, size
 // NOTE: AsyncPutBlob(const char*) overload removed due to memory management issues.
 // For async operations, the caller must manage shared memory lifecycle by:
 // 1. Allocating: hipc::FullPtr<char> shm_ptr = CHI_IPC->AllocateBuffer(data_size);
-// 2. Copying data: memcpy(shm_ptr.ptr_, data, data_size);
+// 2. Copying data: memcpy(shm_ptr.get(), data, data_size);
 // 3. Calling: AsyncPutBlob(blob_name, shm_ptr.shm_, data_size, off, score);
 // 4. Keeping shm_ptr alive until task completes
 
@@ -127,7 +127,7 @@ void Tag::GetBlob(const std::string &blob_name, char *data, size_t data_size, si
   GetBlob(blob_name, shm_ptr, data_size, off);
 
   // Copy data from shared memory to output buffer
-  memcpy(data, shm_fullptr.ptr_, data_size);
+  memcpy(data, shm_fullptr.get(), data_size);
 
   // Explicitly free shared memory buffer
   ipc_manager->FreeBuffer(shm_fullptr);

--- a/context-transfer-engine/test/integration/restart/test_restart.cc
+++ b/context-transfer-engine/test/integration/restart/test_restart.cc
@@ -91,7 +91,7 @@ int PutBlobs() {
 
     // Fill with pattern: each blob gets a different base character
     char pattern = static_cast<char>('A' + i);
-    memset(buf.ptr_, pattern, kBlobSize);
+    memset(buf.get(), pattern, kBlobSize);
 
     // Convert to ShmPtr for API
     hipc::ShmPtr<> shm_ptr = buf.shm_.template Cast<void>();
@@ -188,7 +188,7 @@ int VerifyBlobs() {
       ++failed;
       continue;
     }
-    memset(buf.ptr_, 0, kBlobSize);
+    memset(buf.get(), 0, kBlobSize);
     hipc::ShmPtr<> shm_ptr = buf.shm_.template Cast<void>();
 
     auto get_task = cte_client.AsyncGetBlob(
@@ -203,7 +203,7 @@ int VerifyBlobs() {
     // Verify data pattern
     bool data_ok = true;
     for (chi::u64 j = 0; j < kBlobSize; ++j) {
-      if (buf.ptr_[j] != expected_pattern) {
+      if (buf[j] != expected_pattern) {
         data_ok = false;
         break;
       }

--- a/context-transfer-engine/test/unit/external/external_integration_test.cc
+++ b/context-transfer-engine/test/unit/external/external_integration_test.cc
@@ -189,7 +189,7 @@ private:
             }
 
             // Copy data to shared memory
-            memcpy(shared_data.ptr_, test_data.data(), kTestDataSize);
+            memcpy(shared_data.get(), test_data.data(), kTestDataSize);
 
             // Create or get tag
             wrp_cte::core::TagId tag_id = cte_client_->GetOrCreateTag(
@@ -257,7 +257,7 @@ private:
 
             if (get_result) {
                 // Verify data integrity
-                const char* read_data = static_cast<const char*>(read_buffer.ptr_);
+                const char* read_data = static_cast<const char*>(read_buffer.get());
                 bool data_matches = true;
 
                 for (size_t i = 0; i < kTestDataSize; ++i) {

--- a/context-transfer-engine/test/unit/test_core_client_config.cc
+++ b/context-transfer-engine/test/unit/test_core_client_config.cc
@@ -429,7 +429,7 @@ TEST_CASE("Client - AsyncPutBlob Direct", "[core][client][blob]") {
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
   REQUIRE(!shm_ptr.IsNull());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
 
   // Put blob
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
@@ -457,7 +457,7 @@ TEST_CASE("Client - AsyncGetBlob Direct", "[core][client][blob]") {
   auto data = fixture.CreateTestData(fixture.kTestDataSize);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> put_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(put_ptr.ptr_, data.data(), data.size());
+  memcpy(put_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> put_ref(put_ptr.shm_);
 
   auto put_task = client->AsyncPutBlob(tag_task->tag_id_, "get_test_blob", 0,
@@ -495,7 +495,7 @@ TEST_CASE("Client - AsyncDelBlob", "[core][client][blob]") {
   auto data = fixture.CreateTestData(fixture.kTestDataSize);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
   auto put_task = client->AsyncPutBlob(tag_task->tag_id_, "blob_to_delete", 0,
@@ -526,7 +526,7 @@ TEST_CASE("Client - AsyncReorganizeBlob Direct", "[core][client][blob]") {
   auto data = fixture.CreateTestData(fixture.kTestDataSize);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
   auto put_task = client->AsyncPutBlob(tag_task->tag_id_, "reorg_blob", 0,
@@ -559,7 +559,7 @@ TEST_CASE("Client - AsyncGetBlobScore Direct", "[core][client][blob]") {
   auto data = fixture.CreateTestData(fixture.kTestDataSize);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
   float expected_score = 0.35f;
@@ -593,7 +593,7 @@ TEST_CASE("Client - AsyncGetBlobSize Direct", "[core][client][blob]") {
   auto data = fixture.CreateTestData(fixture.kTestDataSize);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
   auto put_task = client->AsyncPutBlob(tag_task->tag_id_, "sized_blob", 0,
@@ -628,7 +628,7 @@ TEST_CASE("Client - AsyncGetContainedBlobs Direct", "[core][client][blob]") {
   for (int i = 0; i < 3; ++i) {
     auto data = fixture.CreateTestData(fixture.kTestDataSize);
     hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-    memcpy(shm_ptr.ptr_, data.data(), data.size());
+    memcpy(shm_ptr.get(), data.data(), data.size());
     hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
     std::string blob_name = "blob_" + std::to_string(i);
@@ -688,7 +688,7 @@ TEST_CASE("Client - AsyncBlobQuery", "[core][client][query]") {
   auto data = fixture.CreateTestData(fixture.kTestDataSize);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
   auto put_task = client->AsyncPutBlob(tag_task->tag_id_, "queryable_blob", 0,

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -245,15 +245,15 @@ class CTECoreFunctionalTestFixture {
       return false;
     }
 
-    // Access data directly through .ptr_ as specified in
+    // Access data directly through .get() as specified in
     // MODULE_DEVELOPMENT_GUIDE.md
-    if (ptr.ptr_ == nullptr) {
+    if (ptr.get() == nullptr) {
       INFO("Failed to get buffer data from hipc::FullPtr<char>");
       return false;
     }
 
     // Copy the data into the shared memory buffer
-    memcpy(ptr.ptr_, data.data(), data.size());
+    memcpy(ptr.get(), data.data(), data.size());
     INFO("Successfully copied " << data.size()
                                 << " bytes to shared memory buffer");
 
@@ -277,11 +277,11 @@ class CTECoreFunctionalTestFixture {
     // Cast to char first, then use ToFullPtr to get proper FullPtr with ptr_ set
     auto char_ptr = ptr.template Cast<char>();
     hipc::FullPtr<char> buffer_fullptr = CHI_IPC->ToFullPtr<char>(char_ptr);
-    if (buffer_fullptr.ptr_ == nullptr) {
+    if (buffer_fullptr.get() == nullptr) {
       INFO("Failed to get buffer data from hipc::ShmPtr<>");
       return result;
     }
-    char *buffer_data = buffer_fullptr.ptr_;
+    char *buffer_data = buffer_fullptr.get();
 
     // Copy the data from the shared memory buffer
     result.resize(size);
@@ -303,16 +303,16 @@ class CTECoreFunctionalTestFixture {
       return result;
     }
 
-    // Access data directly through .ptr_ as specified in
+    // Access data directly through .get() as specified in
     // MODULE_DEVELOPMENT_GUIDE.md
-    if (ptr.ptr_ == nullptr) {
+    if (ptr.get() == nullptr) {
       INFO("Failed to get buffer data from hipc::FullPtr<char>");
       return result;
     }
 
     // Copy the data from the shared memory buffer
     result.resize(size);
-    memcpy(result.data(), ptr.ptr_, size);
+    memcpy(result.data(), ptr.get(), size);
     INFO("Successfully copied " << size << " bytes from shared memory buffer");
 
     return result;

--- a/context-transfer-engine/test/unit/test_core_runtime_coverage.cc
+++ b/context-transfer-engine/test/unit/test_core_runtime_coverage.cc
@@ -257,7 +257,7 @@ TEST_CASE("Runtime - DelBlob Success Path", "[runtime][blob]") {
   auto data = fixture.CreateTestData(fixture.kTestDataSize);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
   auto put_task = client->AsyncPutBlob(
@@ -331,7 +331,7 @@ TEST_CASE("Runtime - GetBlobScore Success", "[runtime][blob]") {
   auto data = fixture.CreateTestData(fixture.kTestDataSize);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
   float expected_score = 0.475f;
@@ -408,7 +408,7 @@ TEST_CASE("Runtime - GetBlobSize Success", "[runtime][blob]") {
   auto data = fixture.CreateTestData(expected_size);
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_ptr = ipc->AllocateBuffer(data.size());
-  memcpy(shm_ptr.ptr_, data.data(), data.size());
+  memcpy(shm_ptr.get(), data.data(), data.size());
   hipc::ShmPtr<> shm_ref(shm_ptr.shm_);
 
   auto put_task = client->AsyncPutBlob(
@@ -467,7 +467,7 @@ TEST_CASE("Runtime - GetTagSize Success", "[runtime][tag]") {
   size_t size1 = 1024;
   auto data1 = fixture.CreateTestData(size1);
   hipc::FullPtr<char> shm1 = ipc->AllocateBuffer(data1.size());
-  memcpy(shm1.ptr_, data1.data(), data1.size());
+  memcpy(shm1.get(), data1.data(), data1.size());
   hipc::ShmPtr<> ref1(shm1.shm_);
 
   auto put1 = client->AsyncPutBlob(tag_task->tag_id_, "blob1", 0, size1, ref1, 1.0f);
@@ -479,7 +479,7 @@ TEST_CASE("Runtime - GetTagSize Success", "[runtime][tag]") {
   size_t size2 = 512;
   auto data2 = fixture.CreateTestData(size2);
   hipc::FullPtr<char> shm2 = ipc->AllocateBuffer(data2.size());
-  memcpy(shm2.ptr_, data2.data(), data2.size());
+  memcpy(shm2.get(), data2.data(), data2.size());
   hipc::ShmPtr<> ref2(shm2.shm_);
 
   auto put2 = client->AsyncPutBlob(tag_task->tag_id_, "blob2", 0, size2, ref2, 1.0f);
@@ -560,7 +560,7 @@ TEST_CASE("Runtime - GetContainedBlobs Success", "[runtime][blob]") {
   for (int i = 0; i < 3; ++i) {
     std::string blob_name = "blob_" + std::to_string(i);
     hipc::FullPtr<char> shm = ipc->AllocateBuffer(data.size());
-    memcpy(shm.ptr_, data.data(), data.size());
+    memcpy(shm.get(), data.data(), data.size());
     hipc::ShmPtr<> ref(shm.shm_);
 
     auto put = client->AsyncPutBlob(tag_task->tag_id_, blob_name, 0, data.size(), ref, 1.0f);

--- a/context-transfer-engine/test/unit/test_reorganize_blob.cc
+++ b/context-transfer-engine/test/unit/test_reorganize_blob.cc
@@ -229,7 +229,7 @@ TEST_CASE("ReorganizeBlob - PutBlob to DRAM", "[reorganize][put][dram]") {
 
   // Fill buffer with pattern
   auto test_data = g_fixture->CreateTestData(kBlobSize, 'D');  // 'D' for DRAM
-  std::memcpy(shm_buffer.ptr_, test_data.data(), kBlobSize);
+  std::memcpy(shm_buffer.get(), test_data.data(), kBlobSize);
 
   // Put blob with high score (1.0) - should go to DRAM
   std::string blob_name = "test_blob_dram";
@@ -335,7 +335,7 @@ TEST_CASE("ReorganizeBlob - Verify Data Integrity", "[reorganize][integrity]") {
 
   // Verify data pattern
   std::vector<char> read_data(kBlobSize);
-  std::memcpy(read_data.data(), read_buffer.ptr_, kBlobSize);
+  std::memcpy(read_data.data(), read_buffer.get(), kBlobSize);
 
   bool data_valid = g_fixture->VerifyTestData(read_data, 'D');  // 'D' pattern from put
   REQUIRE(data_valid);
@@ -394,7 +394,7 @@ TEST_CASE("ReorganizeBlob - Promote to DRAM", "[reorganize][promote][dram]") {
   tag.GetBlob(blob_name, read_buffer.shm_.template Cast<void>(), kBlobSize, 0);
 
   std::vector<char> read_data(kBlobSize);
-  std::memcpy(read_data.data(), read_buffer.ptr_, kBlobSize);
+  std::memcpy(read_data.data(), read_buffer.get(), kBlobSize);
 
   bool data_valid = g_fixture->VerifyTestData(read_data, 'D');
   REQUIRE(data_valid);

--- a/context-transfer-engine/test/unit/test_tag_operations.cc
+++ b/context-transfer-engine/test/unit/test_tag_operations.cc
@@ -310,7 +310,7 @@ TEST_CASE("Tag - PutBlob SHM Version", "[cte][tag][putblob]") {
   REQUIRE(!shm_fullptr.IsNull());
 
   // Copy data to shared memory
-  memcpy(shm_fullptr.ptr_, data.data(), data.size());
+  memcpy(shm_fullptr.get(), data.data(), data.size());
 
   // Convert to ShmPtr and call SHM version
   hipc::ShmPtr<> shm_ptr(shm_fullptr.shm_);
@@ -601,7 +601,7 @@ TEST_CASE("Tag - AsyncPutBlob", "[cte][tag][async]") {
   auto *ipc = CHI_IPC;
   hipc::FullPtr<char> shm_fullptr = ipc->AllocateBuffer(data.size());
   REQUIRE(!shm_fullptr.IsNull());
-  memcpy(shm_fullptr.ptr_, data.data(), data.size());
+  memcpy(shm_fullptr.get(), data.data(), data.size());
 
   // Call async version
   hipc::ShmPtr<> shm_ptr(shm_fullptr.shm_);

--- a/context-transfer-engine/test/unit/test_tiered_storage_stress.cc
+++ b/context-transfer-engine/test/unit/test_tiered_storage_stress.cc
@@ -233,7 +233,7 @@ TEST_CASE("TieredStorage - Put 128MB with 64MB DRAM", "[tiered][stress][put]") {
 
     // Fill buffer with pattern
     auto test_data = g_fixture->CreateTestData(kBlobSize, i);
-    std::memcpy(shm_buffer.ptr_, test_data.data(), kBlobSize);
+    std::memcpy(shm_buffer.get(), test_data.data(), kBlobSize);
 
     // Put blob with high score (prefer slow tier to leave DRAM space)
     // Using score 0.5 - system should place where there's capacity
@@ -342,7 +342,7 @@ TEST_CASE("TieredStorage - Verify data integrity",
 
     // Verify data pattern
     std::vector<char> read_data(kBlobSize);
-    std::memcpy(read_data.data(), read_buffer.ptr_, kBlobSize);
+    std::memcpy(read_data.data(), read_buffer.get(), kBlobSize);
 
     if (g_fixture->VerifyTestData(read_data, i)) {
       verified_count++;

--- a/context-transport-primitives/benchmark/allocator_benchmark.cc
+++ b/context-transport-primitives/benchmark/allocator_benchmark.cc
@@ -208,7 +208,7 @@ class AllocatorBenchmarkWorker {
 
         if (!ptr.IsNull()) {
           // Write to the allocation to ensure it's valid
-          std::memset(ptr.ptr_, static_cast<unsigned char>(ptrs.size() & 0xFF), alloc_size);
+          std::memset(ptr.get(), static_cast<unsigned char>(ptrs.size() & 0xFF), alloc_size);
           ptrs.push_back(ptr);
           counter_->RecordAlloc();
         }

--- a/context-transport-primitives/include/hermes_shm/data_structures/ipc/rb_tree_pre.h
+++ b/context-transport-primitives/include/hermes_shm/data_structures/ipc/rb_tree_pre.h
@@ -157,15 +157,15 @@ class rb_tree {
   template<typename AllocT>
   HSHM_CROSS_FUN
   void emplace(AllocT *alloc, FullPtr<NodeT> node) {
-    node.ptr_->color_ = RBColor::RED;
-    node.ptr_->left_ = OffsetPtr<>::GetNull();
-    node.ptr_->right_ = OffsetPtr<>::GetNull();
-    node.ptr_->parent_ = OffsetPtr<>::GetNull();
+    node->color_ = RBColor::RED;
+    node->left_ = OffsetPtr<>::GetNull();
+    node->right_ = OffsetPtr<>::GetNull();
+    node->parent_ = OffsetPtr<>::GetNull();
 
     // Standard BST insertion
     if (root_.IsNull()) {
       root_ = node.shm_.off_;
-      node.ptr_->color_ = RBColor::BLACK;
+      node->color_ = RBColor::BLACK;
       size_.store(size_.load() + 1);
       return;
     }
@@ -178,10 +178,10 @@ class rb_tree {
       FullPtr<NodeT> curr(alloc, curr_off);
       parent_off = curr_off;
 
-      if (*node.ptr_ < *curr.ptr_) {
-        curr_off = OffsetPtr<NodeT>(curr.ptr_->left_);
-      } else if (*node.ptr_ > *curr.ptr_) {
-        curr_off = OffsetPtr<NodeT>(curr.ptr_->right_);
+      if (*node < *curr) {
+        curr_off = OffsetPtr<NodeT>(curr->left_);
+      } else if (*node > *curr) {
+        curr_off = OffsetPtr<NodeT>(curr->right_);
       } else {
         // Key already exists - don't insert duplicate
         return;
@@ -189,13 +189,13 @@ class rb_tree {
     }
 
     // Insert node
-    node.ptr_->parent_ = parent_off.template Cast<void>();
+    node->parent_ = parent_off.template Cast<void>();
     FullPtr<NodeT> parent(alloc, parent_off);
 
-    if (*node.ptr_ < *parent.ptr_) {
-      parent.ptr_->left_ = node.shm_.off_.template Cast<void>();
+    if (*node < *parent) {
+      parent->left_ = node.shm_.off_.template Cast<void>();
     } else {
-      parent.ptr_->right_ = node.shm_.off_.template Cast<void>();
+      parent->right_ = node.shm_.off_.template Cast<void>();
     }
 
     size_.store(size_.load() + 1);
@@ -229,71 +229,71 @@ class rb_tree {
 
     // Node to be deleted and node to replace it
     OffsetPtr<> replace_off;
-    RBColor original_color = node.ptr_->color_;
+    RBColor original_color = node->color_;
 
     // Track where the black node was actually removed (for FixDeleteFromParent)
     OffsetPtr<NodeT> deleted_parent;
     bool deleted_was_left;
 
-    if (node.ptr_->left_.IsNull()) {
+    if (node->left_.IsNull()) {
       // Case 1: No left child
-      replace_off = node.ptr_->right_;
-      deleted_parent = OffsetPtr<NodeT>(node.ptr_->parent_);
+      replace_off = node->right_;
+      deleted_parent = OffsetPtr<NodeT>(node->parent_);
       deleted_was_left = false;
       if (!deleted_parent.IsNull()) {
         FullPtr<NodeT> parent(alloc, deleted_parent);
-        deleted_was_left = (parent.ptr_->left_.load() == node_off.load());
+        deleted_was_left = (parent->left_.load() == node_off.load());
       }
-      Transplant(alloc, node_off, node.ptr_->right_.template Cast<void>());
-    } else if (node.ptr_->right_.IsNull()) {
+      Transplant(alloc, node_off, node->right_.template Cast<void>());
+    } else if (node->right_.IsNull()) {
       // Case 2: No right child
-      replace_off = node.ptr_->left_;
-      deleted_parent = OffsetPtr<NodeT>(node.ptr_->parent_);
+      replace_off = node->left_;
+      deleted_parent = OffsetPtr<NodeT>(node->parent_);
       deleted_was_left = false;
       if (!deleted_parent.IsNull()) {
         FullPtr<NodeT> parent(alloc, deleted_parent);
-        deleted_was_left = (parent.ptr_->left_.load() == node_off.load());
+        deleted_was_left = (parent->left_.load() == node_off.load());
       }
-      Transplant(alloc, node_off, node.ptr_->left_.template Cast<void>());
+      Transplant(alloc, node_off, node->left_.template Cast<void>());
     } else {
       // Case 3: Two children - find successor
-      OffsetPtr<NodeT> successor_off = Minimum(alloc, node.ptr_->right_);
+      OffsetPtr<NodeT> successor_off = Minimum(alloc, node->right_);
       FullPtr<NodeT> successor(alloc, successor_off);
-      original_color = successor.ptr_->color_;
-      replace_off = successor.ptr_->right_;
+      original_color = successor->color_;
+      replace_off = successor->right_;
 
       // Track where successor was originally (that's where black node is removed)
-      deleted_parent = OffsetPtr<NodeT>(successor.ptr_->parent_);
+      deleted_parent = OffsetPtr<NodeT>(successor->parent_);
       deleted_was_left = false;
       if (!deleted_parent.IsNull()) {
         FullPtr<NodeT> parent(alloc, deleted_parent);
-        deleted_was_left = (parent.ptr_->left_.load() == successor_off.load());
+        deleted_was_left = (parent->left_.load() == successor_off.load());
       }
 
-      if (successor.ptr_->parent_.load() == node_off.load()) {
+      if (successor->parent_.load() == node_off.load()) {
         // Successor is direct child
         if (!replace_off.IsNull()) {
           FullPtr<NodeT> replace(alloc, OffsetPtr<NodeT>(replace_off.load()));
-          replace.ptr_->parent_ = successor_off.template Cast<void>();
+          replace->parent_ = successor_off.template Cast<void>();
         }
         // When successor is direct child of node, the deleted position's parent becomes the successor itself after transplant
         deleted_parent = successor_off;
       } else {
-        Transplant(alloc, successor_off, successor.ptr_->right_.template Cast<void>());
-        successor.ptr_->right_ = node.ptr_->right_;
-        if (!successor.ptr_->right_.IsNull()) {
-          FullPtr<NodeT> right_child(alloc, OffsetPtr<NodeT>(successor.ptr_->right_.load()));
-          right_child.ptr_->parent_ = successor_off.template Cast<void>();
+        Transplant(alloc, successor_off, successor->right_.template Cast<void>());
+        successor->right_ = node->right_;
+        if (!successor->right_.IsNull()) {
+          FullPtr<NodeT> right_child(alloc, OffsetPtr<NodeT>(successor->right_.load()));
+          right_child->parent_ = successor_off.template Cast<void>();
         }
       }
 
       Transplant(alloc, node_off, successor_off.template Cast<void>());
-      successor.ptr_->left_ = node.ptr_->left_;
-      if (!successor.ptr_->left_.IsNull()) {
-        FullPtr<NodeT> left_child(alloc, OffsetPtr<NodeT>(successor.ptr_->left_.load()));
-        left_child.ptr_->parent_ = successor_off.template Cast<void>();
+      successor->left_ = node->left_;
+      if (!successor->left_.IsNull()) {
+        FullPtr<NodeT> left_child(alloc, OffsetPtr<NodeT>(successor->left_.load()));
+        left_child->parent_ = successor_off.template Cast<void>();
       }
-      successor.ptr_->color_ = node.ptr_->color_;
+      successor->color_ = node->color_;
     }
 
     size_.store(size_.load() - 1);
@@ -312,13 +312,13 @@ class rb_tree {
     // Ensure root is black
     if (!root_.IsNull()) {
       FullPtr<NodeT> root_node(alloc, root_);
-      root_node.ptr_->color_ = RBColor::BLACK;
+      root_node->color_ = RBColor::BLACK;
     }
 
     // Clear the removed node's pointers
-    result.ptr_->left_ = OffsetPtr<>::GetNull();
-    result.ptr_->right_ = OffsetPtr<>::GetNull();
-    result.ptr_->parent_ = OffsetPtr<>::GetNull();
+    result->left_ = OffsetPtr<>::GetNull();
+    result->right_ = OffsetPtr<>::GetNull();
+    result->parent_ = OffsetPtr<>::GetNull();
 
     return result;
   }
@@ -352,10 +352,10 @@ class rb_tree {
     while (!curr_off.IsNull()) {
       FullPtr<NodeT> curr(alloc, curr_off);
 
-      if (key < curr.ptr_->key) {
-        curr_off = OffsetPtr<NodeT>(curr.ptr_->left_);
-      } else if (key > curr.ptr_->key) {
-        curr_off = OffsetPtr<NodeT>(curr.ptr_->right_);
+      if (key < curr->key) {
+        curr_off = OffsetPtr<NodeT>(curr->left_);
+      } else if (key > curr->key) {
+        curr_off = OffsetPtr<NodeT>(curr->right_);
       } else {
         return curr_off;
       }
@@ -373,10 +373,10 @@ class rb_tree {
     OffsetPtr<NodeT> curr_off(node_off);
     while (!curr_off.IsNull()) {
       FullPtr<NodeT> node(alloc, curr_off);
-      if (node.ptr_->left_.IsNull()) {
+      if (node->left_.IsNull()) {
         break;
       }
-      curr_off = OffsetPtr<NodeT>(node.ptr_->left_);
+      curr_off = OffsetPtr<NodeT>(node->left_);
     }
     return curr_off;
   }
@@ -389,20 +389,20 @@ class rb_tree {
   void Transplant(AllocT *alloc, OffsetPtr<NodeT> u_off, OffsetPtr<> v_off) {
     FullPtr<NodeT> u(alloc, u_off);
 
-    if (u.ptr_->parent_.IsNull()) {
+    if (u->parent_.IsNull()) {
       root_ = OffsetPtr<NodeT>(v_off);
     } else {
-      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(u.ptr_->parent_.load()));
-      if (u_off.load() == parent.ptr_->left_.load()) {
-        parent.ptr_->left_ = v_off;
+      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(u->parent_.load()));
+      if (u_off.load() == parent->left_.load()) {
+        parent->left_ = v_off;
       } else {
-        parent.ptr_->right_ = v_off;
+        parent->right_ = v_off;
       }
     }
 
     if (!v_off.IsNull()) {
       FullPtr<NodeT> v(alloc, OffsetPtr<NodeT>(v_off.load()));
-      v.ptr_->parent_ = u.ptr_->parent_;
+      v->parent_ = u->parent_;
     }
   }
 
@@ -413,29 +413,29 @@ class rb_tree {
   HSHM_CROSS_FUN
   void RotateLeft(AllocT *alloc, OffsetPtr<NodeT> x_off) {
     FullPtr<NodeT> x(alloc, x_off);
-    OffsetPtr<NodeT> y_off(x.ptr_->right_);
+    OffsetPtr<NodeT> y_off(x->right_);
     FullPtr<NodeT> y(alloc, y_off);
 
-    x.ptr_->right_ = y.ptr_->left_;
-    if (!y.ptr_->left_.IsNull()) {
-      FullPtr<NodeT> left_child(alloc, OffsetPtr<NodeT>(y.ptr_->left_.load()));
-      left_child.ptr_->parent_ = x_off.template Cast<void>();
+    x->right_ = y->left_;
+    if (!y->left_.IsNull()) {
+      FullPtr<NodeT> left_child(alloc, OffsetPtr<NodeT>(y->left_.load()));
+      left_child->parent_ = x_off.template Cast<void>();
     }
 
-    y.ptr_->parent_ = x.ptr_->parent_;
-    if (x.ptr_->parent_.IsNull()) {
+    y->parent_ = x->parent_;
+    if (x->parent_.IsNull()) {
       root_ = y_off;
     } else {
-      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(x.ptr_->parent_.load()));
-      if (x_off.load() == parent.ptr_->left_.load()) {
-        parent.ptr_->left_ = y_off.template Cast<void>();
+      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(x->parent_.load()));
+      if (x_off.load() == parent->left_.load()) {
+        parent->left_ = y_off.template Cast<void>();
       } else {
-        parent.ptr_->right_ = y_off.template Cast<void>();
+        parent->right_ = y_off.template Cast<void>();
       }
     }
 
-    y.ptr_->left_ = x_off.template Cast<void>();
-    x.ptr_->parent_ = y_off.template Cast<void>();
+    y->left_ = x_off.template Cast<void>();
+    x->parent_ = y_off.template Cast<void>();
   }
 
   /**
@@ -445,29 +445,29 @@ class rb_tree {
   HSHM_CROSS_FUN
   void RotateRight(AllocT *alloc, OffsetPtr<NodeT> y_off) {
     FullPtr<NodeT> y(alloc, y_off);
-    OffsetPtr<NodeT> x_off(y.ptr_->left_);
+    OffsetPtr<NodeT> x_off(y->left_);
     FullPtr<NodeT> x(alloc, x_off);
 
-    y.ptr_->left_ = x.ptr_->right_;
-    if (!x.ptr_->right_.IsNull()) {
-      FullPtr<NodeT> right_child(alloc, OffsetPtr<NodeT>(x.ptr_->right_.load()));
-      right_child.ptr_->parent_ = y_off.template Cast<void>();
+    y->left_ = x->right_;
+    if (!x->right_.IsNull()) {
+      FullPtr<NodeT> right_child(alloc, OffsetPtr<NodeT>(x->right_.load()));
+      right_child->parent_ = y_off.template Cast<void>();
     }
 
-    x.ptr_->parent_ = y.ptr_->parent_;
-    if (y.ptr_->parent_.IsNull()) {
+    x->parent_ = y->parent_;
+    if (y->parent_.IsNull()) {
       root_ = x_off;
     } else {
-      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(y.ptr_->parent_.load()));
-      if (y_off.load() == parent.ptr_->left_.load()) {
-        parent.ptr_->left_ = x_off.template Cast<void>();
+      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(y->parent_.load()));
+      if (y_off.load() == parent->left_.load()) {
+        parent->left_ = x_off.template Cast<void>();
       } else {
-        parent.ptr_->right_ = x_off.template Cast<void>();
+        parent->right_ = x_off.template Cast<void>();
       }
     }
 
-    x.ptr_->right_ = y_off.template Cast<void>();
-    y.ptr_->parent_ = x_off.template Cast<void>();
+    x->right_ = y_off.template Cast<void>();
+    y->parent_ = x_off.template Cast<void>();
   }
 
   /**
@@ -478,82 +478,82 @@ class rb_tree {
   void FixInsert(AllocT *alloc, FullPtr<NodeT> node) {
     OffsetPtr<NodeT> node_off = node.shm_.off_;
 
-    while (!node.ptr_->parent_.IsNull()) {
-      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(node.ptr_->parent_.load()));
-      if (parent.ptr_->color_ == RBColor::BLACK) {
+    while (!node->parent_.IsNull()) {
+      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(node->parent_.load()));
+      if (parent->color_ == RBColor::BLACK) {
         break;
       }
 
-      if (parent.ptr_->parent_.IsNull()) {
+      if (parent->parent_.IsNull()) {
         break;
       }
 
-      FullPtr<NodeT> grandparent(alloc, OffsetPtr<NodeT>(parent.ptr_->parent_.load()));
+      FullPtr<NodeT> grandparent(alloc, OffsetPtr<NodeT>(parent->parent_.load()));
 
-      if (node.ptr_->parent_.load() == grandparent.ptr_->left_.load()) {
+      if (node->parent_.load() == grandparent->left_.load()) {
         // Parent is left child
-        OffsetPtr<> uncle_off = grandparent.ptr_->right_;
+        OffsetPtr<> uncle_off = grandparent->right_;
 
         if (!uncle_off.IsNull()) {
           FullPtr<NodeT> uncle(alloc, OffsetPtr<NodeT>(uncle_off.load()));
-          if (uncle.ptr_->color_ == RBColor::RED) {
+          if (uncle->color_ == RBColor::RED) {
             // Case 1: Uncle is red
-            parent.ptr_->color_ = RBColor::BLACK;
-            uncle.ptr_->color_ = RBColor::BLACK;
-            grandparent.ptr_->color_ = RBColor::RED;
-            node_off = OffsetPtr<NodeT>(parent.ptr_->parent_);
+            parent->color_ = RBColor::BLACK;
+            uncle->color_ = RBColor::BLACK;
+            grandparent->color_ = RBColor::RED;
+            node_off = OffsetPtr<NodeT>(parent->parent_);
             node = FullPtr<NodeT>(alloc, node_off);
             continue;
           }
         }
 
-        if (node_off.load() == parent.ptr_->right_.load()) {
+        if (node_off.load() == parent->right_.load()) {
           // Case 2: Node is right child
-          node_off = OffsetPtr<NodeT>(node.ptr_->parent_.load());
+          node_off = OffsetPtr<NodeT>(node->parent_.load());
           RotateLeft(alloc, node_off);
           node = FullPtr<NodeT>(alloc, node_off);
-          parent = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(node.ptr_->parent_.load()));
-          grandparent = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(parent.ptr_->parent_.load()));
+          parent = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(node->parent_.load()));
+          grandparent = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(parent->parent_.load()));
         }
 
         // Case 3: Node is left child
-        parent.ptr_->color_ = RBColor::BLACK;
-        grandparent.ptr_->color_ = RBColor::RED;
-        RotateRight(alloc, OffsetPtr<NodeT>(parent.ptr_->parent_));
+        parent->color_ = RBColor::BLACK;
+        grandparent->color_ = RBColor::RED;
+        RotateRight(alloc, OffsetPtr<NodeT>(parent->parent_));
       } else {
         // Parent is right child (symmetric)
-        OffsetPtr<> uncle_off = grandparent.ptr_->left_;
+        OffsetPtr<> uncle_off = grandparent->left_;
 
         if (!uncle_off.IsNull()) {
           FullPtr<NodeT> uncle(alloc, OffsetPtr<NodeT>(uncle_off.load()));
-          if (uncle.ptr_->color_ == RBColor::RED) {
-            parent.ptr_->color_ = RBColor::BLACK;
-            uncle.ptr_->color_ = RBColor::BLACK;
-            grandparent.ptr_->color_ = RBColor::RED;
-            node_off = OffsetPtr<NodeT>(parent.ptr_->parent_);
+          if (uncle->color_ == RBColor::RED) {
+            parent->color_ = RBColor::BLACK;
+            uncle->color_ = RBColor::BLACK;
+            grandparent->color_ = RBColor::RED;
+            node_off = OffsetPtr<NodeT>(parent->parent_);
             node = FullPtr<NodeT>(alloc, node_off);
             continue;
           }
         }
 
-        if (node_off.load() == parent.ptr_->left_.load()) {
-          node_off = OffsetPtr<NodeT>(node.ptr_->parent_.load());
+        if (node_off.load() == parent->left_.load()) {
+          node_off = OffsetPtr<NodeT>(node->parent_.load());
           RotateRight(alloc, node_off);
           node = FullPtr<NodeT>(alloc, node_off);
-          parent = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(node.ptr_->parent_.load()));
-          grandparent = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(parent.ptr_->parent_.load()));
+          parent = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(node->parent_.load()));
+          grandparent = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(parent->parent_.load()));
         }
 
-        parent.ptr_->color_ = RBColor::BLACK;
-        grandparent.ptr_->color_ = RBColor::RED;
-        RotateLeft(alloc, OffsetPtr<NodeT>(parent.ptr_->parent_));
+        parent->color_ = RBColor::BLACK;
+        grandparent->color_ = RBColor::RED;
+        RotateLeft(alloc, OffsetPtr<NodeT>(parent->parent_));
       }
     }
 
     // Ensure root is black
     if (!root_.IsNull()) {
       FullPtr<NodeT> root(alloc, root_);
-      root.ptr_->color_ = RBColor::BLACK;
+      root->color_ = RBColor::BLACK;
     }
   }
 
@@ -566,121 +566,121 @@ class rb_tree {
     OffsetPtr<NodeT> node_off(node_off_raw);
     while (node_off.load() != root_.load()) {
       FullPtr<NodeT> node(alloc, node_off);
-      if (node.ptr_->color_ == RBColor::RED) {
+      if (node->color_ == RBColor::RED) {
         break;
       }
 
-      if (node.ptr_->parent_.IsNull()) {
+      if (node->parent_.IsNull()) {
         break;
       }
 
-      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(node.ptr_->parent_.load()));
+      FullPtr<NodeT> parent(alloc, OffsetPtr<NodeT>(node->parent_.load()));
 
-      if (node_off.load() == parent.ptr_->left_.load()) {
-        OffsetPtr<NodeT> sibling_off(parent.ptr_->right_);
+      if (node_off.load() == parent->left_.load()) {
+        OffsetPtr<NodeT> sibling_off(parent->right_);
         if (sibling_off.IsNull()) {
-          node_off = OffsetPtr<NodeT>(node.ptr_->parent_.load());
+          node_off = OffsetPtr<NodeT>(node->parent_.load());
           continue;
         }
 
         FullPtr<NodeT> sibling(alloc, sibling_off);
 
-        if (sibling.ptr_->color_ == RBColor::RED) {
-          sibling.ptr_->color_ = RBColor::BLACK;
-          parent.ptr_->color_ = RBColor::RED;
-          RotateLeft(alloc, OffsetPtr<NodeT>(node.ptr_->parent_));
-          sibling_off = OffsetPtr<NodeT>(parent.ptr_->right_.load());
+        if (sibling->color_ == RBColor::RED) {
+          sibling->color_ = RBColor::BLACK;
+          parent->color_ = RBColor::RED;
+          RotateLeft(alloc, OffsetPtr<NodeT>(node->parent_));
+          sibling_off = OffsetPtr<NodeT>(parent->right_.load());
           sibling = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(sibling_off.load()));
         }
 
-        bool left_black = sibling.ptr_->left_.IsNull();
-        bool right_black = sibling.ptr_->right_.IsNull();
+        bool left_black = sibling->left_.IsNull();
+        bool right_black = sibling->right_.IsNull();
 
-        if (!sibling.ptr_->left_.IsNull()) {
-          FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling.ptr_->left_.load()));
-          left_black = (left.ptr_->color_ == RBColor::BLACK);
+        if (!sibling->left_.IsNull()) {
+          FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling->left_.load()));
+          left_black = (left->color_ == RBColor::BLACK);
         }
-        if (!sibling.ptr_->right_.IsNull()) {
-          FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling.ptr_->right_.load()));
-          right_black = (right.ptr_->color_ == RBColor::BLACK);
+        if (!sibling->right_.IsNull()) {
+          FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling->right_.load()));
+          right_black = (right->color_ == RBColor::BLACK);
         }
 
         if (left_black && right_black) {
-          sibling.ptr_->color_ = RBColor::RED;
-          node_off = OffsetPtr<NodeT>(node.ptr_->parent_.load());
+          sibling->color_ = RBColor::RED;
+          node_off = OffsetPtr<NodeT>(node->parent_.load());
         } else {
           if (right_black) {
-            if (!sibling.ptr_->left_.IsNull()) {
-              FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling.ptr_->left_.load()));
-              left.ptr_->color_ = RBColor::BLACK;
+            if (!sibling->left_.IsNull()) {
+              FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling->left_.load()));
+              left->color_ = RBColor::BLACK;
             }
-            sibling.ptr_->color_ = RBColor::RED;
+            sibling->color_ = RBColor::RED;
             RotateRight(alloc, OffsetPtr<NodeT>(sibling_off));
-            sibling_off = OffsetPtr<NodeT>(parent.ptr_->right_.load());
+            sibling_off = OffsetPtr<NodeT>(parent->right_.load());
             sibling = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(sibling_off.load()));
           }
 
-          sibling.ptr_->color_ = parent.ptr_->color_;
-          parent.ptr_->color_ = RBColor::BLACK;
-          if (!sibling.ptr_->right_.IsNull()) {
-            FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling.ptr_->right_.load()));
-            right.ptr_->color_ = RBColor::BLACK;
+          sibling->color_ = parent->color_;
+          parent->color_ = RBColor::BLACK;
+          if (!sibling->right_.IsNull()) {
+            FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling->right_.load()));
+            right->color_ = RBColor::BLACK;
           }
-          RotateLeft(alloc, OffsetPtr<NodeT>(node.ptr_->parent_));
+          RotateLeft(alloc, OffsetPtr<NodeT>(node->parent_));
           node_off = root_;
         }
       } else {
         // Symmetric case
-        OffsetPtr<NodeT> sibling_off(parent.ptr_->left_);
+        OffsetPtr<NodeT> sibling_off(parent->left_);
         if (sibling_off.IsNull()) {
-          node_off = OffsetPtr<NodeT>(node.ptr_->parent_.load());
+          node_off = OffsetPtr<NodeT>(node->parent_.load());
           continue;
         }
 
         FullPtr<NodeT> sibling(alloc, sibling_off);
 
-        if (sibling.ptr_->color_ == RBColor::RED) {
-          sibling.ptr_->color_ = RBColor::BLACK;
-          parent.ptr_->color_ = RBColor::RED;
-          RotateRight(alloc, OffsetPtr<NodeT>(node.ptr_->parent_));
-          sibling_off = OffsetPtr<NodeT>(parent.ptr_->left_.load());
+        if (sibling->color_ == RBColor::RED) {
+          sibling->color_ = RBColor::BLACK;
+          parent->color_ = RBColor::RED;
+          RotateRight(alloc, OffsetPtr<NodeT>(node->parent_));
+          sibling_off = OffsetPtr<NodeT>(parent->left_.load());
           sibling = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(sibling_off.load()));
         }
 
-        bool left_black = sibling.ptr_->left_.IsNull();
-        bool right_black = sibling.ptr_->right_.IsNull();
+        bool left_black = sibling->left_.IsNull();
+        bool right_black = sibling->right_.IsNull();
 
-        if (!sibling.ptr_->left_.IsNull()) {
-          FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling.ptr_->left_.load()));
-          left_black = (left.ptr_->color_ == RBColor::BLACK);
+        if (!sibling->left_.IsNull()) {
+          FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling->left_.load()));
+          left_black = (left->color_ == RBColor::BLACK);
         }
-        if (!sibling.ptr_->right_.IsNull()) {
-          FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling.ptr_->right_.load()));
-          right_black = (right.ptr_->color_ == RBColor::BLACK);
+        if (!sibling->right_.IsNull()) {
+          FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling->right_.load()));
+          right_black = (right->color_ == RBColor::BLACK);
         }
 
         if (left_black && right_black) {
-          sibling.ptr_->color_ = RBColor::RED;
-          node_off = OffsetPtr<NodeT>(node.ptr_->parent_.load());
+          sibling->color_ = RBColor::RED;
+          node_off = OffsetPtr<NodeT>(node->parent_.load());
         } else {
           if (left_black) {
-            if (!sibling.ptr_->right_.IsNull()) {
-              FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling.ptr_->right_.load()));
-              right.ptr_->color_ = RBColor::BLACK;
+            if (!sibling->right_.IsNull()) {
+              FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling->right_.load()));
+              right->color_ = RBColor::BLACK;
             }
-            sibling.ptr_->color_ = RBColor::RED;
+            sibling->color_ = RBColor::RED;
             RotateLeft(alloc, OffsetPtr<NodeT>(sibling_off));
-            sibling_off = OffsetPtr<NodeT>(parent.ptr_->left_.load());
+            sibling_off = OffsetPtr<NodeT>(parent->left_.load());
             sibling = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(sibling_off.load()));
           }
 
-          sibling.ptr_->color_ = parent.ptr_->color_;
-          parent.ptr_->color_ = RBColor::BLACK;
-          if (!sibling.ptr_->left_.IsNull()) {
-            FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling.ptr_->left_.load()));
-            left.ptr_->color_ = RBColor::BLACK;
+          sibling->color_ = parent->color_;
+          parent->color_ = RBColor::BLACK;
+          if (!sibling->left_.IsNull()) {
+            FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling->left_.load()));
+            left->color_ = RBColor::BLACK;
           }
-          RotateRight(alloc, OffsetPtr<NodeT>(node.ptr_->parent_));
+          RotateRight(alloc, OffsetPtr<NodeT>(node->parent_));
           node_off = root_;
         }
       }
@@ -688,7 +688,7 @@ class rb_tree {
 
     if (!node_off.IsNull()) {
       FullPtr<NodeT> node(alloc, OffsetPtr<NodeT>(node_off.load()));
-      node.ptr_->color_ = RBColor::BLACK;
+      node->color_ = RBColor::BLACK;
     }
   }
 
@@ -704,38 +704,38 @@ class rb_tree {
 
       if (deleted_was_left) {
         // Deleted node was left child
-        OffsetPtr<NodeT> sibling_off(parent.ptr_->right_);
+        OffsetPtr<NodeT> sibling_off(parent->right_);
         if (sibling_off.IsNull()) break;  // Shouldn't happen in valid RB tree
 
         FullPtr<NodeT> sibling(alloc, sibling_off);
 
         // Case 1: Red sibling
-        if (sibling.ptr_->color_ == RBColor::RED) {
-          sibling.ptr_->color_ = RBColor::BLACK;
-          parent.ptr_->color_ = RBColor::RED;
+        if (sibling->color_ == RBColor::RED) {
+          sibling->color_ = RBColor::BLACK;
+          parent->color_ = RBColor::RED;
           RotateLeft(alloc, parent_off);
-          sibling_off = OffsetPtr<NodeT>(parent.ptr_->right_.load());
+          sibling_off = OffsetPtr<NodeT>(parent->right_.load());
           if (sibling_off.IsNull()) break;
           sibling = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(sibling_off.load()));
         }
 
         // Check sibling's children colors
-        bool left_black = sibling.ptr_->left_.IsNull();
-        bool right_black = sibling.ptr_->right_.IsNull();
-        if (!sibling.ptr_->left_.IsNull()) {
-          FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling.ptr_->left_.load()));
-          left_black = (left.ptr_->color_ == RBColor::BLACK);
+        bool left_black = sibling->left_.IsNull();
+        bool right_black = sibling->right_.IsNull();
+        if (!sibling->left_.IsNull()) {
+          FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling->left_.load()));
+          left_black = (left->color_ == RBColor::BLACK);
         }
-        if (!sibling.ptr_->right_.IsNull()) {
-          FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling.ptr_->right_.load()));
-          right_black = (right.ptr_->color_ == RBColor::BLACK);
+        if (!sibling->right_.IsNull()) {
+          FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling->right_.load()));
+          right_black = (right->color_ == RBColor::BLACK);
         }
 
         // Case 2: Sibling and both nephews are black
         if (left_black && right_black) {
-          sibling.ptr_->color_ = RBColor::RED;
-          if (parent.ptr_->color_ == RBColor::RED) {
-            parent.ptr_->color_ = RBColor::BLACK;
+          sibling->color_ = RBColor::RED;
+          if (parent->color_ == RBColor::RED) {
+            parent->color_ = RBColor::BLACK;
             return;
           }
           // If parent is root, we're done (reduced black height of whole tree)
@@ -743,93 +743,93 @@ class rb_tree {
             return;
           }
           // Continue fixing from parent
-          if (parent.ptr_->parent_.IsNull()) break;
-          OffsetPtr<NodeT> grandparent_off(parent.ptr_->parent_.load());
+          if (parent->parent_.IsNull()) break;
+          OffsetPtr<NodeT> grandparent_off(parent->parent_.load());
           FullPtr<NodeT> grandparent(alloc, grandparent_off);
-          deleted_was_left = (grandparent.ptr_->left_.load() == parent_off.load());
+          deleted_was_left = (grandparent->left_.load() == parent_off.load());
           parent_off = grandparent_off;
         } else {
           // Case 3: Right nephew is black (left is red)
           if (right_black) {
-            if (!sibling.ptr_->left_.IsNull()) {
-              FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling.ptr_->left_.load()));
-              left.ptr_->color_ = RBColor::BLACK;
+            if (!sibling->left_.IsNull()) {
+              FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling->left_.load()));
+              left->color_ = RBColor::BLACK;
             }
-            sibling.ptr_->color_ = RBColor::RED;
+            sibling->color_ = RBColor::RED;
             RotateRight(alloc, OffsetPtr<NodeT>(sibling_off));
-            sibling_off = OffsetPtr<NodeT>(parent.ptr_->right_.load());
+            sibling_off = OffsetPtr<NodeT>(parent->right_.load());
             sibling = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(sibling_off.load()));
           }
 
           // Case 4: Right nephew is red
-          sibling.ptr_->color_ = parent.ptr_->color_;
-          parent.ptr_->color_ = RBColor::BLACK;
-          if (!sibling.ptr_->right_.IsNull()) {
-            FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling.ptr_->right_.load()));
-            right.ptr_->color_ = RBColor::BLACK;
+          sibling->color_ = parent->color_;
+          parent->color_ = RBColor::BLACK;
+          if (!sibling->right_.IsNull()) {
+            FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling->right_.load()));
+            right->color_ = RBColor::BLACK;
           }
           RotateLeft(alloc, parent_off);
           return;
         }
       } else {
         // Deleted node was right child (symmetric)
-        OffsetPtr<NodeT> sibling_off(parent.ptr_->left_);
+        OffsetPtr<NodeT> sibling_off(parent->left_);
         if (sibling_off.IsNull()) break;
 
         FullPtr<NodeT> sibling(alloc, sibling_off);
 
-        if (sibling.ptr_->color_ == RBColor::RED) {
-          sibling.ptr_->color_ = RBColor::BLACK;
-          parent.ptr_->color_ = RBColor::RED;
+        if (sibling->color_ == RBColor::RED) {
+          sibling->color_ = RBColor::BLACK;
+          parent->color_ = RBColor::RED;
           RotateRight(alloc, parent_off);
-          sibling_off = OffsetPtr<NodeT>(parent.ptr_->left_.load());
+          sibling_off = OffsetPtr<NodeT>(parent->left_.load());
           if (sibling_off.IsNull()) break;
           sibling = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(sibling_off.load()));
         }
 
-        bool left_black = sibling.ptr_->left_.IsNull();
-        bool right_black = sibling.ptr_->right_.IsNull();
-        if (!sibling.ptr_->left_.IsNull()) {
-          FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling.ptr_->left_.load()));
-          left_black = (left.ptr_->color_ == RBColor::BLACK);
+        bool left_black = sibling->left_.IsNull();
+        bool right_black = sibling->right_.IsNull();
+        if (!sibling->left_.IsNull()) {
+          FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling->left_.load()));
+          left_black = (left->color_ == RBColor::BLACK);
         }
-        if (!sibling.ptr_->right_.IsNull()) {
-          FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling.ptr_->right_.load()));
-          right_black = (right.ptr_->color_ == RBColor::BLACK);
+        if (!sibling->right_.IsNull()) {
+          FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling->right_.load()));
+          right_black = (right->color_ == RBColor::BLACK);
         }
 
         if (left_black && right_black) {
-          sibling.ptr_->color_ = RBColor::RED;
-          if (parent.ptr_->color_ == RBColor::RED) {
-            parent.ptr_->color_ = RBColor::BLACK;
+          sibling->color_ = RBColor::RED;
+          if (parent->color_ == RBColor::RED) {
+            parent->color_ = RBColor::BLACK;
             return;
           }
           // If parent is root, we're done (reduced black height of whole tree)
           if (parent_off.load() == root_.load()) {
             return;
           }
-          if (parent.ptr_->parent_.IsNull()) break;
-          OffsetPtr<NodeT> grandparent_off(parent.ptr_->parent_.load());
+          if (parent->parent_.IsNull()) break;
+          OffsetPtr<NodeT> grandparent_off(parent->parent_.load());
           FullPtr<NodeT> grandparent(alloc, grandparent_off);
-          deleted_was_left = (grandparent.ptr_->left_.load() == parent_off.load());
+          deleted_was_left = (grandparent->left_.load() == parent_off.load());
           parent_off = grandparent_off;
         } else {
           if (left_black) {
-            if (!sibling.ptr_->right_.IsNull()) {
-              FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling.ptr_->right_.load()));
-              right.ptr_->color_ = RBColor::BLACK;
+            if (!sibling->right_.IsNull()) {
+              FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(sibling->right_.load()));
+              right->color_ = RBColor::BLACK;
             }
-            sibling.ptr_->color_ = RBColor::RED;
+            sibling->color_ = RBColor::RED;
             RotateLeft(alloc, OffsetPtr<NodeT>(sibling_off));
-            sibling_off = OffsetPtr<NodeT>(parent.ptr_->left_.load());
+            sibling_off = OffsetPtr<NodeT>(parent->left_.load());
             sibling = FullPtr<NodeT>(alloc, OffsetPtr<NodeT>(sibling_off.load()));
           }
 
-          sibling.ptr_->color_ = parent.ptr_->color_;
-          parent.ptr_->color_ = RBColor::BLACK;
-          if (!sibling.ptr_->left_.IsNull()) {
-            FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling.ptr_->left_.load()));
-            left.ptr_->color_ = RBColor::BLACK;
+          sibling->color_ = parent->color_;
+          parent->color_ = RBColor::BLACK;
+          if (!sibling->left_.IsNull()) {
+            FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(sibling->left_.load()));
+            left->color_ = RBColor::BLACK;
           }
           RotateRight(alloc, parent_off);
           return;

--- a/context-transport-primitives/include/hermes_shm/data_structures/ipc/slist_pre.h
+++ b/context-transport-primitives/include/hermes_shm/data_structures/ipc/slist_pre.h
@@ -214,7 +214,7 @@ class slist {
       // Get the next pointer from current node
       auto current = FullPtr<NodeT>(static_cast<hipc::Allocator*>(alloc_),
                                     current_);
-      OffsetPtr<> next_off = current.ptr_->next_;
+      OffsetPtr<> next_off = current->next_;
 
       if (next_off.IsNull()) {
         // Update to null iterator for end
@@ -260,7 +260,7 @@ class slist {
   HSHM_CROSS_FUN
   void emplace(AllocT *alloc, FullPtr<NodeT> node) {
     // Set node's next to current head
-    node.ptr_->next_ = head_.template Cast<void>();
+    node->next_ = head_.template Cast<void>();
 
     // Update head to point to new node
     head_ = node.shm_.off_;
@@ -304,7 +304,7 @@ class slist {
     }
 
     // Update head to next node
-    head_ = OffsetPtr<NodeT>(head.ptr_->next_);
+    head_ = OffsetPtr<NodeT>(head->next_);
 
     // Decrement size
     size_.store(size_.load() - 1);
@@ -407,11 +407,11 @@ class slist {
 
     if (it.IsAtHead()) {
       // Removing head node - update head_ directly
-      head_ = OffsetPtr<NodeT>(current.ptr_->next_);
+      head_ = OffsetPtr<NodeT>(current->next_);
     } else {
       // Removing middle node - update prev's next pointer
       auto prev = FullPtr<NodeT>(alloc, it.GetPrev());
-      prev.ptr_->next_ = current.ptr_->next_;
+      prev->next_ = current->next_;
     }
 
     // Decrement size

--- a/context-transport-primitives/include/hermes_shm/data_structures/ipc/vector.h
+++ b/context-transport-primitives/include/hermes_shm/data_structures/ipc/vector.h
@@ -656,7 +656,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   T& at(size_t idx) {
-    auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.ptr_;
+    auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.get();
     return ptr[idx];
   }
 
@@ -669,7 +669,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   const T& at(size_t idx) const {
-    const auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.ptr_;
+    const auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.get();
     return ptr[idx];
   }
 
@@ -681,7 +681,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   T& operator[](size_t idx) {
-    auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.ptr_;
+    auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.get();
     return ptr[idx];
   }
 
@@ -693,7 +693,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   const T& operator[](size_t idx) const {
-    const auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.ptr_;
+    const auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.get();
     return ptr[idx];
   }
 
@@ -704,7 +704,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   T& front() {
-    auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.ptr_;
+    auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.get();
     return *ptr;
   }
 
@@ -715,7 +715,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   const T& front() const {
-    const auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.ptr_;
+    const auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.get();
     return *ptr;
   }
 
@@ -726,7 +726,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   T& back() {
-    auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.ptr_;
+    auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.get();
     return ptr[size_ - 1];
   }
 
@@ -737,7 +737,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   const T& back() const {
-    const auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.ptr_;
+    const auto fp = FullPtr(this->GetAllocator(), data_); T *ptr = fp.get();
     return ptr[size_ - 1];
   }
 
@@ -749,7 +749,7 @@ class vector : public ShmContainer<AllocT> {
   HSHM_INLINE_CROSS_FUN
   T* data() {
     if (data_.IsNull()) return nullptr;
-    return FullPtr(this->GetAllocator(), data_).ptr_;
+    return FullPtr(this->GetAllocator(), data_).get();
   }
 
   /**
@@ -760,7 +760,7 @@ class vector : public ShmContainer<AllocT> {
   HSHM_INLINE_CROSS_FUN
   const T* data() const {
     if (data_.IsNull()) return nullptr;
-    return FullPtr(this->GetAllocator(), data_).ptr_;
+    return FullPtr(this->GetAllocator(), data_).get();
   }
 
   /**
@@ -770,7 +770,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   iterator begin() {
-    T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).ptr_;
+    T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).get();
     return iterator(ptr);
   }
 
@@ -781,7 +781,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   const_iterator begin() const {
-    const T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).ptr_;
+    const T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).get();
     return const_iterator(ptr);
   }
 
@@ -792,7 +792,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   iterator end() {
-    T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).ptr_;
+    T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).get();
     return iterator(ptr + size_);
   }
 
@@ -803,7 +803,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   const_iterator end() const {
-    const T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).ptr_;
+    const T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).get();
     return const_iterator(ptr + size_);
   }
 
@@ -814,7 +814,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   const_iterator cbegin() const {
-    const T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).ptr_;
+    const T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).get();
     return const_iterator(ptr);
   }
 
@@ -825,7 +825,7 @@ class vector : public ShmContainer<AllocT> {
    */
   HSHM_INLINE_CROSS_FUN
   const_iterator cend() const {
-    const T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).ptr_;
+    const T *ptr = data_.IsNull() ? nullptr : FullPtr(this->GetAllocator(), data_).get();
     return const_iterator(ptr + size_);
   }
 
@@ -1041,12 +1041,12 @@ HSHM_CROSS_FUN vector<T, AllocT>::vector(AllocT *alloc, size_t size, Args&&... a
     AllocateStorage(size);
     // Initialize elements with provided arguments
     auto fp = FullPtr(this->GetAllocator(), data_);
-    if (fp.ptr_) {
+    if (fp.get()) {
       for (size_t i = 0; i < size; ++i) {
         if constexpr (IS_SHM_CONTAINER(T)) {
-          new (fp.ptr_ + i) T(alloc, std::forward<Args>(args)...);
+          new (&fp[i]) T(alloc, std::forward<Args>(args)...);
         } else {
-          new (fp.ptr_ + i) T(std::forward<Args>(args)...);
+          new (&fp[i]) T(std::forward<Args>(args)...);
         }
       }
       size_ = size;
@@ -1104,10 +1104,10 @@ HSHM_CROSS_FUN vector<T, AllocT>::vector(AllocT *alloc, IterT first, IterT last)
   if (count > 0) {
     AllocateStorage(count);
     auto fp = FullPtr(this->GetAllocator(), data_);
-    if (fp.ptr_) {
+    if (fp.get()) {
       size_t idx = 0;
       for (IterT it = first; it != last; ++it, ++idx) {
-        new (fp.ptr_ + idx) T(*it);
+        new (&fp[idx]) T(*it);
       }
       size_ = count;
     }
@@ -1246,13 +1246,13 @@ HSHM_CROSS_FUN void vector<T, AllocT>::DestroyElements() {
   }
 
   auto fp = FullPtr(alloc, data_);
-  if (!fp.ptr_) {
+  if (!fp.get()) {
     return;
   }
 
   // Call destructor on each element
   for (size_t i = 0; i < size_; ++i) {
-    fp.ptr_[i].~T();
+    fp[i].~T();
   }
 }
 
@@ -1280,7 +1280,7 @@ HSHM_CROSS_FUN void vector<T, AllocT>::CopyElements(const T *src, size_t count) 
     return;
   }
 
-  T *dest = FullPtr(alloc, data_).ptr_;
+  T *dest = FullPtr(alloc, data_).get();
   if (!dest) {
     size_ = 0;
     return;
@@ -1323,7 +1323,7 @@ HSHM_CROSS_FUN void vector<T, AllocT>::MoveElements(T *src, size_t count) {
     return;
   }
 
-  T *dest = FullPtr(alloc, data_).ptr_;
+  T *dest = FullPtr(alloc, data_).get();
   if (!dest) {
     size_ = 0;
     return;
@@ -1368,9 +1368,9 @@ HSHM_CROSS_FUN void vector<T, AllocT>::emplace_back(Args&&... args) {
   }
 
   auto fp = FullPtr(alloc, data_);
-  if (fp.ptr_) {
+  if (fp.get()) {
     // Construct element in-place at current size position
-    new (fp.ptr_ + size_) T(std::forward<Args>(args)...);
+    new (&fp[size_]) T(std::forward<Args>(args)...);
     size_++;
   }
 }
@@ -1422,12 +1422,12 @@ vector<T, AllocT>::emplace(const_iterator pos, Args&&... args) {
   }
 
   auto fp = FullPtr(alloc, data_);
-  if (!fp.ptr_) {
+  if (!fp.get()) {
     return iterator(nullptr);
   }
 
   // Calculate index from iterator
-  size_t idx = &(*pos) - fp.ptr_;
+  size_t idx = &(*pos) - fp.get();
 
   // Check if we need to grow
   if (size_ >= capacity_) {
@@ -1438,15 +1438,15 @@ vector<T, AllocT>::emplace(const_iterator pos, Args&&... args) {
 
   // Shift elements to the right
   for (size_t i = size_; i > idx; --i) {
-    new (fp.ptr_ + i) T(std::move(fp.ptr_[i - 1]));
-    fp.ptr_[i - 1].~T();
+    new (&fp[i]) T(std::move(fp[i - 1]));
+    fp[i - 1].~T();
   }
 
   // Construct new element
-  new (fp.ptr_ + idx) T(std::forward<Args>(args)...);
+  new (&fp[idx]) T(std::forward<Args>(args)...);
   size_++;
 
-  return iterator(fp.ptr_ + idx);
+  return iterator(&fp[idx]);
 }
 
 /**
@@ -1499,25 +1499,25 @@ vector<T, AllocT>::erase(const_iterator pos) {
   }
 
   auto fp = FullPtr(alloc, data_);
-  if (!fp.ptr_) {
+  if (!fp.get()) {
     return iterator(nullptr);
   }
 
   // Calculate index from iterator
-  size_t idx = &(*pos) - fp.ptr_;
+  size_t idx = &(*pos) - fp.get();
 
   // Call destructor on the element
-  fp.ptr_[idx].~T();
+  fp[idx].~T();
 
   // Shift elements to the left
   for (size_t i = idx; i < size_ - 1; ++i) {
-    new (fp.ptr_ + i) T(std::move(fp.ptr_[i + 1]));
-    fp.ptr_[i + 1].~T();
+    new (&fp[i]) T(std::move(fp[i + 1]));
+    fp[i + 1].~T();
   }
 
   size_--;
 
-  return iterator(fp.ptr_ + idx);
+  return iterator(&fp[idx]);
 }
 
 /**
@@ -1541,33 +1541,33 @@ vector<T, AllocT>::erase(const_iterator first, const_iterator last) {
   }
 
   auto fp = FullPtr(alloc, data_);
-  if (!fp.ptr_) {
+  if (!fp.get()) {
     return iterator(nullptr);
   }
 
   // Calculate indices from iterators
-  size_t first_idx = &(*first) - fp.ptr_;
-  size_t last_idx = &(*last) - fp.ptr_;
+  size_t first_idx = &(*first) - fp.get();
+  size_t last_idx = &(*last) - fp.get();
   size_t count = last_idx - first_idx;
 
   if (count == 0) {
-    return iterator(fp.ptr_ + first_idx);
+    return iterator(&fp[first_idx]);
   }
 
   // Destroy elements in range
   for (size_t i = first_idx; i < last_idx; ++i) {
-    fp.ptr_[i].~T();
+    fp[i].~T();
   }
 
   // Shift remaining elements to the left
   for (size_t i = first_idx; i < size_ - count; ++i) {
-    new (fp.ptr_ + i) T(std::move(fp.ptr_[i + count]));
-    fp.ptr_[i + count].~T();
+    new (&fp[i]) T(std::move(fp[i + count]));
+    fp[i + count].~T();
   }
 
   size_ -= count;
 
-  return iterator(fp.ptr_ + first_idx);
+  return iterator(&fp[first_idx]);
 }
 
 /**
@@ -1618,7 +1618,7 @@ HSHM_CROSS_FUN void vector<T, AllocT>::reserve(size_t new_capacity) {
 
   // Copy elements to new storage
   if (old_size > 0 && !old_data.IsNull()) {
-    T *old_ptr = FullPtr(alloc, old_data).ptr_;
+    T *old_ptr = FullPtr(alloc, old_data).get();
     CopyElements(old_ptr, old_size);
 
     // Deallocate old storage
@@ -1666,7 +1666,7 @@ HSHM_CROSS_FUN void vector<T, AllocT>::shrink_to_fit() {
 
     // Copy elements to new storage
     if (!old_data.IsNull()) {
-      T *old_ptr = FullPtr(alloc, old_data).ptr_;
+      T *old_ptr = FullPtr(alloc, old_data).get();
       CopyElements(old_ptr, current_size);
 
       // Deallocate old storage
@@ -1711,12 +1711,12 @@ HSHM_CROSS_FUN void vector<T, AllocT>::resize(size_t new_size) {
 
     // Default-initialize new elements
     auto fp = FullPtr(alloc, data_);
-    if (fp.ptr_) {
+    if (fp.get()) {
       for (size_t i = size_; i < new_size; ++i) {
         if constexpr (IS_SHM_CONTAINER(T)) {
-          new (fp.ptr_ + i) T(alloc);
+          new (&fp[i]) T(alloc);
         } else {
-          new (fp.ptr_ + i) T();
+          new (&fp[i]) T();
         }
       }
     }
@@ -1724,9 +1724,9 @@ HSHM_CROSS_FUN void vector<T, AllocT>::resize(size_t new_size) {
   } else {
     // Need to shrink
     auto fp = FullPtr(alloc, data_);
-    if (fp.ptr_ && !std::is_trivially_destructible<T>::value) {
+    if (fp.get() && !std::is_trivially_destructible<T>::value) {
       for (size_t i = new_size; i < size_; ++i) {
-        fp.ptr_[i].~T();
+        fp[i].~T();
       }
     }
     size_ = new_size;
@@ -1763,18 +1763,18 @@ HSHM_CROSS_FUN void vector<T, AllocT>::resize(size_t new_size, const T &value) {
 
     // Fill new elements with value
     auto fp = FullPtr(alloc, data_);
-    if (fp.ptr_) {
+    if (fp.get()) {
       for (size_t i = size_; i < new_size; ++i) {
-        new (fp.ptr_ + i) T(value);
+        new (&fp[i]) T(value);
       }
     }
     size_ = new_size;
   } else {
     // Need to shrink
     auto fp = FullPtr(alloc, data_);
-    if (fp.ptr_ && !std::is_trivially_destructible<T>::value) {
+    if (fp.get() && !std::is_trivially_destructible<T>::value) {
       for (size_t i = new_size; i < size_; ++i) {
-        fp.ptr_[i].~T();
+        fp[i].~T();
       }
     }
     size_ = new_size;
@@ -1874,17 +1874,17 @@ vector<T, AllocT>::operator==(const vector &other) const {
   auto fp = FullPtr(alloc, data_);
   auto other_fp = FullPtr(other.GetAllocator(), other.data_);
 
-  if (!fp.ptr_ && !other_fp.ptr_) {
+  if (!fp.get() && !other_fp.get()) {
     return true;
   }
 
-  if (!fp.ptr_ || !other_fp.ptr_) {
+  if (!fp.get() || !other_fp.get()) {
     return false;
   }
 
   // Compare elements
   for (size_t i = 0; i < size_; ++i) {
-    if (!(fp.ptr_[i] == other_fp.ptr_[i])) {
+    if (!(fp[i] == other_fp[i])) {
       return false;
     }
   }

--- a/context-transport-primitives/include/hermes_shm/data_structures/priv/vector.h
+++ b/context-transport-primitives/include/hermes_shm/data_structures/priv/vector.h
@@ -590,9 +590,9 @@ class vector {
   HSHM_INLINE_CROSS_FUN
   void ConstructMove(size_type pos, T&& val) {
     if constexpr (kIsPod) {
-      data_.ptr_[pos] = static_cast<T&&>(val);
+      data_[pos] = static_cast<T&&>(val);
     } else {
-      new (&data_.ptr_[pos]) T(static_cast<T&&>(val));
+      new (&data_[pos]) T(static_cast<T&&>(val));
     }
   }
 
@@ -606,9 +606,9 @@ class vector {
   HSHM_INLINE_CROSS_FUN
   void ConstructCopy(size_type pos, const T& val) {
     if constexpr (kIsPod) {
-      data_.ptr_[pos] = val;
+      data_[pos] = val;
     } else {
-      new (&data_.ptr_[pos]) T(val);
+      new (&data_[pos]) T(val);
     }
   }
 
@@ -621,7 +621,7 @@ class vector {
   HSHM_INLINE_CROSS_FUN
   void Destroy(size_type pos) {
     if constexpr (!kIsPod) {
-      data_.ptr_[pos].~T();
+      data_[pos].~T();
     }
   }
 
@@ -679,9 +679,9 @@ class vector {
     reserve(count);
     for (size_type i = 0; i < count; ++i) {
       if constexpr (kIsPod) {
-        data_.ptr_[size_] = T();
+        data_[size_] = T();
       } else {
-        new (&data_.ptr_[size_]) T();
+        new (&data_[size_]) T();
       }
       ++size_;
     }
@@ -830,7 +830,7 @@ class vector {
     if (pos >= size_) {
       throw std::out_of_range("Vector index out of bounds");
     }
-    return data_.ptr_[pos];
+    return data_[pos];
   }
 
   /**
@@ -846,7 +846,7 @@ class vector {
     if (pos >= size_) {
       throw std::out_of_range("Vector index out of bounds");
     }
-    return data_.ptr_[pos];
+    return data_[pos];
   }
 
   /**
@@ -858,7 +858,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   T& operator[](size_type pos) {
-    return data_.ptr_[pos];
+    return data_[pos];
   }
 
   /**
@@ -870,7 +870,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   const T& operator[](size_type pos) const {
-    return data_.ptr_[pos];
+    return data_[pos];
   }
 
   /**
@@ -881,7 +881,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   T& front() {
-    return data_.ptr_[0];
+    return data_[0];
   }
 
   /**
@@ -892,7 +892,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   const T& front() const {
-    return data_.ptr_[0];
+    return data_[0];
   }
 
   /**
@@ -903,7 +903,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   T& back() {
-    return data_.ptr_[size_ - 1];
+    return data_[size_ - 1];
   }
 
   /**
@@ -914,7 +914,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   const T& back() const {
-    return data_.ptr_[size_ - 1];
+    return data_[size_ - 1];
   }
 
   /**
@@ -925,7 +925,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   T* data() {
-    return data_.ptr_;
+    return data_.get();
   }
 
   /**
@@ -936,7 +936,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   const T* data() const {
-    return data_.ptr_;
+    return data_.get();
   }
 
   /**
@@ -947,7 +947,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   iterator begin() {
-    return iterator(data_.ptr_);
+    return iterator(data_.get());
   }
 
   /**
@@ -958,7 +958,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   const_iterator begin() const {
-    return const_iterator(data_.ptr_);
+    return const_iterator(data_.get());
   }
 
   /**
@@ -969,7 +969,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   const_iterator cbegin() const {
-    return const_iterator(data_.ptr_);
+    return const_iterator(data_.get());
   }
 
   /**
@@ -980,7 +980,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   iterator end() {
-    return iterator(data_.ptr_ + size_);
+    return iterator(data_.get() + size_);
   }
 
   /**
@@ -991,7 +991,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   const_iterator end() const {
-    return const_iterator(data_.ptr_ + size_);
+    return const_iterator(data_.get() + size_);
   }
 
   /**
@@ -1002,7 +1002,7 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   const_iterator cend() const {
-    return const_iterator(data_.ptr_ + size_);
+    return const_iterator(data_.get() + size_);
   }
 
   /**
@@ -1112,10 +1112,10 @@ class vector {
 
     if (!data_.IsNull()) {
       if constexpr (kIsPod) {
-        std::memcpy(new_data.ptr_, data_.ptr_, size_ * sizeof(T));
+        std::memcpy(new_data.get(), data_.get(), size_ * sizeof(T));
       } else {
         for (size_type i = 0; i < size_; ++i) {
-          new (&new_data.ptr_[i]) T(std::move(data_.ptr_[i]));
+          new (&new_data[i]) T(std::move(data_[i]));
           Destroy(i);
         }
       }
@@ -1144,10 +1144,10 @@ class vector {
         auto new_data = alloc_->template AllocateObjs<T>(size_);
 
         if constexpr (kIsPod) {
-          std::memcpy(new_data.ptr_, data_.ptr_, size_ * sizeof(T));
+          std::memcpy(new_data.get(), data_.get(), size_ * sizeof(T));
         } else {
           for (size_type i = 0; i < size_; ++i) {
-            new (&new_data.ptr_[i]) T(std::move(data_.ptr_[i]));
+            new (&new_data[i]) T(std::move(data_[i]));
             Destroy(i);
           }
         }
@@ -1217,24 +1217,24 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   iterator insert(const_iterator pos, const T& val) {
-    size_type idx = pos.get() - data_.ptr_;
+    size_type idx = pos.get() - data_.get();
     if (size_ >= capacity_) {
       Grow(size_ + 1);
     }
 
     if constexpr (kIsPod) {
-      std::memmove(&data_.ptr_[idx + 1], &data_.ptr_[idx], (size_ - idx) * sizeof(T));
-      data_.ptr_[idx] = val;
+      std::memmove(&data_[idx + 1], &data_[idx], (size_ - idx) * sizeof(T));
+      data_[idx] = val;
     } else {
       for (size_type i = size_; i > idx; --i) {
-        new (&data_.ptr_[i]) T(std::move(data_.ptr_[i - 1]));
+        new (&data_[i]) T(std::move(data_[i - 1]));
         Destroy(i - 1);
       }
-      new (&data_.ptr_[idx]) T(val);
+      new (&data_[idx]) T(val);
     }
 
     ++size_;
-    return iterator(&data_.ptr_[idx]);
+    return iterator(&data_[idx]);
   }
 
   /**
@@ -1247,24 +1247,24 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   iterator insert(const_iterator pos, T&& val) {
-    size_type idx = pos.get() - data_.ptr_;
+    size_type idx = pos.get() - data_.get();
     if (size_ >= capacity_) {
       Grow(size_ + 1);
     }
 
     if constexpr (kIsPod) {
-      std::memmove(&data_.ptr_[idx + 1], &data_.ptr_[idx], (size_ - idx) * sizeof(T));
-      data_.ptr_[idx] = std::move(val);
+      std::memmove(&data_[idx + 1], &data_[idx], (size_ - idx) * sizeof(T));
+      data_[idx] = std::move(val);
     } else {
       for (size_type i = size_; i > idx; --i) {
-        new (&data_.ptr_[i]) T(std::move(data_.ptr_[i - 1]));
+        new (&data_[i]) T(std::move(data_[i - 1]));
         Destroy(i - 1);
       }
-      new (&data_.ptr_[idx]) T(std::move(val));
+      new (&data_[idx]) T(std::move(val));
     }
 
     ++size_;
-    return iterator(&data_.ptr_[idx]);
+    return iterator(&data_[idx]);
   }
 
   /**
@@ -1279,7 +1279,7 @@ class vector {
   HSHM_INLINE_CROSS_FUN
   iterator insert(const_iterator pos, const_iterator first,
                   const_iterator last) {
-    size_type idx = pos.get() - data_.ptr_;
+    size_type idx = pos.get() - data_.get();
     size_type count = last.get() - first.get();
 
     if (size_ + count > capacity_) {
@@ -1287,21 +1287,21 @@ class vector {
     }
 
     if constexpr (kIsPod) {
-      std::memmove(&data_.ptr_[idx + count], &data_.ptr_[idx], (size_ - idx) * sizeof(T));
-      std::memcpy(&data_.ptr_[idx], first.get(), count * sizeof(T));
+      std::memmove(&data_[idx + count], &data_[idx], (size_ - idx) * sizeof(T));
+      std::memcpy(&data_[idx], first.get(), count * sizeof(T));
     } else {
       for (size_type i = size_ + count - 1; i >= idx + count; --i) {
-        new (&data_.ptr_[i]) T(std::move(data_.ptr_[i - count]));
+        new (&data_[i]) T(std::move(data_[i - count]));
         Destroy(i - count);
       }
       size_type src_idx = 0;
       for (size_type i = idx; i < idx + count; ++i, ++src_idx) {
-        new (&data_.ptr_[i]) T(*(first.get() + src_idx));
+        new (&data_[i]) T(*(first.get() + src_idx));
       }
     }
 
     size_ += count;
-    return iterator(&data_.ptr_[idx]);
+    return iterator(&data_[idx]);
   }
 
   /**
@@ -1313,20 +1313,20 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   iterator erase(const_iterator pos) {
-    size_type idx = pos.get() - data_.ptr_;
+    size_type idx = pos.get() - data_.get();
 
     if constexpr (kIsPod) {
-      std::memmove(&data_.ptr_[idx], &data_.ptr_[idx + 1], (size_ - idx - 1) * sizeof(T));
+      std::memmove(&data_[idx], &data_[idx + 1], (size_ - idx - 1) * sizeof(T));
     } else {
       Destroy(idx);
       for (size_type i = idx; i < size_ - 1; ++i) {
-        new (&data_.ptr_[i]) T(std::move(data_.ptr_[i + 1]));
+        new (&data_[i]) T(std::move(data_[i + 1]));
         Destroy(i + 1);
       }
     }
 
     --size_;
-    return iterator(&data_.ptr_[idx]);
+    return iterator(&data_[idx]);
   }
 
   /**
@@ -1339,23 +1339,23 @@ class vector {
    */
   HSHM_INLINE_CROSS_FUN
   iterator erase(const_iterator first, const_iterator last) {
-    size_type first_idx = first.get() - data_.ptr_;
-    size_type last_idx = last.get() - data_.ptr_;
+    size_type first_idx = first.get() - data_.get();
+    size_type last_idx = last.get() - data_.get();
     size_type count = last_idx - first_idx;
 
     if constexpr (kIsPod) {
-      std::memmove(&data_.ptr_[first_idx], &data_.ptr_[last_idx],
+      std::memmove(&data_[first_idx], &data_[last_idx],
                    (size_ - last_idx) * sizeof(T));
     } else {
       DestroyRange(first_idx, last_idx);
       for (size_type i = first_idx; i < size_ - count; ++i) {
-        new (&data_.ptr_[i]) T(std::move(data_.ptr_[i + count]));
+        new (&data_[i]) T(std::move(data_[i + count]));
         Destroy(i + count);
       }
     }
 
     size_ -= count;
-    return iterator(&data_.ptr_[first_idx]);
+    return iterator(&data_[first_idx]);
   }
 
   /**
@@ -1372,9 +1372,9 @@ class vector {
       }
       for (size_type i = size_; i < new_size; ++i) {
         if constexpr (kIsPod) {
-          data_.ptr_[i] = T();
+          data_[i] = T();
         } else {
-          new (&data_.ptr_[i]) T();
+          new (&data_[i]) T();
         }
       }
       size_ = new_size;

--- a/context-transport-primitives/include/hermes_shm/lightbeam/nixl_transport.h
+++ b/context-transport-primitives/include/hermes_shm/lightbeam/nixl_transport.h
@@ -275,7 +275,7 @@ class NixlTransport : public Transport {
       }
       nixl_xfer_dlist_t src(DRAM_SEG);
       src.addDesc(nixlBasicDesc(
-          reinterpret_cast<uintptr_t>(b.data.ptr_), b.size, /*devId=*/0));
+          reinterpret_cast<uintptr_t>(b.data.get()), b.size, /*devId=*/0));
 
       nixl_xfer_dlist_t dst(FILE_SEG);
       dst.addDesc(nixlBasicDesc(
@@ -335,7 +335,7 @@ class NixlTransport : public Transport {
         continue;
       }
       Bulk& rb = meta.recv[i];
-      std::memcpy(rb.data.ptr_, sb.data.ptr_, sb.size);
+      std::memcpy(rb.data.get(), sb.data.get(), sb.size);
     }
     return 0;
   }

--- a/context-transport-primitives/include/hermes_shm/lightbeam/shm_transport.h
+++ b/context-transport-primitives/include/hermes_shm/lightbeam/shm_transport.h
@@ -282,6 +282,7 @@ class ShmTransport
 #endif
   }
 
+ public:
   // SPSC ring buffer write (system-scope atomics for GPU/CPU visibility)
   HSHM_CROSS_FUN
   static void WriteTransfer(const char* data, size_t size, const LbmContext& ctx) {

--- a/context-transport-primitives/include/hermes_shm/lightbeam/shm_transport.h
+++ b/context-transport-primitives/include/hermes_shm/lightbeam/shm_transport.h
@@ -100,9 +100,9 @@ class ShmTransport
 
   void ClearRecvHandles(LbmMeta<>& meta) {
     for (auto& bulk : meta.recv) {
-      if (bulk.data.ptr_ && !bulk.desc) {
-        std::free(bulk.data.ptr_);
-        bulk.data.ptr_ = nullptr;
+      if (bulk.data.get() && !bulk.desc) {
+        std::free(bulk.data.get());
+        bulk.data.set_ptr(nullptr);
       }
     }
   }
@@ -150,7 +150,7 @@ class ShmTransport
             sizeof(meta.send[i].data.shm_), ctx);
         if (meta.send[i].data.shm_.alloc_id_.IsNull()) {
           // Private memory — also send full data bytes
-          WriteTransfer(meta.send[i].data.ptr_, meta.send[i].size, ctx);
+          WriteTransfer(meta.send[i].data.get(), meta.send[i].size, ctx);
         }
       }
     }
@@ -216,7 +216,7 @@ class ShmTransport
         hipc::ShmPtr<char> shm;
         ReadTransfer(reinterpret_cast<char*>(&shm), sizeof(shm), ctx);
         meta.recv[i].data.shm_ = shm;
-        meta.recv[i].data.ptr_ = nullptr;
+        meta.recv[i].data.set_ptr(nullptr);
       } else if (meta.recv[i].flags.Any(BULK_XFER)) {
         // BULK_XFER: Read ShmPtr first, then data if private memory
         hipc::ShmPtr<char> shm;
@@ -225,10 +225,10 @@ class ShmTransport
         if (!shm.alloc_id_.IsNull()) {
           // Shared memory — ShmPtr passthrough, no data transfer
           meta.recv[i].data.shm_ = shm;
-          meta.recv[i].data.ptr_ = nullptr;
+          meta.recv[i].data.set_ptr(nullptr);
         } else {
           // Private memory — read full data bytes
-          char* buf = meta.recv[i].data.ptr_;
+          char* buf = meta.recv[i].data.get();
           bool allocated = false;
           if (!buf) {
 #if HSHM_IS_HOST
@@ -236,7 +236,7 @@ class ShmTransport
 #else
             auto alloc_ptr =
                 meta.alloc_->template AllocateObjs<char>(meta.recv[i].size);
-            buf = alloc_ptr.ptr_;
+            buf = alloc_ptr.get();
 #endif
             allocated = true;
           }
@@ -244,7 +244,7 @@ class ShmTransport
           ReadTransfer(buf, meta.recv[i].size, ctx);
 
           if (allocated) {
-            meta.recv[i].data.ptr_ = buf;
+            meta.recv[i].data.set_ptr(buf);
             meta.recv[i].data.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
             meta.recv[i].data.shm_.off_ = reinterpret_cast<size_t>(buf);
           }

--- a/context-transport-primitives/include/hermes_shm/lightbeam/socket_transport.h
+++ b/context-transport-primitives/include/hermes_shm/lightbeam/socket_transport.h
@@ -183,9 +183,9 @@ class SocketTransport : public Transport {
 
   void ClearRecvHandles(LbmMeta<>& meta) {
     for (auto& bulk : meta.recv) {
-      if (bulk.data.ptr_) {
-        std::free(bulk.data.ptr_);
-        bulk.data.ptr_ = nullptr;
+      if (bulk.data.get()) {
+        std::free(bulk.data.get());
+        bulk.data.set_ptr(nullptr);
       }
     }
   }
@@ -282,7 +282,7 @@ class SocketTransport : public Transport {
 
     for (size_t i = 0; i < meta.send.size(); ++i) {
       if (!meta.send[i].flags.Any(BULK_XFER)) continue;
-      iov[idx].base = meta.send[i].data.ptr_;
+      iov[idx].base = meta.send[i].data.get();
       iov[idx].len = meta.send[i].size;
       idx++;
     }
@@ -409,7 +409,7 @@ class SocketTransport : public Transport {
     for (size_t i = 0; i < meta.recv.size(); ++i) {
       if (!meta.recv[i].flags.Any(BULK_XFER)) continue;
 
-      char* buf = meta.recv[i].data.ptr_;
+      char* buf = meta.recv[i].data.get();
       bool allocated = false;
       if (!buf) {
         buf = static_cast<char*>(std::malloc(meta.recv[i].size));
@@ -432,7 +432,7 @@ class SocketTransport : public Transport {
       }
 
       if (allocated) {
-        meta.recv[i].data.ptr_ = buf;
+        meta.recv[i].data.set_ptr(buf);
         meta.recv[i].data.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
         meta.recv[i].data.shm_.off_ = reinterpret_cast<size_t>(buf);
       }

--- a/context-transport-primitives/include/hermes_shm/lightbeam/zmq_transport.h
+++ b/context-transport-primitives/include/hermes_shm/lightbeam/zmq_transport.h
@@ -330,7 +330,7 @@ class ZeroMqTransport : public Transport {
       }
 
       zmq_msg_t msg;
-      zmq_msg_init_data(&msg, meta.send[i].data.ptr_, meta.send[i].size,
+      zmq_msg_init_data(&msg, meta.send[i].data.get(), meta.send[i].size,
                          zmq_noop_free, nullptr);
       rc = zmq_msg_send(&msg, socket_, flags);
       if (rc == -1) {
@@ -443,7 +443,7 @@ class ZeroMqTransport : public Transport {
       recv_count++;
       int flags = (recv_count < meta.send_bulks) ? ZMQ_RCVMORE : 0;
 
-      if (meta.recv[i].data.ptr_) {
+      if (meta.recv[i].data.get()) {
         zmq_msg_t zmq_msg;
         zmq_msg_init(&zmq_msg);
         int rc = zmq_msg_recv(&zmq_msg, socket_, flags);
@@ -452,7 +452,7 @@ class ZeroMqTransport : public Transport {
           zmq_msg_close(&zmq_msg);
           return err;
         }
-        memcpy(meta.recv[i].data.ptr_,
+        memcpy(meta.recv[i].data.get(),
                zmq_msg_data(&zmq_msg), meta.recv[i].size);
         zmq_msg_close(&zmq_msg);
       } else {
@@ -466,7 +466,7 @@ class ZeroMqTransport : public Transport {
           return err;
         }
         char *zmq_data = static_cast<char*>(zmq_msg_data(zmq_msg));
-        meta.recv[i].data.ptr_ = zmq_data;
+        meta.recv[i].data.set_ptr(zmq_data);
         meta.recv[i].data.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
         meta.recv[i].data.shm_.off_ = reinterpret_cast<size_t>(zmq_data);
         meta.recv[i].desc = zmq_msg;

--- a/context-transport-primitives/include/hermes_shm/memory/allocator/allocator.h
+++ b/context-transport-primitives/include/hermes_shm/memory/allocator/allocator.h
@@ -811,7 +811,7 @@ public:
 
   /** Ostream operator */
   friend std::ostream &operator<<(std::ostream &os, const FullPtr &ptr) {
-    os << (void *)ptr.ptr_ << " " << ptr.shm_;
+    os << (void *)ptr.get() << " " << ptr.shm_;
     return os;
   }
 
@@ -840,7 +840,7 @@ public:
       shm_.off_ = shm.load();
       shm_.alloc_id_ = alloc->GetId();
       char *backend_data = alloc->GetBackendData();
-      ptr_ = reinterpret_cast<T *>(backend_data + shm.load());
+      set_ptr(reinterpret_cast<T*>(backend_data + shm.load()));
     } else {
       SetNull();
     }
@@ -851,7 +851,7 @@ public:
   HSHM_CROSS_FUN explicit FullPtr(AllocT *alloc, size_t offset) {
     shm_.off_ = offset;
     shm_.alloc_id_ = alloc->GetId();
-    ptr_ = reinterpret_cast<T *>(alloc->GetBackendData() + offset);
+    set_ptr(reinterpret_cast<T*>(alloc->GetBackendData() + offset));
   }
 
   /** Shared half + alloc constructor for ShmPtr */
@@ -861,7 +861,7 @@ public:
     if (alloc->ContainsPtr(shm)) {
       shm_.off_ = shm.off_.load();
       shm_.alloc_id_ = shm.alloc_id_;
-      ptr_ = reinterpret_cast<T *>(alloc->GetBackendData() + shm.off_.load());
+      set_ptr(reinterpret_cast<T*>(alloc->GetBackendData() + shm.off_.load()));
     } else {
       SetNull();
     }
@@ -874,7 +874,7 @@ public:
       shm_.off_ = (size_t)(reinterpret_cast<const char *>(ptr) -
                            alloc->GetBackendData());
       shm_.alloc_id_ = alloc->GetId();
-      ptr_ = const_cast<T *>(ptr);
+      set_ptr(const_cast<T *>(ptr));
     } else {
       SetNull();
     }
@@ -882,18 +882,18 @@ public:
 
   /** Copy constructor */
   HSHM_INLINE_CROSS_FUN FullPtr(const FullPtr &other)
-      : ptr_(other.ptr_), shm_(other.shm_) {}
+      : ptr_(other.get()), shm_(other.shm_) {}
 
   /** Move constructor */
   HSHM_INLINE_CROSS_FUN FullPtr(FullPtr &&other) noexcept
-      : ptr_(other.ptr_), shm_(other.shm_) {
+      : ptr_(other.get()), shm_(other.shm_) {
     other.SetNull();
   }
 
   /** Copy assignment operator */
   HSHM_INLINE_CROSS_FUN FullPtr &operator=(const FullPtr &other) {
     if (this != &other) {
-      ptr_ = other.ptr_;
+      set_ptr(other.get());
       shm_ = other.shm_;
     }
     return *this;
@@ -902,7 +902,7 @@ public:
   /** Move assignment operator */
   HSHM_INLINE_CROSS_FUN FullPtr &operator=(FullPtr &&other) {
     if (this != &other) {
-      ptr_ = other.ptr_;
+      set_ptr(other.get());
       shm_ = other.shm_;
       other.SetNull();
     }
@@ -947,48 +947,48 @@ public:
 
   /** Equality operator */
   HSHM_INLINE_CROSS_FUN bool operator==(const FullPtr &other) const {
-    return ptr_ == other.ptr_ && shm_ == other.shm_;
+    return get() == other.get() && shm_ == other.shm_;
   }
 
   /** Inequality operator */
   HSHM_INLINE_CROSS_FUN bool operator!=(const FullPtr &other) const {
-    return ptr_ != other.ptr_ || shm_ != other.shm_;
+    return get() != other.get() || shm_ != other.shm_;
   }
 
   /** Addition operator */
   HSHM_INLINE_CROSS_FUN FullPtr operator+(size_t size) const {
-    return FullPtr(ptr_ + size, shm_ + size);
+    return FullPtr(get() + size, shm_ + size);
   }
 
   /** Subtraction operator */
   HSHM_INLINE_CROSS_FUN FullPtr operator-(size_t size) const {
-    return FullPtr(ptr_ - size, shm_ - size);
+    return FullPtr(get() - size, shm_ - size);
   }
 
   /** Addition assignment operator */
   HSHM_INLINE_CROSS_FUN FullPtr &operator+=(size_t size) {
-    ptr_ += size;
+    set_ptr(get() + size);
     shm_ += size;
     return *this;
   }
 
   /** Subtraction assignment operator */
   HSHM_INLINE_CROSS_FUN FullPtr &operator-=(size_t size) {
-    ptr_ -= size;
+    set_ptr(get() - size);
     shm_ -= size;
     return *this;
   }
 
   /** Increment operator (pre) */
   HSHM_INLINE_CROSS_FUN FullPtr &operator++() {
-    ptr_++;
+    set_ptr(get() + 1);
     shm_++;
     return *this;
   }
 
   /** Decrement operator (pre) */
   HSHM_INLINE_CROSS_FUN FullPtr &operator--() {
-    ptr_--;
+    set_ptr(get() - 1);
     shm_--;
     return *this;
   }
@@ -1009,7 +1009,7 @@ public:
 
   /** Check if null */
   HSHM_INLINE_CROSS_FUN bool IsNull() const {
-    return ptr_ == nullptr || shm_.IsNull();
+    return get() == nullptr || shm_.IsNull();
   }
 
   /** Validate that ptr_ and shm_ are consistent with allocator backend
@@ -1023,7 +1023,7 @@ public:
       return true;  // Null pointers are always valid
     }
     size_t calculated_offset =
-        reinterpret_cast<size_t>(ptr_) -
+        reinterpret_cast<size_t>(get()) -
         reinterpret_cast<size_t>(alloc->GetBackendData());
     size_t stored_offset = shm_.off_.load();
     return calculated_offset == stored_offset;
@@ -1036,7 +1036,7 @@ public:
 
   /** Set to null */
   HSHM_INLINE_CROSS_FUN void SetNull() {
-    ptr_ = nullptr;
+    set_ptr(nullptr);
     shm_.SetNull();
   }
 
@@ -1066,7 +1066,7 @@ public:
 
   /** Mark first bit */
   HSHM_INLINE_CROSS_FUN FullPtr Mark() const {
-    return FullPtr(ptr_, shm_.Mark());
+    return FullPtr(get(), shm_.Mark());
   }
 
   /** Check if first bit is marked */
@@ -1074,7 +1074,7 @@ public:
 
   /** Unmark first bit */
   HSHM_INLINE_CROSS_FUN FullPtr Unmark() const {
-    return FullPtr(ptr_, shm_.Unmark());
+    return FullPtr(get(), shm_.Unmark());
   }
 
   /** Set to 0 */
@@ -1268,7 +1268,7 @@ class BaseAllocator : public CoreAllocT {
     size_t total_size = sizeof(T) + size;
     auto region = Allocate<T>(total_size);
     if (!region.IsNull()) {
-      new (region.ptr_) T();  // Construct T at the region start
+      new (region.get()) T();  // Construct T at the region start
     }
     return region;
   }
@@ -1277,7 +1277,7 @@ class BaseAllocator : public CoreAllocT {
   template <typename T, typename... Args>
   HSHM_INLINE_CROSS_FUN FullPtr<T> NewObjs(size_t count, Args &&...args) {
     auto alloc_result = AllocateObjs<T>(count);
-    ConstructObjs<T>(alloc_result.ptr_, 0, count, std::forward<Args>(args)...);
+    ConstructObjs<T>(alloc_result.get(), 0, count, std::forward<Args>(args)...);
     return alloc_result;
   }
 
@@ -1299,16 +1299,16 @@ class BaseAllocator : public CoreAllocT {
   HSHM_INLINE_CROSS_FUN FullPtr<T> ReallocateObjs(FullPtr<T> &p,
                                                   size_t new_count) {
     auto *alloc = this;
-    FullPtr<void> old_full_ptr(alloc, reinterpret_cast<void *>(p.ptr_));
+    FullPtr<void> old_full_ptr(alloc, reinterpret_cast<void *>(p.get()));
     auto new_full_ptr = Reallocate<void>(old_full_ptr, new_count * sizeof(T));
-    p = FullPtr<T>(alloc, reinterpret_cast<T *>(new_full_ptr.ptr_));
+    p = FullPtr<T>(alloc, reinterpret_cast<T *>(new_full_ptr.get()));
     return p;
   }
 
   /** Free a region */
   template <typename T>
   HSHM_INLINE_CROSS_FUN void FreeRegion(const FullPtr<T> &p) {
-    DestructObj(p.ptr_);
+    DestructObj(p.get());
     FreeOffsetNoNullCheck(p.shm_.off_.template Cast<void>());
   }
 
@@ -1317,9 +1317,9 @@ class BaseAllocator : public CoreAllocT {
    * */
   template <typename T>
   HSHM_INLINE_CROSS_FUN void DelObjs(FullPtr<T> &p, size_t count) {
-    DestructObjs<T>(p.ptr_, count);
+    DestructObjs<T>(p.get(), count);
     auto *alloc = this;
-    FullPtr<void> void_ptr(alloc, reinterpret_cast<void *>(p.ptr_));
+    FullPtr<void> void_ptr(alloc, reinterpret_cast<void *>(p.get()));
     Free<void>(void_ptr);
   }
 

--- a/context-transport-primitives/include/hermes_shm/memory/allocator/allocator.h
+++ b/context-transport-primitives/include/hermes_shm/memory/allocator/allocator.h
@@ -36,6 +36,8 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
+#include <new>
 #include <type_traits>
 
 #include "hermes_shm/constants/macros.h"
@@ -783,7 +785,9 @@ using AtomicShmPtr = ShmPtrBase<T, true>;
 template <typename T = char, bool ATOMIC = false>
 struct FullPtr : public ShmPointer {
   typedef ShmPtrBase<T, ATOMIC> PointerT;
+private:
   T *ptr_;
+public:
   PointerT shm_;
 
   /** Serialize hipc::FullPtr */
@@ -905,12 +909,32 @@ struct FullPtr : public ShmPointer {
     return *this;
   }
 
+  /** Set raw pointer (for internal framework use) */
+  HSHM_INLINE_CROSS_FUN void set_ptr(T *p) { ptr_ = p; }
+
+  /** Get raw pointer with launder barrier (use at every dereference) */
+  HSHM_INLINE_CROSS_FUN T* get() const {
+    if constexpr (std::is_void_v<T>) {
+      return ptr_;
+    } else {
+      return std::launder(ptr_);
+    }
+  }
+
+  /** Overload subscript */
+  template <typename U = T>
+  HSHM_INLINE_CROSS_FUN
+      typename std::enable_if<!std::is_void<U>::value, U &>::type
+      operator[](size_t i) const {
+    return std::launder(ptr_)[i];
+  }
+
   /** Overload arrow */
   template <typename U = T>
   HSHM_INLINE_CROSS_FUN
       typename std::enable_if<!std::is_void<U>::value, U *>::type
       operator->() const {
-    return ptr_;
+    return std::launder(ptr_);
   }
 
   /** Overload dereference */
@@ -918,7 +942,7 @@ struct FullPtr : public ShmPointer {
   HSHM_INLINE_CROSS_FUN
       typename std::enable_if<!std::is_void<U>::value, U &>::type
       operator*() const {
-    return *ptr_;
+    return *std::launder(ptr_);
   }
 
   /** Equality operator */

--- a/context-transport-primitives/include/hermes_shm/memory/allocator/buddy_allocator.h
+++ b/context-transport-primitives/include/hermes_shm/memory/allocator/buddy_allocator.h
@@ -230,7 +230,7 @@ class _BuddyAllocator : public Allocator {
     // Get the BuddyPage header (offset points after header)
     size_t page_offset = offset.load() - sizeof(BuddyPage);
     hipc::FullPtr<BuddyPage> page(this, OffsetPtr<BuddyPage>(page_offset));
-    size_t old_size = page.ptr_->size_;  // Size without header
+    size_t old_size = page.get()->size_;  // Size without header
 
     // If new size fits in existing allocation, reuse it
     if (new_size <= old_size) {
@@ -246,7 +246,7 @@ class _BuddyAllocator : public Allocator {
     // Copy old data to new location
     hipc::FullPtr<char> old_data(this, OffsetPtr<char>(offset.load()));
     hipc::FullPtr<char> new_data(this, OffsetPtr<char>(new_offset.load()));
-    memcpy(new_data.ptr_, old_data.ptr_, old_size);
+    memcpy(new_data.get(), old_data.get(), old_size);
 
     // Free old allocation
     FreeOffset(offset);
@@ -275,7 +275,7 @@ class _BuddyAllocator : public Allocator {
     // Get the BuddyPage header (offset points after header)
     size_t page_offset = offset.load() - sizeof(BuddyPage);
     hipc::FullPtr<BuddyPage> page(this, OffsetPtr<BuddyPage>(page_offset));
-    size_t data_size = page.ptr_->size_;  // Size without header
+    size_t data_size = page.get()->size_;  // Size without header
 
     // Determine which free list to add to based on data size
     if (data_size <= kSmallThreshold) {
@@ -284,7 +284,7 @@ class _BuddyAllocator : public Allocator {
 
       // Initialize BuddyPage as a free list node
       hipc::FullPtr<BuddyPage> free_page(this, OffsetPtr<BuddyPage>(page_offset));
-      free_page.ptr_->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
+      free_page.get()->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
       // size_ already contains data_size from the allocation, keep it as-is
 
       // Add to free list - BuddyPage inherits from slist_node
@@ -296,7 +296,7 @@ class _BuddyAllocator : public Allocator {
 
       // Initialize BuddyPage as a free list node
       hipc::FullPtr<BuddyPage> free_page(this, OffsetPtr<BuddyPage>(page_offset));
-      free_page.ptr_->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
+      free_page.get()->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
       // size_ already contains data_size from the allocation, keep it as-is
 
       // Add to free list - BuddyPage inherits from slist_node
@@ -396,7 +396,7 @@ class _BuddyAllocator : public Allocator {
         size_t found_offset = FindFirstFit(i, total_size);
         if (found_offset != 0) {
         hipc::FullPtr<FreeLargeBuddyPage> free_page(this, OffsetPtr<FreeLargeBuddyPage>(found_offset));
-        size_t page_data_size = free_page.ptr_->size_;
+        size_t page_data_size = free_page.get()->size_;
         size_t page_total_size = page_data_size + sizeof(BuddyPage);
 
         // If there's a large enough remainder, add it back to appropriate list
@@ -440,7 +440,7 @@ class _BuddyAllocator : public Allocator {
           this, OffsetPtr<FreeLargeBuddyPage>(it.GetCurrent().load()));
 
       // Check if this page size (including header) is large enough
-      size_t page_total_size = free_page.ptr_->size_ + sizeof(BuddyPage);
+      size_t page_total_size = free_page.get()->size_ + sizeof(BuddyPage);
       if (page_total_size >= required_size) {
         // Found a fit - capture offset before removing from list
         size_t offset = it.GetCurrent().load();
@@ -480,7 +480,7 @@ class _BuddyAllocator : public Allocator {
         if (offset != 0) {
           // Read original page size before overwriting with new arena bounds
           FullPtr<BuddyPage> page(this, OffsetPtr<BuddyPage>(offset));
-          size_t page_total_size = page.ptr_->size_ + sizeof(BuddyPage);
+          size_t page_total_size = page.get()->size_ + sizeof(BuddyPage);
 
           small_arena_.Init(offset, offset + arena_size);
 
@@ -529,8 +529,8 @@ class _BuddyAllocator : public Allocator {
         if (free_page.IsNull()) {
           break;
         }
-        free_page.ptr_->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
-        free_page.ptr_->size_ = page_data_size;  // Data size excluding header
+        free_page.get()->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
+        free_page.get()->size_ = page_data_size;  // Data size excluding header
 
         // Add to free list
         FullPtr<BuddyPage> node_ptr(this, OffsetPtr<BuddyPage>(remaining_offset));
@@ -564,8 +564,8 @@ class _BuddyAllocator : public Allocator {
       size_t rem_list_idx = GetSmallPageListIndexForFree(data_size);
 
       hipc::FullPtr<BuddyPage> remainder(this, OffsetPtr<BuddyPage>(page_offset));
-      remainder.ptr_->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
-      remainder.ptr_->size_ = data_size;  // Data size excluding header
+      remainder->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
+      remainder->size_ = data_size;  // Data size excluding header
 
       FullPtr<BuddyPage> rem_node(this, OffsetPtr<BuddyPage>(page_offset));
       small_pages_[rem_list_idx].emplace(this, rem_node);
@@ -574,8 +574,8 @@ class _BuddyAllocator : public Allocator {
       size_t rem_list_idx = GetLargePageListIndexForFree(data_size);
 
       hipc::FullPtr<BuddyPage> remainder(this, OffsetPtr<BuddyPage>(page_offset));
-      remainder.ptr_->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
-      remainder.ptr_->size_ = data_size;  // Data size excluding header
+      remainder->next_ = OffsetPtr<>::GetNull();  // Initialize slist_node
+      remainder->size_ = data_size;  // Data size excluding header
 
       FullPtr<BuddyPage> rem_node(this, OffsetPtr<BuddyPage>(page_offset));
       large_pages_[rem_list_idx].emplace(this, rem_node);
@@ -591,7 +591,7 @@ class _BuddyAllocator : public Allocator {
    */
   HSHM_CROSS_FUN OffsetPtr<> FinalizeAllocation(size_t page_offset, size_t user_size) {
     hipc::FullPtr<BuddyPage> page(this, OffsetPtr<BuddyPage>(page_offset));
-    page.ptr_->size_ = user_size;  // Store size without header
+    page->size_ = user_size;  // Store size without header
 
     size_t result_offset = page_offset + sizeof(BuddyPage);
     return OffsetPtr<>(result_offset);

--- a/context-transport-primitives/include/hermes_shm/memory/allocator/malloc_allocator.h
+++ b/context-transport-primitives/include/hermes_shm/memory/allocator/malloc_allocator.h
@@ -176,6 +176,13 @@ class _MallocAllocator : public Allocator {
     MallocPage *page = reinterpret_cast<MallocPage*>(
         reinterpret_cast<char*>(user_ptr) - sizeof(MallocPage));
 
+    // Safety guard: only free if this is our allocation.
+    // Non-HSHM pointers (e.g. ZMQ zero-copy recv buffers) won't have the
+    // magic header, so we skip them rather than corrupting the heap.
+    if (page->magic_ != MallocPage::MAGIC) {
+      return;
+    }
+
 #ifdef HSHM_ALLOC_TRACK_SIZE
     size_t size = page->page_size_ - sizeof(MallocPage);
     total_alloc_ -= size;

--- a/context-transport-primitives/include/hermes_shm/memory/allocator/mp_allocator.h
+++ b/context-transport-primitives/include/hermes_shm/memory/allocator/mp_allocator.h
@@ -388,9 +388,9 @@ class _MultiProcessAllocator : public Allocator {
     }
 
     // Initialize ThreadBlock with the region size and store in TLS
-    tblock_ptr.ptr_->shm_init(GetBackend(), thread_unit_, pblock->tid_count_++);
-    HSHM_THREAD_MODEL->SetTls<void>(pblock->tblock_key_, reinterpret_cast<void*>(tblock_ptr.ptr_));
-    return tblock_ptr.ptr_;
+    tblock_ptr.get()->shm_init(GetBackend(), thread_unit_, pblock->tid_count_++);
+    HSHM_THREAD_MODEL->SetTls<void>(pblock->tblock_key_, reinterpret_cast<void*>(tblock_ptr.get()));
+    return tblock_ptr.get();
   }
 
   /**
@@ -470,7 +470,7 @@ class _MultiProcessAllocator : public Allocator {
       auto node = free_procs_.pop(&alloc_);
       if (!node.IsNull()) {
         pblock_ptr = node.Cast<ProcessBlock>();
-        pid = pblock_ptr.ptr_->pid_;  // Get the pid from the existing block
+        pid = pblock_ptr.get()->pid_;  // Get the pid from the existing block
       }
     }
 
@@ -486,7 +486,7 @@ class _MultiProcessAllocator : public Allocator {
       }
 
       // Step 3d: Call shm_init on the ProcessBlock with the region size
-      if (!pblock_ptr.ptr_->shm_init(GetBackend(), process_unit_, pid)) {
+      if (!pblock_ptr.get()->shm_init(GetBackend(), process_unit_, pid)) {
         alloc_.Free(pblock_ptr);  // Free the SINGLE allocation on error
         return FullPtr<ProcessBlock>::GetNull();
       }
@@ -496,7 +496,7 @@ class _MultiProcessAllocator : public Allocator {
     alloc_procs_.emplace(&alloc_, pblock_ptr);
 
     // Step 5: Call SetProcessBlock(pblock)
-    SetProcessBlock(pblock_ptr.ptr_);
+    SetProcessBlock(pblock_ptr.get());
 
     // Step 6: Return the ProcessBlock FullPtr
     return pblock_ptr;

--- a/context-transport-primitives/test/unit/allocator/allocator_test.h
+++ b/context-transport-primitives/test/unit/allocator/allocator_test.h
@@ -76,7 +76,7 @@ class AllocatorTest {
         throw std::runtime_error("Allocation failed in TestAllocFreeImmediate");
       }
       // Verify allocator correctness by writing to all allocated memory
-      std::memset(ptr.ptr_, static_cast<unsigned char>(i & 0xFF), alloc_size);
+      std::memset(ptr.get(), static_cast<unsigned char>(i & 0xFF), alloc_size);
       alloc_->Free(ptr);
     }
   }
@@ -105,7 +105,7 @@ class AllocatorTest {
           throw std::runtime_error("Allocation failed in TestAllocFreeBatch");
         }
         // Verify allocator correctness by writing to all allocated memory
-        std::memset(ptr.ptr_, static_cast<unsigned char>((iter * 100 + i) & 0xFF), alloc_size);
+        std::memset(ptr.get(), static_cast<unsigned char>((iter * 100 + i) & 0xFF), alloc_size);
         ptrs.push_back(ptr);
       }
 
@@ -157,7 +157,7 @@ class AllocatorTest {
         if (!ptr.Validate(alloc_)) {
           throw std::runtime_error("Allocation failed in TestRandomAllocation");
         }
-        std::memset(ptr.ptr_, static_cast<unsigned char>((iter + ptrs.size()) & 0xFF), alloc_size);
+        std::memset(ptr.get(), static_cast<unsigned char>((iter + ptrs.size()) & 0xFF), alloc_size);
         ptrs.push_back({ptr, alloc_size});
         total_allocated += alloc_size;
       }
@@ -208,7 +208,7 @@ class AllocatorTest {
         }
 
         // Verify allocator correctness by writing to all allocated memory
-        std::memset(ptr.ptr_,
+        std::memset(ptr.get(),
                     static_cast<unsigned char>((iter + ptrs.size()) & 0xFF),
                     alloc_size);
         
@@ -301,7 +301,7 @@ class AllocatorTest {
           throw std::runtime_error("Large allocation failed in TestLargeThenSmall");
         }
         // Verify allocator correctness by writing to all allocated memory
-        std::memset(ptr.ptr_, static_cast<unsigned char>((iter + i) & 0xFF), large_size);
+        std::memset(ptr.get(), static_cast<unsigned char>((iter + i) & 0xFF), large_size);
         large_ptrs.push_back(ptr);
       }
 
@@ -322,7 +322,7 @@ class AllocatorTest {
           throw std::runtime_error("Small allocation failed in TestLargeThenSmall");
         }
         // Verify allocator correctness by writing to all allocated memory
-        std::memset(ptr.ptr_, static_cast<unsigned char>((iter + i + 128) & 0xFF), small_size);
+        std::memset(ptr.get(), static_cast<unsigned char>((iter + i + 128) & 0xFF), small_size);
         small_ptrs.push_back(ptr);
       }
 

--- a/context-transport-primitives/test/unit/allocator/test_buddy_allocator.cc
+++ b/context-transport-primitives/test/unit/allocator/test_buddy_allocator.cc
@@ -240,7 +240,7 @@ TEST_CASE("BuddyAllocator Regression - Fix1: AllocateLarge searches higher size 
   REQUIRE_FALSE(ptr.IsNull());
 
   // Write to the memory to verify it is usable
-  std::memset(ptr.ptr_, 0xAB, k300KB);
+  std::memset(ptr.get(), 0xAB, k300KB);
 
   // Cleanup
   alloc->Free(ptr);
@@ -291,7 +291,7 @@ TEST_CASE("BuddyAllocator Regression - Fix2: Heap rollback on failed allocation"
     // The fixed Heap::Allocate rolls back its pointer on failure.
     auto recovery_ptr = alloc->template Allocate<char>(1024);
     REQUIRE_FALSE(recovery_ptr.IsNull());
-    std::memset(recovery_ptr.ptr_, 0xCD, 1024);
+    std::memset(recovery_ptr.get(), 0xCD, 1024);
     alloc->Free(recovery_ptr);
   }
 
@@ -355,7 +355,7 @@ TEST_CASE("BuddyAllocator Regression - Fix3: Small remainder does not corrupt st
 
   auto big_ptr = alloc->template Allocate<char>(kLargeData);
   REQUIRE_FALSE(big_ptr.IsNull());
-  std::memset(big_ptr.ptr_, 0xAA, kLargeData);
+  std::memset(big_ptr.get(), 0xAA, kLargeData);
   alloc->Free(big_ptr);  // goes to large_pages_ with size_ == kLargeData
 
   // Request k128KB — the remainder is exactly kBuddyPageHdr bytes total.
@@ -363,13 +363,13 @@ TEST_CASE("BuddyAllocator Regression - Fix3: Small remainder does not corrupt st
   // Fixed code: guard returns early, no corruption.
   auto small_ptr = alloc->template Allocate<char>(k128KB);
   REQUIRE_FALSE(small_ptr.IsNull());
-  std::memset(small_ptr.ptr_, 0xBB, k128KB);
+  std::memset(small_ptr.get(), 0xBB, k128KB);
   alloc->Free(small_ptr);
 
   // Verify subsequent allocations work correctly after the boundary case.
   auto verify_ptr = alloc->template Allocate<char>(4096);
   REQUIRE_FALSE(verify_ptr.IsNull());
-  std::memset(verify_ptr.ptr_, 0xCC, 4096);
+  std::memset(verify_ptr.get(), 0xCC, 4096);
   alloc->Free(verify_ptr);
 }
 
@@ -421,7 +421,7 @@ TEST_CASE("BuddyAllocator Regression - Fix4: RepopulateSmallArena does not leak 
     auto p = alloc->template Allocate<char>(kSmall);
     // Must succeed — memory was returned via the freed large blocks.
     REQUIRE_FALSE(p.IsNull());
-    std::memset(p.ptr_, static_cast<unsigned char>(i & 0xFF), kSmall);
+    std::memset(p.get(), static_cast<unsigned char>(i & 0xFF), kSmall);
     small_ptrs.push_back(p);
   }
 
@@ -548,7 +548,7 @@ TEST_CASE("BuddyAllocator Regression - Fix7and8: AllocateSmall finds larger free
   constexpr size_t k512B = 512;
   auto saved = alloc->template Allocate<char>(k512B);
   REQUIRE_FALSE(saved.IsNull());
-  std::memset(saved.ptr_, 0x11, k512B);
+  std::memset(saved.get(), 0x11, k512B);
 
   // Step 2: Exhaust the heap and arena with 64-byte allocations.
   constexpr size_t k64B = 64;
@@ -570,7 +570,7 @@ TEST_CASE("BuddyAllocator Regression - Fix7and8: AllocateSmall finds larger free
   // The old code would return null here.
   auto result = alloc->template Allocate<char>(k64B);
   REQUIRE_FALSE(result.IsNull());
-  std::memset(result.ptr_, 0x22, k64B);
+  std::memset(result.get(), 0x22, k64B);
   alloc->Free(result);
 
   // Cleanup

--- a/context-transport-primitives/test/unit/allocator/test_hshm_malloc.cc
+++ b/context-transport-primitives/test/unit/allocator/test_hshm_malloc.cc
@@ -48,22 +48,22 @@ TEST_CASE("HSHM_MALLOC: basic allocate and free", "[hshm_malloc][basic]") {
   auto buffer = HSHM_MALLOC->AllocateObjs<char>(size);
 
   std::cout << "Allocated " << size << " bytes" << std::endl;
-  std::cout << "  ptr_ = " << (void*)buffer.ptr_ << std::endl;
+  std::cout << "  ptr_ = " << (void*)buffer.get() << std::endl;
   std::cout << "  off_ = " << buffer.shm_.off_.load() << std::endl;
   std::cout << "  alloc_id = (" << buffer.shm_.alloc_id_.major_
             << "." << buffer.shm_.alloc_id_.minor_ << ")" << std::endl;
 
   REQUIRE(!buffer.IsNull());
-  REQUIRE(buffer.ptr_ != nullptr);
+  REQUIRE(buffer.get() != nullptr);
 
   // Write to the buffer to ensure it's valid
   for (size_t i = 0; i < size; i++) {
-    buffer.ptr_[i] = static_cast<char>(i % 256);
+    buffer[i] = static_cast<char>(i % 256);
   }
 
   // Verify the data
   for (size_t i = 0; i < size; i++) {
-    REQUIRE(buffer.ptr_[i] == static_cast<char>(i % 256));
+    REQUIRE(buffer[i] == static_cast<char>(i % 256));
   }
 
   std::cout << "Buffer is valid and writable" << std::endl;
@@ -89,14 +89,14 @@ TEST_CASE("HSHM_MALLOC: multiple allocations", "[hshm_malloc][multiple]") {
     auto buffer = HSHM_MALLOC->AllocateObjs<char>(size);
 
     std::cout << "Allocated buffer " << i << ": " << size << " bytes at ptr_="
-              << (void*)buffer.ptr_ << std::endl;
+              << (void*)buffer.get() << std::endl;
 
     REQUIRE(!buffer.IsNull());
-    REQUIRE(buffer.ptr_ != nullptr);
+    REQUIRE(buffer.get() != nullptr);
 
     // Write unique pattern
     for (size_t j = 0; j < size; j++) {
-      buffer.ptr_[j] = static_cast<char>((i * 100 + j) % 256);
+      buffer[j] = static_cast<char>((i * 100 + j) % 256);
     }
 
     buffers.push_back(buffer);
@@ -106,7 +106,7 @@ TEST_CASE("HSHM_MALLOC: multiple allocations", "[hshm_malloc][multiple]") {
   for (int i = 0; i < num_buffers; i++) {
     size_t size = 512 + i * 128;
     for (size_t j = 0; j < size; j++) {
-      REQUIRE(buffers[i].ptr_[j] == static_cast<char>((i * 100 + j) % 256));
+      REQUIRE(buffers[i][j] == static_cast<char>((i * 100 + j) % 256));
     }
   }
 
@@ -114,7 +114,7 @@ TEST_CASE("HSHM_MALLOC: multiple allocations", "[hshm_malloc][multiple]") {
 
   // Free all buffers
   for (int i = 0; i < num_buffers; i++) {
-    std::cout << "Freeing buffer " << i << " at ptr_=" << (void*)buffers[i].ptr_ << std::endl;
+    std::cout << "Freeing buffer " << i << " at ptr_=" << (void*)buffers[i].get() << std::endl;
     HSHM_MALLOC->Free(buffers[i]);
   }
 
@@ -155,7 +155,7 @@ TEST_CASE("HSHM_MALLOC: ptr and offset relationship", "[hshm_malloc][ptr_offset]
 
   REQUIRE(!buffer.IsNull());
 
-  std::cout << "ptr_ = " << (void*)buffer.ptr_ << std::endl;
+  std::cout << "ptr_ = " << (void*)buffer.get() << std::endl;
   std::cout << "off_ = " << buffer.shm_.off_.load() << std::endl;
 
   // For HSHM_MALLOC with MallocPage header:
@@ -163,7 +163,7 @@ TEST_CASE("HSHM_MALLOC: ptr and offset relationship", "[hshm_malloc][ptr_offset]
   // - The ptr_ should also point to the data
   // - They should be the same value
 
-  uintptr_t ptr_value = reinterpret_cast<uintptr_t>(buffer.ptr_);
+  uintptr_t ptr_value = reinterpret_cast<uintptr_t>(buffer.get());
   size_t off_value = buffer.shm_.off_.load();
 
   std::cout << "ptr_ as uintptr_t = " << ptr_value << std::endl;
@@ -189,20 +189,20 @@ TEST_CASE("HSHM_MALLOC: simulate IpcManager allocation", "[hshm_malloc][ipc_mana
   FullPtr<char> buffer = HSHM_MALLOC->AllocateObjs<char>(size);
 
   REQUIRE(!buffer.IsNull());
-  REQUIRE(buffer.ptr_ != nullptr);
+  REQUIRE(buffer.get() != nullptr);
   REQUIRE(buffer.shm_.alloc_id_ == AllocatorId::GetNull());
 
   std::cout << "Allocation successful:" << std::endl;
-  std::cout << "  ptr_ = " << (void*)buffer.ptr_ << std::endl;
+  std::cout << "  ptr_ = " << (void*)buffer.get() << std::endl;
   std::cout << "  off_ = " << buffer.shm_.off_.load() << std::endl;
   std::cout << "  alloc_id = NULL (as expected)" << std::endl;
 
   // Write some data
-  std::memset(buffer.ptr_, 0xAB, size);
+  std::memset(buffer.get(), 0xAB, size);
 
   // Verify
   for (size_t i = 0; i < size; i++) {
-    REQUIRE(buffer.ptr_[i] == static_cast<char>(0xAB));
+    REQUIRE(buffer[i] == static_cast<char>(0xAB));
   }
 
   std::cout << "Data written and verified" << std::endl;
@@ -225,7 +225,7 @@ TEST_CASE("HSHM_MALLOC: verify single free only", "[hshm_malloc][single_free]") 
   auto buffer = HSHM_MALLOC->AllocateObjs<char>(512);
   REQUIRE(!buffer.IsNull());
 
-  std::cout << "Allocated buffer at ptr_=" << (void*)buffer.ptr_ << std::endl;
+  std::cout << "Allocated buffer at ptr_=" << (void*)buffer.get() << std::endl;
 
   // Free once (should work)
   std::cout << "Freeing buffer (first time)..." << std::endl;
@@ -249,11 +249,11 @@ TEST_CASE("HSHM_MALLOC: reallocation", "[hshm_malloc][realloc]") {
   auto buffer = HSHM_MALLOC->AllocateObjs<char>(initial_size);
   REQUIRE(!buffer.IsNull());
 
-  std::cout << "Initial allocation: " << initial_size << " bytes at ptr_=" << (void*)buffer.ptr_ << std::endl;
+  std::cout << "Initial allocation: " << initial_size << " bytes at ptr_=" << (void*)buffer.get() << std::endl;
 
   // Write unique pattern
   for (size_t i = 0; i < initial_size; i++) {
-    buffer.ptr_[i] = static_cast<char>(i % 256);
+    buffer[i] = static_cast<char>(i % 256);
   }
 
   // Reallocate to larger size
@@ -261,22 +261,22 @@ TEST_CASE("HSHM_MALLOC: reallocation", "[hshm_malloc][realloc]") {
   auto new_buffer = HSHM_MALLOC->ReallocateObjs<char>(buffer, new_size);
   REQUIRE(!new_buffer.IsNull());
 
-  std::cout << "Reallocated to " << new_size << " bytes at ptr_=" << (void*)new_buffer.ptr_ << std::endl;
+  std::cout << "Reallocated to " << new_size << " bytes at ptr_=" << (void*)new_buffer.get() << std::endl;
 
   // Verify original data is preserved
   for (size_t i = 0; i < initial_size; i++) {
-    REQUIRE(new_buffer.ptr_[i] == static_cast<char>(i % 256));
+    REQUIRE(new_buffer[i] == static_cast<char>(i % 256));
   }
   std::cout << "Original data preserved after reallocation" << std::endl;
 
   // Write to the new space
   for (size_t i = initial_size; i < new_size; i++) {
-    new_buffer.ptr_[i] = static_cast<char>((i + 100) % 256);
+    new_buffer[i] = static_cast<char>((i + 100) % 256);
   }
 
   // Verify all data
   for (size_t i = initial_size; i < new_size; i++) {
-    REQUIRE(new_buffer.ptr_[i] == static_cast<char>((i + 100) % 256));
+    REQUIRE(new_buffer[i] == static_cast<char>((i + 100) % 256));
   }
   std::cout << "New space is accessible" << std::endl;
 
@@ -300,7 +300,7 @@ TEST_CASE("HSHM_MALLOC: realloc smaller", "[hshm_malloc][realloc_small]") {
 
   // Write pattern
   for (size_t i = 0; i < initial_size; i++) {
-    buffer.ptr_[i] = static_cast<char>(i % 256);
+    buffer[i] = static_cast<char>(i % 256);
   }
 
   // Reallocate to smaller size
@@ -312,7 +312,7 @@ TEST_CASE("HSHM_MALLOC: realloc smaller", "[hshm_malloc][realloc_small]") {
 
   // Verify data in smaller region is preserved
   for (size_t i = 0; i < new_size; i++) {
-    REQUIRE(new_buffer.ptr_[i] == static_cast<char>(i % 256));
+    REQUIRE(new_buffer[i] == static_cast<char>(i % 256));
   }
   std::cout << "Data preserved in smaller buffer" << std::endl;
 
@@ -363,9 +363,9 @@ TEST_CASE("HSHM_MALLOC: various sizes", "[hshm_malloc][sizes]") {
     REQUIRE(!buffer.IsNull());
 
     // Write and verify
-    std::memset(buffer.ptr_, 0xAB, size);
+    std::memset(buffer.get(), 0xAB, size);
     for (size_t i = 0; i < size; i++) {
-      REQUIRE(buffer.ptr_[i] == static_cast<char>(0xAB));
+      REQUIRE(buffer[i] == static_cast<char>(0xAB));
     }
 
     HSHM_MALLOC->Free(buffer);
@@ -389,8 +389,8 @@ TEST_CASE("HSHM_MALLOC: stress test", "[hshm_malloc][stress]") {
     REQUIRE(!buffer.IsNull());
 
     // Quick write
-    buffer.ptr_[0] = static_cast<char>(i % 256);
-    buffer.ptr_[size - 1] = static_cast<char>(i % 256);
+    buffer[0] = static_cast<char>(i % 256);
+    buffer[size - 1] = static_cast<char>(i % 256);
 
     HSHM_MALLOC->Free(buffer);
   }

--- a/context-transport-primitives/test/unit/allocator/test_sub_alloc.cc
+++ b/context-transport-primitives/test/unit/allocator/test_sub_alloc.cc
@@ -65,7 +65,7 @@ TEST_CASE("SubAllocator - Basic Creation and Destruction", "[SubAllocator]") {
         sub_alloc_size);
 
     REQUIRE(!sub_alloc.IsNull());
-    REQUIRE(sub_alloc.ptr_->GetId() == parent_alloc->GetId());
+    REQUIRE(sub_alloc->GetId() == parent_alloc->GetId());
 
     // Free the sub-allocator
     parent_alloc->FreeSubAllocator(sub_alloc);
@@ -109,9 +109,9 @@ TEST_CASE("SubAllocator - Allocations within SubAllocator", "[SubAllocator]") {
 
 
     for (size_t i = 0; i < 1000; ++i) {
-      auto ptr = sub_alloc.ptr_->template Allocate<void>(1024);
+      auto ptr = sub_alloc->template Allocate<void>(1024);
       REQUIRE_FALSE(ptr.IsNull());
-      sub_alloc.ptr_->Free(ptr);
+      sub_alloc->Free(ptr);
     }
   }
 
@@ -121,14 +121,14 @@ TEST_CASE("SubAllocator - Allocations within SubAllocator", "[SubAllocator]") {
 
     // Allocate batch
     for (size_t i = 0; i < 100; ++i) {
-      auto ptr = sub_alloc.ptr_->template Allocate<void>(4096);
+      auto ptr = sub_alloc->template Allocate<void>(4096);
       REQUIRE_FALSE(ptr.IsNull());
       ptrs.push_back(ptr);
     }
 
     // Free batch
     for (auto &ptr : ptrs) {
-      sub_alloc.ptr_->Free(ptr);
+      sub_alloc->Free(ptr);
     }
   }
 
@@ -149,7 +149,7 @@ TEST_CASE("SubAllocator - Random Allocation Test", "[SubAllocator]") {
   REQUIRE(!sub_alloc.IsNull());
 
   // Use the AllocatorTest framework to run random tests
-  AllocatorTest<hipc::ArenaAllocator<false>> tester(sub_alloc.ptr_);
+  AllocatorTest<hipc::ArenaAllocator<false>> tester(sub_alloc.get());
 
   SECTION("1 iteration of random allocations") {
     REQUIRE_NOTHROW(tester.TestRandomAllocation(1));
@@ -178,9 +178,9 @@ TEST_CASE("SubAllocator - Multiple SubAllocators with Random Tests", "[SubAlloca
   REQUIRE(!sub_alloc3.IsNull());
 
   SECTION("Run random tests on all three sub-allocators") {
-    AllocatorTest<hipc::ArenaAllocator<false>> tester1(sub_alloc1.ptr_);
-    AllocatorTest<hipc::ArenaAllocator<false>> tester2(sub_alloc2.ptr_);
-    AllocatorTest<hipc::ArenaAllocator<false>> tester3(sub_alloc3.ptr_);
+    AllocatorTest<hipc::ArenaAllocator<false>> tester1(sub_alloc1.get());
+    AllocatorTest<hipc::ArenaAllocator<false>> tester2(sub_alloc2.get());
+    AllocatorTest<hipc::ArenaAllocator<false>> tester3(sub_alloc3.get());
 
     REQUIRE_NOTHROW(tester1.TestRandomAllocation(1));
     REQUIRE_NOTHROW(tester2.TestRandomAllocation(1));
@@ -207,17 +207,17 @@ TEST_CASE("SubAllocator - Nested SubAllocators", "[SubAllocator][nested]") {
 
   // Create a nested sub-allocator from the first sub-allocator (32 MB)
   size_t sub_alloc2_size = 32 * 1024 * 1024;
-  auto sub_alloc2 = sub_alloc1.ptr_->CreateSubAllocator<hipc::ArenaAllocator<false>>(
+  auto sub_alloc2 = sub_alloc1->CreateSubAllocator<hipc::ArenaAllocator<false>>(
       sub_alloc2_size);
 
   REQUIRE(!sub_alloc2.IsNull());
 
   // Test allocations in the nested sub-allocator
-  AllocatorTest<hipc::ArenaAllocator<false>> tester(sub_alloc2.ptr_);
+  AllocatorTest<hipc::ArenaAllocator<false>> tester(sub_alloc2.get());
   REQUIRE_NOTHROW(tester.TestRandomAllocation(1));
 
   // Free nested sub-allocator first, then parent sub-allocator
-  sub_alloc1.ptr_->FreeSubAllocator(sub_alloc2);
+  sub_alloc1->FreeSubAllocator(sub_alloc2);
   parent_alloc->FreeSubAllocator(sub_alloc1);
 
 }

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_rb_tree_pre.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_rb_tree_pre.cc
@@ -83,7 +83,7 @@ bool VerifyRBProperties(AllocT *alloc, pre::rb_tree<NodeT, false> &tree) {
   FullPtr<NodeT> root(alloc, OffsetPtr<NodeT>(tree.GetRoot().load()));
 
   // Property 2: Root must be black
-  if (root.ptr_->color_ != pre::RBColor::BLACK) {
+  if (root->color_ != pre::RBColor::BLACK) {
     return false;
   }
 
@@ -97,30 +97,30 @@ bool VerifyRBProperties(AllocT *alloc, pre::rb_tree<NodeT, false> &tree) {
     FullPtr<NodeT> node(alloc, node_off);
 
     // Check BST property
-    if (min_key && node.ptr_->key <= *min_key) return -1;
-    if (max_key && node.ptr_->key >= *max_key) return -1;
+    if (min_key && node->key <= *min_key) return -1;
+    if (max_key && node->key >= *max_key) return -1;
 
     // Property 4: Red nodes have black children
-    if (node.ptr_->color_ == pre::RBColor::RED) {
-      if (!node.ptr_->left_.IsNull()) {
-        FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(node.ptr_->left_.load()));
-        if (left.ptr_->color_ == pre::RBColor::RED) return -1;
+    if (node->color_ == pre::RBColor::RED) {
+      if (!node->left_.IsNull()) {
+        FullPtr<NodeT> left(alloc, OffsetPtr<NodeT>(node->left_.load()));
+        if (left->color_ == pre::RBColor::RED) return -1;
       }
-      if (!node.ptr_->right_.IsNull()) {
-        FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(node.ptr_->right_.load()));
-        if (right.ptr_->color_ == pre::RBColor::RED) return -1;
+      if (!node->right_.IsNull()) {
+        FullPtr<NodeT> right(alloc, OffsetPtr<NodeT>(node->right_.load()));
+        if (right->color_ == pre::RBColor::RED) return -1;
       }
     }
 
     // Property 5: Same number of black nodes on all paths
-    int left_black = check_node(OffsetPtr<NodeT>(node.ptr_->left_), min_key, &node.ptr_->key);
-    int right_black = check_node(OffsetPtr<NodeT>(node.ptr_->right_), &node.ptr_->key, max_key);
+    int left_black = check_node(OffsetPtr<NodeT>(node->left_), min_key, &node->key);
+    int right_black = check_node(OffsetPtr<NodeT>(node->right_), &node->key, max_key);
 
     if (left_black == -1 || right_black == -1 || left_black != right_black) {
       return -1;
     }
 
-    return left_black + (node.ptr_->color_ == pre::RBColor::BLACK ? 1 : 0);
+    return left_black + (node->color_ == pre::RBColor::BLACK ? 1 : 0);
   };
 
   return check_node(OffsetPtr<NodeT>(tree.GetRoot().load()), nullptr, nullptr) != -1;
@@ -147,13 +147,13 @@ TEST_CASE("rb_tree_pre - Basic Operations", "[rb_tree_pre]") {
 
     // Allocate a test node
     auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-    node_ptr.ptr_->key = 42;
-    node_ptr.ptr_->value_ = 100;
+    node_ptr->key = 42;
+    node_ptr->value_ = 100;
 
     // Insert the node (TestRBNode inherits from rb_node, so we can cast)
     hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
     tree.emplace(alloc, test_ptr);
 
     REQUIRE(tree.size() == 1);
@@ -163,7 +163,7 @@ TEST_CASE("rb_tree_pre - Basic Operations", "[rb_tree_pre]") {
     // Find the node
     auto found = tree.find(alloc, 42);
     REQUIRE_FALSE(found.IsNull());
-    REQUIRE(found.ptr_->value_ == 100);
+    REQUIRE(found->value_ == 100);
   }
 
   SECTION("Multiple elements in order") {
@@ -173,12 +173,12 @@ TEST_CASE("rb_tree_pre - Basic Operations", "[rb_tree_pre]") {
     // Insert nodes in ascending order
     for (int i = 0; i < 10; ++i) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = i;
-      node_ptr.ptr_->value_ = i * 10;
+      node_ptr->key = i;
+      node_ptr->value_ = i * 10;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
     }
 
@@ -189,7 +189,7 @@ TEST_CASE("rb_tree_pre - Basic Operations", "[rb_tree_pre]") {
     for (int i = 0; i < 10; ++i) {
       auto found = tree.find(alloc, i);
       REQUIRE_FALSE(found.IsNull());
-      REQUIRE(found.ptr_->value_ == i * 10);
+      REQUIRE(found->value_ == i * 10);
     }
   }
 
@@ -200,12 +200,12 @@ TEST_CASE("rb_tree_pre - Basic Operations", "[rb_tree_pre]") {
     // Insert nodes in descending order
     for (int i = 9; i >= 0; --i) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = i;
-      node_ptr.ptr_->value_ = i * 10;
+      node_ptr->key = i;
+      node_ptr->value_ = i * 10;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
     }
 
@@ -221,12 +221,12 @@ TEST_CASE("rb_tree_pre - Basic Operations", "[rb_tree_pre]") {
 
     for (int key : keys) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = key;
-      node_ptr.ptr_->value_ = key;
+      node_ptr->key = key;
+      node_ptr->value_ = key;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
 
       REQUIRE(VerifyRBProperties(alloc, tree));
@@ -247,24 +247,24 @@ TEST_CASE("rb_tree_pre - Basic Operations", "[rb_tree_pre]") {
 
     // Insert node with key 42
     auto node1_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-    node1_ptr.ptr_->key = 42;
-    node1_ptr.ptr_->value_ = 100;
+    node1_ptr->key = 42;
+    node1_ptr->value_ = 100;
 
     hipc::ShmPtrBase<TestRBNode<int>> test_shm1(node1_ptr.shm_.alloc_id_, node1_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr1(alloc, test_shm1);
-    test_ptr1.ptr_ = node1_ptr.ptr_;
+    test_ptr1.set_ptr(node1_ptr.get());
     tree.emplace(alloc, test_ptr1);
 
     REQUIRE(tree.size() == 1);
 
     // Try to insert another node with same key
     auto node2_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-    node2_ptr.ptr_->key = 42;
-    node2_ptr.ptr_->value_ = 200;
+    node2_ptr->key = 42;
+    node2_ptr->value_ = 200;
 
     hipc::ShmPtrBase<TestRBNode<int>> test_shm2(node2_ptr.shm_.alloc_id_, node2_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr2(alloc, test_shm2);
-    test_ptr2.ptr_ = node2_ptr.ptr_;
+    test_ptr2.set_ptr(node2_ptr.get());
     tree.emplace(alloc, test_ptr2);
 
     // Size should remain 1 (duplicate not inserted)
@@ -272,7 +272,7 @@ TEST_CASE("rb_tree_pre - Basic Operations", "[rb_tree_pre]") {
 
     // Original value should be preserved
     auto found = tree.find(alloc, 42);
-    REQUIRE(found.ptr_->value_ == 100);
+    REQUIRE(found->value_ == 100);
   }
 
 }
@@ -297,12 +297,12 @@ TEST_CASE("rb_tree_pre - Deletion", "[rb_tree_pre]") {
     tree.Init();
 
     auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-    node_ptr.ptr_->key = 42;
-    node_ptr.ptr_->value_ = 100;
+    node_ptr->key = 42;
+    node_ptr->value_ = 100;
 
     hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
     tree.emplace(alloc, test_ptr);
 
     REQUIRE(tree.size() == 1);
@@ -312,7 +312,7 @@ TEST_CASE("rb_tree_pre - Deletion", "[rb_tree_pre]") {
     REQUIRE(tree.size() == 0);
     REQUIRE(tree.empty());
 
-    REQUIRE(popped.ptr_->value_ == 100);
+    REQUIRE(popped->value_ == 100);
   }
 
   SECTION("Delete non-existent key") {
@@ -322,12 +322,12 @@ TEST_CASE("rb_tree_pre - Deletion", "[rb_tree_pre]") {
     // Insert a few nodes
     for (int i = 0; i < 5; ++i) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = i * 10;
-      node_ptr.ptr_->value_ = i;
+      node_ptr->key = i * 10;
+      node_ptr->value_ = i;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
     }
 
@@ -348,12 +348,12 @@ TEST_CASE("rb_tree_pre - Deletion", "[rb_tree_pre]") {
     // Insert all
     for (int key : keys) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = key;
-      node_ptr.ptr_->value_ = key;
+      node_ptr->key = key;
+      node_ptr->value_ = key;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
     }
 
@@ -383,12 +383,12 @@ TEST_CASE("rb_tree_pre - Deletion", "[rb_tree_pre]") {
     // Insert 5 nodes
     for (int i = 0; i < 5; ++i) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = i;
-      node_ptr.ptr_->value_ = i;
+      node_ptr->key = i;
+      node_ptr->value_ = i;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
     }
 
@@ -401,12 +401,12 @@ TEST_CASE("rb_tree_pre - Deletion", "[rb_tree_pre]") {
     // Insert 3 more
     for (int i = 10; i < 13; ++i) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = i;
-      node_ptr.ptr_->value_ = i;
+      node_ptr->key = i;
+      node_ptr->value_ = i;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
     }
 
@@ -441,12 +441,12 @@ TEST_CASE("rb_tree_pre - Large Tree", "[rb_tree_pre]") {
     // Insert
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = i;
-      node_ptr.ptr_->value_ = i;
+      node_ptr->key = i;
+      node_ptr->value_ = i;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
     }
 
@@ -482,12 +482,12 @@ TEST_CASE("rb_tree_pre - Atomic Version", "[rb_tree_pre][atomic]") {
     // Insert nodes
     for (int i = 0; i < 20; ++i) {
       auto node_ptr = alloc->Allocate<TestRBNode<int>>( sizeof(TestRBNode<int>));
-      node_ptr.ptr_->key = i;
-      node_ptr.ptr_->value_ = i * 2;
+      node_ptr->key = i;
+      node_ptr->value_ = i * 2;
 
       hipc::ShmPtrBase<TestRBNode<int>> test_shm(node_ptr.shm_.alloc_id_, node_ptr.shm_.off_.load());
     FullPtr<TestRBNode<int>> test_ptr(alloc, test_shm);
-    test_ptr.ptr_ = node_ptr.ptr_;
+    test_ptr.set_ptr(node_ptr.get());
       tree.emplace(alloc, test_ptr);
     }
 
@@ -515,24 +515,24 @@ TEST_CASE("rb_tree_pre - Deletion Edge Cases", "[rb_tree_pre][deletion]") {
 
     // Insert root and two children
     auto root = alloc->Allocate<TestRBNode<int>>(sizeof(TestRBNode<int>));
-    root.ptr_->key = 50;
+    root->key = 50;
     hipc::ShmPtrBase<TestRBNode<int>> root_shm(root.shm_.alloc_id_, root.shm_.off_.load());
     FullPtr<TestRBNode<int>> root_ptr(alloc, root_shm);
-    root_ptr.ptr_ = root.ptr_;
+    root_ptr.set_ptr(root.get());
     tree.emplace(alloc, root_ptr);
 
     auto left = alloc->Allocate<TestRBNode<int>>(sizeof(TestRBNode<int>));
-    left.ptr_->key = 25;
+    left->key = 25;
     hipc::ShmPtrBase<TestRBNode<int>> left_shm(left.shm_.alloc_id_, left.shm_.off_.load());
     FullPtr<TestRBNode<int>> left_ptr(alloc, left_shm);
-    left_ptr.ptr_ = left.ptr_;
+    left_ptr.set_ptr(left.get());
     tree.emplace(alloc, left_ptr);
 
     auto right = alloc->Allocate<TestRBNode<int>>(sizeof(TestRBNode<int>));
-    right.ptr_->key = 75;
+    right->key = 75;
     hipc::ShmPtrBase<TestRBNode<int>> right_shm(right.shm_.alloc_id_, right.shm_.off_.load());
     FullPtr<TestRBNode<int>> right_ptr(alloc, right_shm);
-    right_ptr.ptr_ = right.ptr_;
+    right_ptr.set_ptr(right.get());
     tree.emplace(alloc, right_ptr);
 
     REQUIRE(tree.size() == 3);
@@ -557,10 +557,10 @@ TEST_CASE("rb_tree_pre - Deletion Edge Cases", "[rb_tree_pre][deletion]") {
     std::vector<int> keys = {50, 25, 75, 10};
     for (int key : keys) {
       auto node = alloc->Allocate<TestRBNode<int>>(sizeof(TestRBNode<int>));
-      node.ptr_->key = key;
+      node->key = key;
       hipc::ShmPtrBase<TestRBNode<int>> shm(node.shm_.alloc_id_, node.shm_.off_.load());
       FullPtr<TestRBNode<int>> ptr(alloc, shm);
-      ptr.ptr_ = node.ptr_;
+      ptr.set_ptr(node.get());
       tree.emplace(alloc, ptr);
     }
 
@@ -582,10 +582,10 @@ TEST_CASE("rb_tree_pre - Deletion Edge Cases", "[rb_tree_pre][deletion]") {
     std::vector<int> keys = {50, 25, 75, 90};
     for (int key : keys) {
       auto node = alloc->Allocate<TestRBNode<int>>(sizeof(TestRBNode<int>));
-      node.ptr_->key = key;
+      node->key = key;
       hipc::ShmPtrBase<TestRBNode<int>> shm(node.shm_.alloc_id_, node.shm_.off_.load());
       FullPtr<TestRBNode<int>> ptr(alloc, shm);
-      ptr.ptr_ = node.ptr_;
+      ptr.set_ptr(node.get());
       tree.emplace(alloc, ptr);
     }
 
@@ -607,10 +607,10 @@ TEST_CASE("rb_tree_pre - Deletion Edge Cases", "[rb_tree_pre][deletion]") {
     std::vector<int> keys = {50, 25, 75, 60};
     for (int key : keys) {
       auto node = alloc->Allocate<TestRBNode<int>>(sizeof(TestRBNode<int>));
-      node.ptr_->key = key;
+      node->key = key;
       hipc::ShmPtrBase<TestRBNode<int>> shm(node.shm_.alloc_id_, node.shm_.off_.load());
       FullPtr<TestRBNode<int>> ptr(alloc, shm);
-      ptr.ptr_ = node.ptr_;
+      ptr.set_ptr(node.get());
       tree.emplace(alloc, ptr);
     }
 
@@ -628,10 +628,10 @@ TEST_CASE("rb_tree_pre - Deletion Edge Cases", "[rb_tree_pre][deletion]") {
     std::vector<int> keys = {50, 25, 75, 10, 30, 60, 90, 5};
     for (int key : keys) {
       auto node = alloc->Allocate<TestRBNode<int>>(sizeof(TestRBNode<int>));
-      node.ptr_->key = key;
+      node->key = key;
       hipc::ShmPtrBase<TestRBNode<int>> shm(node.shm_.alloc_id_, node.shm_.off_.load());
       FullPtr<TestRBNode<int>> ptr(alloc, shm);
-      ptr.ptr_ = node.ptr_;
+      ptr.set_ptr(node.get());
       tree.emplace(alloc, ptr);
     }
 
@@ -655,10 +655,10 @@ TEST_CASE("rb_tree_pre - Deletion Edge Cases", "[rb_tree_pre][deletion]") {
     for (int i = 0; i < NUM_NODES; ++i) {
       keys.push_back(i);
       auto node = alloc->Allocate<TestRBNode<int>>(sizeof(TestRBNode<int>));
-      node.ptr_->key = i;
+      node->key = i;
       hipc::ShmPtrBase<TestRBNode<int>> shm(node.shm_.alloc_id_, node.shm_.off_.load());
       FullPtr<TestRBNode<int>> ptr(alloc, shm);
-      ptr.ptr_ = node.ptr_;
+      ptr.set_ptr(node.get());
       tree.emplace(alloc, ptr);
     }
 
@@ -691,10 +691,10 @@ TEST_CASE("rb_tree_pre - String Keys", "[rb_tree_pre][string_keys]") {
 
     for (const auto& key : keys) {
       auto node = alloc->Allocate<TestRBNode<std::string>>(sizeof(TestRBNode<std::string>));
-      new (node.ptr_) TestRBNode<std::string>(key, 0);
+      new (node.get()) TestRBNode<std::string>(key, 0);
       hipc::ShmPtrBase<TestRBNode<std::string>> shm(node.shm_.alloc_id_, node.shm_.off_.load());
       FullPtr<TestRBNode<std::string>> ptr(alloc, shm);
-      ptr.ptr_ = node.ptr_;
+      ptr.set_ptr(node.get());
       tree.emplace(alloc, ptr);
     }
 

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_slist_pre.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_slist_pre.cc
@@ -81,7 +81,7 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
 
     // Allocate a test node
     auto node_ptr = alloc->Allocate<TestNode>( sizeof(TestNode));
-    node_ptr.ptr_->value_ = 42;
+    node_ptr->value_ = 42;
 
     // Emplace the node
     list.emplace(alloc, node_ptr);
@@ -97,7 +97,7 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
     REQUIRE(list.empty());
 
     // Verify the data
-    auto *popped_node = reinterpret_cast<TestNode*>(popped.ptr_);
+    auto *popped_node = reinterpret_cast<TestNode*>(popped.get());
     REQUIRE(popped_node->value_ == 42);
   }
 
@@ -109,7 +109,7 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
     const int NUM_NODES = 5;
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>( sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
 
       list.emplace(alloc, node_ptr);
     }
@@ -121,7 +121,7 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
       auto popped = list.pop(alloc);
       REQUIRE_FALSE(popped.IsNull());
 
-      auto *popped_node = reinterpret_cast<TestNode*>(popped.ptr_);
+      auto *popped_node = reinterpret_cast<TestNode*>(popped.get());
       REQUIRE(popped_node->value_ == i);
     }
 
@@ -148,7 +148,7 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
 
     // Add a node
     auto node_ptr = alloc->Allocate<TestNode>( sizeof(TestNode));
-    node_ptr.ptr_->value_ = 100;
+    node_ptr->value_ = 100;
     list.emplace(alloc, node_ptr);
 
     // Peek should return the head without removing it
@@ -156,7 +156,7 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
     REQUIRE_FALSE(peeked.IsNull());
     REQUIRE(list.size() == 1);  // Size unchanged
 
-    auto *peeked_node = reinterpret_cast<TestNode*>(peeked.ptr_);
+    auto *peeked_node = reinterpret_cast<TestNode*>(peeked.get());
     REQUIRE(peeked_node->value_ == 100);
   }
 
@@ -167,7 +167,7 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
     // Emplace 3 nodes
     for (int i = 0; i < 3; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>( sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
     REQUIRE(list.size() == 3);
@@ -180,7 +180,7 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
     // Emplace 2 more nodes
     for (int i = 10; i < 12; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>( sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
     REQUIRE(list.size() == 3);
@@ -190,9 +190,9 @@ TEST_CASE("slist_pre - Basic Operations", "[slist_pre]") {
     auto n2 = list.pop(alloc);
     auto n3 = list.pop(alloc);
 
-    REQUIRE(reinterpret_cast<TestNode*>(n1.ptr_)->value_ == 11);
-    REQUIRE(reinterpret_cast<TestNode*>(n2.ptr_)->value_ == 10);
-    REQUIRE(reinterpret_cast<TestNode*>(n3.ptr_)->value_ == 0);
+    REQUIRE(reinterpret_cast<TestNode*>(n1.get())->value_ == 11);
+    REQUIRE(reinterpret_cast<TestNode*>(n2.get())->value_ == 10);
+    REQUIRE(reinterpret_cast<TestNode*>(n3.get())->value_ == 0);
   }
 
 }
@@ -211,7 +211,7 @@ TEST_CASE("slist_pre - Atomic Version", "[slist_pre][atomic]") {
     const int NUM_NODES = 10;
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>( sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 
@@ -221,7 +221,7 @@ TEST_CASE("slist_pre - Atomic Version", "[slist_pre][atomic]") {
     for (int i = NUM_NODES - 1; i >= 0; --i) {
       auto popped = list.pop(alloc);
       REQUIRE_FALSE(popped.IsNull());
-      REQUIRE(reinterpret_cast<TestNode*>(popped.ptr_)->value_ == i);
+      REQUIRE(reinterpret_cast<TestNode*>(popped.get())->value_ == i);
     }
 
     REQUIRE(list.size() == 0);
@@ -242,7 +242,7 @@ TEST_CASE("slist_pre - Node Reuse", "[slist_pre]") {
 
     // Allocate a node
     auto node_ptr = alloc->Allocate<TestNode>( sizeof(TestNode));
-    node_ptr.ptr_->value_ = 1;
+    node_ptr->value_ = 1;
 
     // Emplace, pop, modify, and re-emplace
     list.emplace(alloc, node_ptr);
@@ -252,7 +252,7 @@ TEST_CASE("slist_pre - Node Reuse", "[slist_pre]") {
     REQUIRE(list.size() == 0);
 
     // Modify the node
-    auto *reused_node = reinterpret_cast<TestNode*>(popped.ptr_);
+    auto *reused_node = reinterpret_cast<TestNode*>(popped.get());
     reused_node->value_ = 999;
 
     // Re-emplace the same node
@@ -261,7 +261,7 @@ TEST_CASE("slist_pre - Node Reuse", "[slist_pre]") {
 
     // Pop and verify
     auto final = list.pop(alloc);
-    REQUIRE(reinterpret_cast<TestNode*>(final.ptr_)->value_ == 999);
+    REQUIRE(reinterpret_cast<TestNode*>(final.get())->value_ == 999);
   }
 
 }
@@ -281,7 +281,7 @@ TEST_CASE("slist_pre - Large List", "[slist_pre]") {
     // Emplace many nodes
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>( sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 
@@ -322,7 +322,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
 
     // Allocate and emplace a single node
     auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-    node_ptr.ptr_->value_ = 42;
+    node_ptr->value_ = 42;
     list.emplace(alloc, node_ptr);
 
     // Iterate and verify
@@ -331,7 +331,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     REQUIRE(it != list.end());
 
     auto node = FullPtr<TestNode>(alloc, OffsetPtr<TestNode>(it.GetCurrent().load()));
-    REQUIRE(node.ptr_->value_ == 42);
+    REQUIRE(node->value_ == 42);
 
     // Advance to next (should be end)
     auto next_it_copy = it;
@@ -348,7 +348,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     // Emplace nodes in order 0, 1, 2, 3, 4 (but LIFO means list order is 4, 3, 2, 1, 0)
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 
@@ -357,7 +357,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     int idx = 0;
     for (auto it = list.begin(alloc); it != list.end(); ++it) {
       auto node = FullPtr<TestNode>(alloc, OffsetPtr<TestNode>(it.GetCurrent().load()));
-      REQUIRE(node.ptr_->value_ == expected_values[idx]);
+      REQUIRE(node->value_ == expected_values[idx]);
       idx++;
     }
     REQUIRE(idx == NUM_NODES);
@@ -370,7 +370,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     // Allocate and emplace two nodes
     for (int i = 0; i < 2; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 
@@ -393,7 +393,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     // Emplace nodes
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 
@@ -432,7 +432,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
 
     // Allocate and emplace a single node
     auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-    node_ptr.ptr_->value_ = 100;
+    node_ptr->value_ = 100;
     list.emplace(alloc, node_ptr);
 
     auto it = list.begin(alloc);
@@ -458,7 +458,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     // Emplace nodes
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 
@@ -481,7 +481,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     // Emplace nodes with distinct values
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-      node_ptr.ptr_->value_ = i * 10;
+      node_ptr->value_ = i * 10;
       list.emplace(alloc, node_ptr);
     }
 
@@ -522,7 +522,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
 
     // Add a node
     auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-    node_ptr.ptr_->value_ = 1;
+    node_ptr->value_ = 1;
     list.emplace(alloc, node_ptr);
 
     auto it_begin = list.begin(alloc);
@@ -542,7 +542,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     // Emplace many nodes
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 
@@ -551,7 +551,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     int expected_value = NUM_NODES - 1;  // LIFO order
     for (auto it = list.begin(alloc); it != list.end(); ++it) {
       auto node = FullPtr<TestNode>(alloc, OffsetPtr<TestNode>(it.GetCurrent().load()));
-      REQUIRE(node.ptr_->value_ == expected_value);
+      REQUIRE(node->value_ == expected_value);
       expected_value--;
       count++;
     }
@@ -567,7 +567,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     const int NUM_NODES = 5;
     for (int i = 0; i < NUM_NODES; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 
@@ -593,7 +593,7 @@ TEST_CASE("slist_pre - Iterator Forward Traversal", "[slist_pre][iterator]") {
     // Add initial nodes
     for (int i = 0; i < 3; ++i) {
       auto node_ptr = alloc->Allocate<TestNode>(sizeof(TestNode));
-      node_ptr.ptr_->value_ = i;
+      node_ptr->value_ = i;
       list.emplace(alloc, node_ptr);
     }
 

--- a/context-transport-primitives/test/unit/data_structures/priv/test_priv_string.cc
+++ b/context-transport-primitives/test/unit/data_structures/priv/test_priv_string.cc
@@ -61,7 +61,7 @@ class SimpleHeapAllocator {
     size_t size = count * sizeof(T);
     T* ptr = static_cast<T*>(malloc(size));
     hipc::FullPtr<T> result;
-    result.ptr_ = ptr;
+    result.set_ptr(ptr);
     result.shm_.off_ = 0;
     result.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
     return result;
@@ -77,7 +77,7 @@ class SimpleHeapAllocator {
   hipc::FullPtr<T> Allocate(size_t size) {
     T* ptr = static_cast<T*>(malloc(size));
     hipc::FullPtr<T> result;
-    result.ptr_ = ptr;
+    result.set_ptr(ptr);
     result.shm_.off_ = 0;
     result.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
     return result;
@@ -91,8 +91,8 @@ class SimpleHeapAllocator {
    */
   template <typename T, bool ATOMIC = false>
   void Free(const hipc::FullPtr<T, ATOMIC>& ptr) {
-    if (ptr.ptr_ != nullptr) {
-      free(ptr.ptr_);
+    if (ptr.get() != nullptr) {
+      free(ptr.get());
     }
   }
 };

--- a/context-transport-primitives/test/unit/data_structures/priv/test_priv_vector.cc
+++ b/context-transport-primitives/test/unit/data_structures/priv/test_priv_vector.cc
@@ -64,7 +64,7 @@ class SimpleHeapAllocator {
     T* ptr = static_cast<T*>(malloc(size));
     // Create a FullPtr with only the private pointer (no shared backing)
     hipc::FullPtr<T> result;
-    result.ptr_ = ptr;
+    result.set_ptr(ptr);
     result.shm_.off_ = 0;
     result.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
     return result;
@@ -81,7 +81,7 @@ class SimpleHeapAllocator {
   hipc::FullPtr<T> Allocate(size_t size) {
     T* ptr = static_cast<T*>(malloc(size));
     hipc::FullPtr<T> result;
-    result.ptr_ = ptr;
+    result.set_ptr(ptr);
     result.shm_.off_ = 0;
     result.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
     return result;
@@ -96,8 +96,8 @@ class SimpleHeapAllocator {
    */
   template <typename T, bool ATOMIC = false>
   void Free(const hipc::FullPtr<T, ATOMIC>& ptr) {
-    if (ptr.ptr_ != nullptr) {
-      free(ptr.ptr_);
+    if (ptr.get() != nullptr) {
+      free(ptr.get());
     }
   }
 };

--- a/context-transport-primitives/test/unit/gpu/test_gpu_malloc.cc
+++ b/context-transport-primitives/test/unit/gpu/test_gpu_malloc.cc
@@ -76,9 +76,9 @@ __global__ void AllocateRingBufferKernel(AllocT *alloc, size_t capacity,
   auto ring_ptr =
       alloc->template NewObj<mpsc_ring_buffer<T, AllocT>>(alloc, capacity);
   printf("AllocateRingBufferKernel: Ring buffer created: %p %p\n", alloc,
-         ring_ptr.ptr_);
+         ring_ptr.get());
   // Return the ring buffer pointer
-  *result = ring_ptr.ptr_;
+  *result = ring_ptr.get();
 }
 
 /**

--- a/context-transport-primitives/test/unit/gpu/test_gpu_shm_mmap.cc
+++ b/context-transport-primitives/test/unit/gpu/test_gpu_shm_mmap.cc
@@ -214,7 +214,7 @@ TEST_CASE("GpuShmMmap", "[gpu][backend]") {
     // and GPU
     using RingBuffer = mpsc_ring_buffer<int, AllocT>;
     RingBuffer *ring_ptr =
-        alloc_ptr->NewObj<RingBuffer>(alloc_ptr, kNumElements).ptr_;
+        alloc_ptr->NewObj<RingBuffer>(alloc_ptr, kNumElements).get();
     REQUIRE(ring_ptr != nullptr);
 
     // Step 4 & 5: Pass the ring_buffer to the kernel and push 10 elements
@@ -277,7 +277,7 @@ TEST_CASE("GpuShmMmap", "[gpu][backend]") {
 
     // Step 3: Allocate a hipc::vector<char> from allocator
     using CharVector = hipc::vector<char, AllocT>;
-    CharVector *vec_ptr = alloc_ptr->NewObj<CharVector>(alloc_ptr).ptr_;
+    CharVector *vec_ptr = alloc_ptr->NewObj<CharVector>(alloc_ptr).get();
     REQUIRE(vec_ptr != nullptr);
 
     // Step 4: Reserve 8192 bytes for the vector
@@ -338,7 +338,7 @@ TEST_CASE("GpuShmMmap", "[gpu][backend]") {
     // Allocate ring buffer for TestTransferStruct
     using RingBuffer = mpsc_ring_buffer<TestTransferStruct, AllocT>;
     RingBuffer *ring_ptr =
-        alloc_ptr->NewObj<RingBuffer>(alloc_ptr, kNumElements).ptr_;
+        alloc_ptr->NewObj<RingBuffer>(alloc_ptr, kNumElements).get();
     REQUIRE(ring_ptr != nullptr);
 
     // Launch kernel to push structs
@@ -372,7 +372,7 @@ TEST_CASE("GpuShmMmap", "[gpu][backend]") {
 
     using RingBuffer = mpsc_ring_buffer<TestTransferStruct, AllocT>;
     RingBuffer *ring_ptr =
-        alloc_ptr->NewObj<RingBuffer>(alloc_ptr, kNumElements).ptr_;
+        alloc_ptr->NewObj<RingBuffer>(alloc_ptr, kNumElements).get();
     REQUIRE(ring_ptr != nullptr);
 
     // Launch kernel (no sync -- CPU polls immediately)

--- a/context-transport-primitives/test/unit/gpu/test_local_serialize_gpu.cc
+++ b/context-transport-primitives/test/unit/gpu/test_local_serialize_gpu.cc
@@ -156,7 +156,7 @@ TEST_CASE("LocalSerialize GPU", "[gpu][serialize]") {
 
     // Step 3: Allocate a priv::vector<char> from allocator
     using CharVector = hshm::priv::vector<char, AllocT>;
-    CharVector *vec_ptr = alloc_ptr->NewObj<CharVector>(alloc_ptr).ptr_;
+    CharVector *vec_ptr = alloc_ptr->NewObj<CharVector>(alloc_ptr).get();
     REQUIRE(vec_ptr != nullptr);
 
     // Reserve space for serialized data
@@ -240,7 +240,7 @@ TEST_CASE("LocalSerialize GPU", "[gpu][serialize]") {
     REQUIRE(alloc_ptr != nullptr);
 
     using CharVector = hshm::priv::vector<char, AllocT>;
-    CharVector *vec_ptr = alloc_ptr->NewObj<CharVector>(alloc_ptr).ptr_;
+    CharVector *vec_ptr = alloc_ptr->NewObj<CharVector>(alloc_ptr).get();
     REQUIRE(vec_ptr != nullptr);
 
     // Reserve space for larger data
@@ -314,7 +314,7 @@ TEST_CASE("LocalSerialize GPU", "[gpu][serialize]") {
     REQUIRE(alloc_ptr != nullptr);
 
     using CharVector = hshm::priv::vector<char, AllocT>;
-    CharVector *vec_ptr = alloc_ptr->NewObj<CharVector>(alloc_ptr).ptr_;
+    CharVector *vec_ptr = alloc_ptr->NewObj<CharVector>(alloc_ptr).get();
     REQUIRE(vec_ptr != nullptr);
     vec_ptr->reserve(4096);
 

--- a/context-transport-primitives/test/unit/gpu/test_local_transfer_gpu.cc
+++ b/context-transport-primitives/test/unit/gpu/test_local_transfer_gpu.cc
@@ -123,11 +123,11 @@ TEST_CASE("ShmTransfer GPU", "[gpu][transfer]") {
 
     // Step 3: Allocate copy space and ShmTransferInfo from pinned memory
     auto copy_space_ptr = alloc_ptr->AllocateObjs<char>(kCopySpaceSize);
-    char *copy_space = copy_space_ptr.ptr_;
+    char *copy_space = copy_space_ptr.get();
     REQUIRE(copy_space != nullptr);
 
     auto shm_info_ptr = alloc_ptr->AllocateObjs<ShmTransferInfo>(1);
-    ShmTransferInfo *shm_info = shm_info_ptr.ptr_;
+    ShmTransferInfo *shm_info = shm_info_ptr.get();
     REQUIRE(shm_info != nullptr);
     new (shm_info) ShmTransferInfo();
     shm_info->copy_space_size_ = kCopySpaceSize;
@@ -189,11 +189,11 @@ TEST_CASE("ShmTransfer GPU", "[gpu][transfer]") {
     REQUIRE(alloc_ptr != nullptr);
 
     auto copy_space_ptr = alloc_ptr->AllocateObjs<char>(kCopySpaceSize);
-    char *copy_space = copy_space_ptr.ptr_;
+    char *copy_space = copy_space_ptr.get();
     REQUIRE(copy_space != nullptr);
 
     auto shm_info_ptr = alloc_ptr->AllocateObjs<ShmTransferInfo>(1);
-    ShmTransferInfo *shm_info = shm_info_ptr.ptr_;
+    ShmTransferInfo *shm_info = shm_info_ptr.get();
     REQUIRE(shm_info != nullptr);
     new (shm_info) ShmTransferInfo();
     shm_info->copy_space_size_ = kCopySpaceSize;
@@ -249,7 +249,7 @@ TEST_CASE("ShmTransfer GPU", "[gpu][transfer]") {
 
     // Allocate buffer directly from GpuShmMmap
     auto buffer_ptr = alloc_ptr->AllocateObjs<char>(1024);
-    char *buffer = buffer_ptr.ptr_;
+    char *buffer = buffer_ptr.get();
     REQUIRE(buffer != nullptr);
 
     // Initialize on CPU
@@ -291,11 +291,11 @@ TEST_CASE("ShmTransfer GPU", "[gpu][transfer]") {
     REQUIRE(alloc_ptr != nullptr);
 
     auto copy_space_ptr = alloc_ptr->AllocateObjs<char>(kCopySpaceSize);
-    char *copy_space = copy_space_ptr.ptr_;
+    char *copy_space = copy_space_ptr.get();
     REQUIRE(copy_space != nullptr);
 
     auto shm_info_ptr = alloc_ptr->AllocateObjs<ShmTransferInfo>(1);
-    ShmTransferInfo *shm_info = shm_info_ptr.ptr_;
+    ShmTransferInfo *shm_info = shm_info_ptr.get();
     REQUIRE(shm_info != nullptr);
     new (shm_info) ShmTransferInfo();
     shm_info->copy_space_size_ = kCopySpaceSize;
@@ -365,7 +365,7 @@ __global__ void GpuSendKernel(GpuAllocT *alloc, char *data_buf,
 
     // Create bulk descriptor for the data buffer (private memory)
     Bulk bulk;
-    bulk.data.ptr_ = data_buf;
+    bulk.data.set_ptr(data_buf);
     bulk.data.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
     bulk.data.shm_.off_ = 0;
     bulk.size = data_size;
@@ -411,7 +411,7 @@ __global__ void GpuRecvKernel(GpuAllocT *alloc, char *output_buf,
       *recv_size = meta.recv[0].size;
       size_t copy_size = meta.recv[0].size;
       if (copy_size > max_size) copy_size = max_size;
-      ShmTransport::MemCopy(output_buf, meta.recv[0].data.ptr_, copy_size);
+      ShmTransport::MemCopy(output_buf, meta.recv[0].data.get(), copy_size);
     }
   }
 }
@@ -443,18 +443,18 @@ TEST_CASE("ShmTransport Send/Recv GPU", "[gpu][transport]") {
 
     // Step 3: Allocate copy space and ShmTransferInfo from pinned memory
     auto copy_space_ptr = alloc_ptr->AllocateObjs<char>(kCopySpaceSize);
-    char *copy_space = copy_space_ptr.ptr_;
+    char *copy_space = copy_space_ptr.get();
     REQUIRE(copy_space != nullptr);
 
     auto shm_info_ptr = alloc_ptr->AllocateObjs<ShmTransferInfo>(1);
-    ShmTransferInfo *shm_info = shm_info_ptr.ptr_;
+    ShmTransferInfo *shm_info = shm_info_ptr.get();
     REQUIRE(shm_info != nullptr);
     new (shm_info) ShmTransferInfo();
     shm_info->copy_space_size_ = kCopySpaceSize;
 
     // Step 4: Allocate send result in pinned memory (GPU writes to it)
     auto result_ptr = alloc_ptr->AllocateObjs<int>(1);
-    int *send_result = result_ptr.ptr_;
+    int *send_result = result_ptr.get();
     REQUIRE(send_result != nullptr);
     *send_result = -1;
 
@@ -489,12 +489,12 @@ TEST_CASE("ShmTransport Send/Recv GPU", "[gpu][transport]") {
     REQUIRE(recv_meta.send_bulks == 1);
     REQUIRE(recv_meta.recv.size() == 1);
     REQUIRE(recv_meta.recv[0].size == kDataSize);
-    REQUIRE(recv_meta.recv[0].data.ptr_ != nullptr);
+    REQUIRE(recv_meta.recv[0].data.get() != nullptr);
 
     // Verify received bulk data matches the pattern
     bool data_correct = true;
     for (size_t i = 0; i < kDataSize; ++i) {
-      if (recv_meta.recv[0].data.ptr_[i] != static_cast<char>(i % 251)) {
+      if (recv_meta.recv[0].data.get()[i] != static_cast<char>(i % 251)) {
         data_correct = false;
         break;
       }
@@ -502,7 +502,7 @@ TEST_CASE("ShmTransport Send/Recv GPU", "[gpu][transport]") {
     REQUIRE(data_correct);
 
     // Cleanup
-    std::free(recv_meta.recv[0].data.ptr_);
+    std::free(recv_meta.recv[0].data.get());
     cudaFreeHost(data_buf);
   }
 
@@ -520,17 +520,17 @@ TEST_CASE("ShmTransport Send/Recv GPU", "[gpu][transport]") {
     REQUIRE(alloc_ptr != nullptr);
 
     auto copy_space_ptr = alloc_ptr->AllocateObjs<char>(kCopySpaceSize);
-    char *copy_space = copy_space_ptr.ptr_;
+    char *copy_space = copy_space_ptr.get();
     REQUIRE(copy_space != nullptr);
 
     auto shm_info_ptr = alloc_ptr->AllocateObjs<ShmTransferInfo>(1);
-    ShmTransferInfo *shm_info = shm_info_ptr.ptr_;
+    ShmTransferInfo *shm_info = shm_info_ptr.get();
     REQUIRE(shm_info != nullptr);
     new (shm_info) ShmTransferInfo();
     shm_info->copy_space_size_ = kCopySpaceSize;
 
     auto result_ptr = alloc_ptr->AllocateObjs<int>(1);
-    int *send_result = result_ptr.ptr_;
+    int *send_result = result_ptr.get();
     REQUIRE(send_result != nullptr);
     *send_result = -1;
 
@@ -562,19 +562,19 @@ TEST_CASE("ShmTransport Send/Recv GPU", "[gpu][transport]") {
     REQUIRE(recv_rc == 0);
     REQUIRE(recv_meta.recv.size() == 1);
     REQUIRE(recv_meta.recv[0].size == kLargeDataSize);
-    REQUIRE(recv_meta.recv[0].data.ptr_ != nullptr);
+    REQUIRE(recv_meta.recv[0].data.get() != nullptr);
 
     // Verify all data is correct
     bool data_correct = true;
     for (size_t i = 0; i < kLargeDataSize; ++i) {
-      if (recv_meta.recv[0].data.ptr_[i] != kPattern) {
+      if (recv_meta.recv[0].data.get()[i] != kPattern) {
         data_correct = false;
         break;
       }
     }
     REQUIRE(data_correct);
 
-    std::free(recv_meta.recv[0].data.ptr_);
+    std::free(recv_meta.recv[0].data.get());
     cudaFreeHost(data_buf);
   }
 
@@ -603,28 +603,28 @@ TEST_CASE("ShmTransport Send/Recv GPU", "[gpu][transport]") {
 
     // Step 3: Allocate shared copy space and ShmTransferInfo
     auto copy_space_ptr = shared_alloc->AllocateObjs<char>(kCopySpaceSize);
-    char *copy_space = copy_space_ptr.ptr_;
+    char *copy_space = copy_space_ptr.get();
     REQUIRE(copy_space != nullptr);
 
     auto shm_info_ptr = shared_alloc->AllocateObjs<ShmTransferInfo>(1);
-    ShmTransferInfo *shm_info = shm_info_ptr.ptr_;
+    ShmTransferInfo *shm_info = shm_info_ptr.get();
     REQUIRE(shm_info != nullptr);
     new (shm_info) ShmTransferInfo();
     shm_info->copy_space_size_ = kCopySpaceSize;
 
     // Step 4: Allocate results in shared pinned memory
     auto send_result_ptr = shared_alloc->AllocateObjs<int>(1);
-    int *send_result = send_result_ptr.ptr_;
+    int *send_result = send_result_ptr.get();
     REQUIRE(send_result != nullptr);
     *send_result = -1;
 
     auto recv_result_ptr = shared_alloc->AllocateObjs<int>(1);
-    int *recv_result = recv_result_ptr.ptr_;
+    int *recv_result = recv_result_ptr.get();
     REQUIRE(recv_result != nullptr);
     *recv_result = -1;
 
     auto recv_size_ptr = shared_alloc->AllocateObjs<size_t>(1);
-    size_t *recv_size = recv_size_ptr.ptr_;
+    size_t *recv_size = recv_size_ptr.get();
     REQUIRE(recv_size != nullptr);
     *recv_size = 0;
 

--- a/context-transport-primitives/test/unit/lightbeam/distributed_lightbeam_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/distributed_lightbeam_test.cc
@@ -114,8 +114,8 @@ void ServerThread(Transport& server, size_t num_clients,
     std::cout << "[Server] Received message " << i << ", rc=" << rc
               << std::endl;
 
-    std::string received(meta.recv[0].data.ptr_,
-                         meta.recv[0].data.ptr_ + meta.recv[0].size);
+    std::string received(meta.recv[0].data.get(),
+                         meta.recv[0].data.get() + meta.recv[0].size);
     std::cout << "[Server] Received: " << received << std::endl;
     assert(received == magic);
   }

--- a/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
@@ -302,8 +302,8 @@ void TestSocketTransportWithEM() {
 
   assert(recv_meta.request_id == 55);
   assert(recv_meta.operation == "em_test");
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   assert(received == data);
 
   server->ClearRecvHandles(recv_meta);
@@ -359,8 +359,8 @@ void TestZmqTransportWithEM() {
   assert(recv_meta.request_id == 66);
   assert(recv_meta.operation == "zmq_em");
 
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   assert(received == data);
 
   server->ClearRecvHandles(recv_meta);

--- a/context-transport-primitives/test/unit/lightbeam/lightbeam_transport_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/lightbeam_transport_test.cc
@@ -82,8 +82,8 @@ void TestZeroMQ() {
   }
   assert(recv_meta.send.size() == 1);
 
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   std::cout << "Received: " << received << std::endl;
   assert(received == magic);
 

--- a/context-transport-primitives/test/unit/lightbeam/shm_transfer_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/shm_transfer_test.cc
@@ -314,7 +314,7 @@ TEST_CASE("ShmTransfer - Send/Recv Basic", "[shm_transfer][sendrecv]") {
   LbmMeta<> send_meta;
   std::vector<char> bulk_data = GenerateTestData(DATA_SIZE);
   Bulk bulk;
-  bulk.data.ptr_ = bulk_data.data();
+  bulk.data.set_ptr(bulk_data.data());
   bulk.data.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
   bulk.data.shm_.off_ = 0;
   bulk.size = DATA_SIZE;
@@ -345,19 +345,19 @@ TEST_CASE("ShmTransfer - Send/Recv Basic", "[shm_transfer][sendrecv]") {
   REQUIRE(recv_meta.send.size() == 1);
   REQUIRE(recv_meta.recv.size() == 1);
   REQUIRE(recv_meta.recv[0].size == DATA_SIZE);
-  REQUIRE(recv_meta.recv[0].data.ptr_ != nullptr);
+  REQUIRE(recv_meta.recv[0].data.get() != nullptr);
 
   // Verify received data matches
   bool data_correct = true;
   for (size_t i = 0; i < DATA_SIZE; ++i) {
-    if (recv_meta.recv[0].data.ptr_[i] != static_cast<char>(i % 256)) {
+    if (recv_meta.recv[0].data.get()[i] != static_cast<char>(i % 256)) {
       data_correct = false;
       break;
     }
   }
   REQUIRE(data_correct);
 
-  std::free(recv_meta.recv[0].data.ptr_);
+  std::free(recv_meta.recv[0].data.get());
 }
 
 TEST_CASE("ShmTransfer - Send/Recv Large Multi-Chunk", "[shm_transfer][sendrecv]") {
@@ -369,7 +369,7 @@ TEST_CASE("ShmTransfer - Send/Recv Large Multi-Chunk", "[shm_transfer][sendrecv]
   LbmMeta<> send_meta;
   std::vector<char> bulk_data = GenerateTestData(DATA_SIZE);
   Bulk bulk;
-  bulk.data.ptr_ = bulk_data.data();
+  bulk.data.set_ptr(bulk_data.data());
   bulk.data.shm_.alloc_id_ = hipc::AllocatorId::GetNull();
   bulk.data.shm_.off_ = 0;
   bulk.size = DATA_SIZE;
@@ -402,14 +402,14 @@ TEST_CASE("ShmTransfer - Send/Recv Large Multi-Chunk", "[shm_transfer][sendrecv]
 
   bool data_correct = true;
   for (size_t i = 0; i < DATA_SIZE; ++i) {
-    if (recv_meta.recv[0].data.ptr_[i] != static_cast<char>(i % 256)) {
+    if (recv_meta.recv[0].data.get()[i] != static_cast<char>(i % 256)) {
       data_correct = false;
       break;
     }
   }
   REQUIRE(data_correct);
 
-  std::free(recv_meta.recv[0].data.ptr_);
+  std::free(recv_meta.recv[0].data.get());
 }
 
 TEST_CASE("ShmTransfer - Send/Recv Metadata Only", "[shm_transfer][sendrecv]") {

--- a/context-transport-primitives/test/unit/lightbeam/shm_transport_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/shm_transport_test.cc
@@ -119,10 +119,10 @@ void TestBasicShmTransfer() {
   sender.join();
   assert(send_rc == 0);
 
-  std::string received1(recv_meta.recv[0].data.ptr_,
-                         recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
-  std::string received2(recv_meta.recv[1].data.ptr_,
-                         recv_meta.recv[1].data.ptr_ + recv_meta.recv[1].size);
+  std::string received1(recv_meta.recv[0].data.get(),
+                         recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
+  std::string received2(recv_meta.recv[1].data.get(),
+                         recv_meta.recv[1].data.get() + recv_meta.recv[1].size);
   std::cout << "Bulk 1: " << received1 << "\n";
   std::cout << "Bulk 2: " << received2 << "\n";
   assert(received1 == data1);
@@ -167,8 +167,8 @@ void TestMultipleBulks() {
   assert(send_rc == 0);
 
   for (size_t i = 0; i < data_chunks.size(); ++i) {
-    std::string received(recv_meta.recv[i].data.ptr_,
-                         recv_meta.recv[i].data.ptr_ + recv_meta.recv[i].size);
+    std::string received(recv_meta.recv[i].data.get(),
+                         recv_meta.recv[i].data.get() + recv_meta.recv[i].size);
     std::cout << "Chunk " << i << ": " << received << "\n";
     assert(received == data_chunks[i]);
   }
@@ -245,8 +245,8 @@ void TestLargeTransfer() {
   sender.join();
   assert(send_rc == 0);
 
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   assert(received == large_data);
   std::cout << "Transferred " << large_data.size()
             << " bytes through " << kCopySpaceSize
@@ -267,7 +267,7 @@ void TestShmPtrPassthrough() {
 
   // Simulate a bulk whose data lives in shared memory (non-null alloc_id)
   hipc::FullPtr<char> shm_ptr;
-  shm_ptr.ptr_ = reinterpret_cast<char*>(0xDEADBEEF);
+  shm_ptr.set_ptr(reinterpret_cast<char*>(0xDEADBEEF));
   shm_ptr.shm_.alloc_id_ = hipc::AllocatorId(1, 2);
   shm_ptr.shm_.off_ = 0x1234;
 
@@ -293,7 +293,7 @@ void TestShmPtrPassthrough() {
   assert(send_rc == 0);
 
   // Verify: ptr_ should be nullptr, shm_ should carry the original ShmPtr
-  assert(recv_meta.recv[0].data.ptr_ == nullptr);
+  assert(recv_meta.recv[0].data.get() == nullptr);
   assert(recv_meta.recv[0].data.shm_.alloc_id_ == hipc::AllocatorId(1, 2));
   assert(recv_meta.recv[0].data.shm_.off_.load() == 0x1234);
 
@@ -319,7 +319,7 @@ void TestMixedBulks() {
 
   // Bulk 1: shared memory (ShmPtr passthrough)
   hipc::FullPtr<char> shm_ptr;
-  shm_ptr.ptr_ = reinterpret_cast<char*>(0xCAFEBABE);
+  shm_ptr.set_ptr(reinterpret_cast<char*>(0xCAFEBABE));
   shm_ptr.shm_.alloc_id_ = hipc::AllocatorId(3, 4);
   shm_ptr.shm_.off_ = 0x5678;
 
@@ -352,13 +352,13 @@ void TestMixedBulks() {
   assert(send_rc == 0);
 
   // Verify bulk 0: full data copy
-  std::string received0(recv_meta.recv[0].data.ptr_,
-                         recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received0(recv_meta.recv[0].data.get(),
+                         recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   assert(received0 == private_data);
   std::cout << "Bulk 0 (data copy): " << received0 << "\n";
 
   // Verify bulk 1: ShmPtr passthrough
-  assert(recv_meta.recv[1].data.ptr_ == nullptr);
+  assert(recv_meta.recv[1].data.get() == nullptr);
   assert(recv_meta.recv[1].data.shm_.alloc_id_ == hipc::AllocatorId(3, 4));
   assert(recv_meta.recv[1].data.shm_.off_.load() == 0x5678);
   std::cout << "Bulk 1 (ShmPtr): alloc_id=("
@@ -409,8 +409,8 @@ void TestFactory() {
   sender.join();
   assert(send_rc == 0);
 
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   std::cout << "Received: " << received << "\n";
   assert(received == data);
 
@@ -461,7 +461,7 @@ void TestShmClearRecvHandles() {
   assert(send_rc == 0);
 
   // Verify data was received
-  assert(recv_meta.recv[0].data.ptr_ != nullptr);
+  assert(recv_meta.recv[0].data.get() != nullptr);
 
   // Clear should free the buffer
   server.ClearRecvHandles(recv_meta);
@@ -479,7 +479,7 @@ void TestShmBulkExposeFlag() {
 
   // Create a BULK_EXPOSE entry with a ShmPtr
   hipc::FullPtr<char> shm_ptr;
-  shm_ptr.ptr_ = reinterpret_cast<char*>(0xBAADF00D);
+  shm_ptr.set_ptr(reinterpret_cast<char*>(0xBAADF00D));
   shm_ptr.shm_.alloc_id_ = hipc::AllocatorId(5, 6);
   shm_ptr.shm_.off_ = 0xABCD;
 
@@ -505,7 +505,7 @@ void TestShmBulkExposeFlag() {
 
   // BULK_EXPOSE: only ShmPtr is sent, no data
   assert(recv_meta.recv.size() == 1);
-  assert(recv_meta.recv[0].data.ptr_ == nullptr);
+  assert(recv_meta.recv[0].data.get() == nullptr);
   assert(recv_meta.recv[0].data.shm_.alloc_id_ == hipc::AllocatorId(5, 6));
   assert(recv_meta.recv[0].data.shm_.off_.load() == 0xABCD);
   assert(recv_meta.recv[0].size == 2048);

--- a/context-transport-primitives/test/unit/lightbeam/socket_transport_full_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/socket_transport_full_test.cc
@@ -105,10 +105,10 @@ void TestTcpBasic() {
   assert(recv_meta.request_id == 42);
   assert(recv_meta.operation == "tcp_test");
 
-  std::string received1(recv_meta.recv[0].data.ptr_,
-                         recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
-  std::string received2(recv_meta.recv[1].data.ptr_,
-                         recv_meta.recv[1].data.ptr_ + recv_meta.recv[1].size);
+  std::string received1(recv_meta.recv[0].data.get(),
+                         recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
+  std::string received2(recv_meta.recv[1].data.get(),
+                         recv_meta.recv[1].data.get() + recv_meta.recv[1].size);
   assert(received1 == data1);
   assert(received2 == data2);
 
@@ -147,8 +147,8 @@ void TestMultipleBulks() {
   assert(recv_meta.send.size() == data_chunks.size());
 
   for (size_t i = 0; i < data_chunks.size(); ++i) {
-    std::string received(recv_meta.recv[i].data.ptr_,
-                         recv_meta.recv[i].data.ptr_ + recv_meta.recv[i].size);
+    std::string received(recv_meta.recv[i].data.get(),
+                         recv_meta.recv[i].data.get() + recv_meta.recv[i].size);
     assert(received == data_chunks[i]);
   }
 
@@ -185,8 +185,8 @@ void TestUnixDomain() {
   assert(recv_meta.request_id == 99);
   assert(recv_meta.operation == "ipc_test");
 
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   assert(received == data);
 
   server->ClearRecvHandles(recv_meta);
@@ -294,7 +294,7 @@ void TestLargeTransfer() {
 
   int mismatches = 0;
   for (size_t i = 0; i < large_size; ++i) {
-    if (recv_meta.recv[0].data.ptr_[i] != large_data[i]) {
+    if (recv_meta.recv[0].data.get()[i] != large_data[i]) {
       mismatches++;
     }
   }
@@ -345,11 +345,11 @@ void TestClearRecvHandles() {
   assert(info.rc == 0);
 
   // After recv, data pointer should be non-null (malloc'd buffer)
-  assert(recv_meta.recv[0].data.ptr_ != nullptr);
+  assert(recv_meta.recv[0].data.get() != nullptr);
 
   // Clear handles should free the buffers
   server->ClearRecvHandles(recv_meta);
-  assert(recv_meta.recv[0].data.ptr_ == nullptr);
+  assert(recv_meta.recv[0].data.get() == nullptr);
 
   std::cout << "[Socket ClearRecvHandles] Test passed!\n";
 }
@@ -384,8 +384,8 @@ void TestBidirectional() {
   assert(recv_meta.request_id == 1);
   assert(info.fd_ >= 0);
 
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   assert(received == request_data);
   server->ClearRecvHandles(recv_meta);
 
@@ -410,8 +410,8 @@ void TestBidirectional() {
   assert(client_recv.request_id == 2);
   assert(client_recv.operation == "response");
 
-  std::string resp_received(client_recv.recv[0].data.ptr_,
-                            client_recv.recv[0].data.ptr_ + client_recv.recv[0].size);
+  std::string resp_received(client_recv.recv[0].data.get(),
+                            client_recv.recv[0].data.get() + client_recv.recv[0].size);
   assert(resp_received == response_data);
   client->ClearRecvHandles(client_recv);
 

--- a/context-transport-primitives/test/unit/lightbeam/socket_transport_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/socket_transport_test.cc
@@ -115,10 +115,10 @@ void TestBasicTcpTransfer() {
   std::cout << "Server received bulk data successfully\n";
 
   // Verify data from transport-allocated recv buffers
-  std::string received1(recv_meta.recv[0].data.ptr_,
-                         recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
-  std::string received2(recv_meta.recv[1].data.ptr_,
-                         recv_meta.recv[1].data.ptr_ + recv_meta.recv[1].size);
+  std::string received1(recv_meta.recv[0].data.get(),
+                         recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
+  std::string received2(recv_meta.recv[1].data.get(),
+                         recv_meta.recv[1].data.get() + recv_meta.recv[1].size);
   std::cout << "Bulk 1: " << received1 << "\n";
   std::cout << "Bulk 2: " << received2 << "\n";
   assert(received1 == data1);
@@ -171,8 +171,8 @@ void TestMultipleBulks() {
   assert(recv_meta.send.size() == data_chunks.size());
 
   for (size_t i = 0; i < data_chunks.size(); ++i) {
-    std::string received(recv_meta.recv[i].data.ptr_,
-                         recv_meta.recv[i].data.ptr_ + recv_meta.recv[i].size);
+    std::string received(recv_meta.recv[i].data.get(),
+                         recv_meta.recv[i].data.get() + recv_meta.recv[i].size);
     std::cout << "Chunk " << i << ": " << received << "\n";
     assert(received == data_chunks[i]);
   }
@@ -224,8 +224,8 @@ void TestUnixDomainSocket() {
   assert(recv_meta.request_id == 99);
   assert(recv_meta.operation == "ipc_test");
 
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   std::cout << "Received: " << received << "\n";
   assert(received == data);
 

--- a/context-transport-primitives/test/unit/lightbeam/test_lightbeam_new.cc
+++ b/context-transport-primitives/test/unit/lightbeam/test_lightbeam_new.cc
@@ -114,10 +114,10 @@ void TestBasicTransfer() {
   std::cout << "Server received bulk data successfully\n";
 
   // Verify received data from transport-allocated recv buffers
-  std::string received1(recv_meta.recv[0].data.ptr_,
-                         recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
-  std::string received2(recv_meta.recv[1].data.ptr_,
-                         recv_meta.recv[1].data.ptr_ + recv_meta.recv[1].size);
+  std::string received1(recv_meta.recv[0].data.get(),
+                         recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
+  std::string received2(recv_meta.recv[1].data.get(),
+                         recv_meta.recv[1].data.get() + recv_meta.recv[1].size);
 
   std::cout << "Bulk 1: " << received1 << "\n";
   std::cout << "Bulk 2: " << received2 << "\n";
@@ -178,8 +178,8 @@ void TestMultipleBulks() {
 
   // Verify all chunks from transport-allocated recv buffers
   for (size_t i = 0; i < data_chunks.size(); ++i) {
-    std::string received(recv_meta.recv[i].data.ptr_,
-                         recv_meta.recv[i].data.ptr_ + recv_meta.recv[i].size);
+    std::string received(recv_meta.recv[i].data.get(),
+                         recv_meta.recv[i].data.get() + recv_meta.recv[i].size);
     std::cout << "Chunk " << i << ": " << received << "\n";
     assert(received == data_chunks[i]);
   }

--- a/context-transport-primitives/test/unit/lightbeam/zmq_transport_full_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/zmq_transport_full_test.cc
@@ -106,10 +106,10 @@ void TestBasicTransfer() {
   assert(recv_meta.operation == "zmq_test");
   assert(recv_meta.send.size() == 2);
 
-  std::string received1(recv_meta.recv[0].data.ptr_,
-                         recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
-  std::string received2(recv_meta.recv[1].data.ptr_,
-                         recv_meta.recv[1].data.ptr_ + recv_meta.recv[1].size);
+  std::string received1(recv_meta.recv[0].data.get(),
+                         recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
+  std::string received2(recv_meta.recv[1].data.get(),
+                         recv_meta.recv[1].data.get() + recv_meta.recv[1].size);
   assert(received1 == data1);
   assert(received2 == data2);
 
@@ -148,8 +148,8 @@ void TestMultipleBulks() {
   assert(recv_meta.send.size() == data_chunks.size());
 
   for (size_t i = 0; i < data_chunks.size(); ++i) {
-    std::string received(recv_meta.recv[i].data.ptr_,
-                         recv_meta.recv[i].data.ptr_ + recv_meta.recv[i].size);
+    std::string received(recv_meta.recv[i].data.get(),
+                         recv_meta.recv[i].data.get() + recv_meta.recv[i].size);
     assert(received == data_chunks[i]);
   }
 
@@ -257,7 +257,7 @@ void TestLargeTransfer() {
   // Verify data integrity
   int mismatches = 0;
   for (size_t i = 0; i < large_size; ++i) {
-    if (recv_meta.recv[0].data.ptr_[i] != large_data[i]) {
+    if (recv_meta.recv[0].data.get()[i] != large_data[i]) {
       mismatches++;
     }
   }
@@ -350,8 +350,8 @@ void TestBidirectional() {
   assert(recv_meta.request_id == 1);
   assert(!info.identity_.empty());
 
-  std::string received(recv_meta.recv[0].data.ptr_,
-                       recv_meta.recv[0].data.ptr_ + recv_meta.recv[0].size);
+  std::string received(recv_meta.recv[0].data.get(),
+                       recv_meta.recv[0].data.get() + recv_meta.recv[0].size);
   assert(received == request_data);
   server->ClearRecvHandles(recv_meta);
 
@@ -375,8 +375,8 @@ void TestBidirectional() {
   assert(client_recv.request_id == 2);
   assert(client_recv.operation == "response");
 
-  std::string resp_received(client_recv.recv[0].data.ptr_,
-                            client_recv.recv[0].data.ptr_ + client_recv.recv[0].size);
+  std::string resp_received(client_recv.recv[0].data.get(),
+                            client_recv.recv[0].data.get() + client_recv.recv[0].size);
   assert(resp_received == response_data);
   client->ClearRecvHandles(client_recv);
 

--- a/context-transport-primitives/test/unit/util/test_numbers.cc
+++ b/context-transport-primitives/test/unit/util/test_numbers.cc
@@ -72,9 +72,9 @@ TEST_CASE("BitWidth - Non-powers of two") {
 }
 
 TEST_CASE("BitWidth - equals FloorLog2 plus one for positive values") {
-  hshm::size_t values[] = {1, 2, 3, 5, 7, 9, 15, 17, 63, 64, 100, 1000,
+  size_t values[] = {1, 2, 3, 5, 7, 9, 15, 17, 63, 64, 100, 1000,
                             1ULL << 20, 1ULL << 32};
-  for (hshm::size_t v : values) {
+  for (size_t v : values) {
     REQUIRE(hshm::BitWidth(v) == hshm::FloorLog2(v) + 1);
   }
 }
@@ -113,9 +113,9 @@ TEST_CASE("FloorLog2 - Non-powers of two") {
 }
 
 TEST_CASE("FloorLog2 - Equals CeilLog2 for powers of two") {
-  hshm::size_t powers[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024,
+  size_t powers[] = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024,
                             1ULL << 20, 1ULL << 32};
-  for (hshm::size_t p : powers) {
+  for (size_t p : powers) {
     REQUIRE(hshm::FloorLog2(p) == hshm::CeilLog2(p));
   }
 }
@@ -159,28 +159,28 @@ TEST_CASE("CeilLog2 - Non-powers of two") {
 }
 
 TEST_CASE("CeilLog2 - Ceil is at least Floor for all values") {
-  hshm::size_t values[] = {1, 2, 3, 5, 7, 9, 15, 17, 63, 64, 100, 1000,
+  size_t values[] = {1, 2, 3, 5, 7, 9, 15, 17, 63, 64, 100, 1000,
                             1ULL << 20, 1ULL << 32};
-  for (hshm::size_t v : values) {
+  for (size_t v : values) {
     REQUIRE(hshm::CeilLog2(v) >= hshm::FloorLog2(v));
   }
 }
 
 TEST_CASE("CeilLog2 - Ceil exceeds Floor only for non-powers-of-two") {
-  hshm::size_t non_powers[] = {3, 5, 6, 7, 9, 10, 15, 17, 100, 1000};
-  for (hshm::size_t v : non_powers) {
+  size_t non_powers[] = {3, 5, 6, 7, 9, 10, 15, 17, 100, 1000};
+  for (size_t v : non_powers) {
     REQUIRE(hshm::CeilLog2(v) == hshm::FloorLog2(v) + 1);
   }
 }
 
 TEST_CASE("CeilLog2 - Large value 1ULL << 20") {
-  hshm::size_t v = 1ULL << 20;
+  size_t v = 1ULL << 20;
   REQUIRE(hshm::CeilLog2(v) == 20);
   REQUIRE(hshm::FloorLog2(v) == 20);
 }
 
 TEST_CASE("CeilLog2 - Large value 1ULL << 32") {
-  hshm::size_t v = 1ULL << 32;
+  size_t v = 1ULL << 32;
   REQUIRE(hshm::CeilLog2(v) == 32);
   REQUIRE(hshm::FloorLog2(v) == 32);
 }


### PR DESCRIPTION
The reinterpret cast here will cause UB when the `ptr_` is dereferenced, due to [type accessibility](https://en.cppreference.com/w/cpp/language/reinterpret_cast.html):
```cpp
template <typename AllocT>
HSHM_CROSS_FUN explicit FullPtr(AllocT *alloc, size_t offset) {
    shm_.off_ = offset;
    shm_.alloc_id_ = alloc->GetId();
    ptr_ = reinterpret_cast<T *>(alloc->GetBackendData() + offset);
}
```
From [cpp-reference](https://en.cppreference.com/w/cpp/language/reinterpret_cast.html):
> ### Type accessibility
> If a type T_ref is [similar](https://en.cppreference.com/w/cpp/language/implicit_cast.html#Similar_types) to any of the following types, an object of [dynamic type](https://en.cppreference.com/w/cpp/language/type-id.html#Dynamic_type) T_obj is type-accessible through a lvalue(until C++11)glvalue(since C++11) of type T_ref:
> - char, unsigned char or std::byte(since C++17): this permits examination of the [object representation](https://en.cppreference.com/w/cpp/language/objects.html#Object_representation_and_value_representation) of any object as an array of bytes.
> - T_obj
> - the signed or unsigned type corresponding to T_obj 
> 
> If a program attempts to read or modify the stored value of an object through a lvalue(until C++11)glvalue(since C++11) through which it is not type-accessible, the behavior is undefined.
> 
> This rule enables type-based alias analysis, in which a compiler assumes that the value read through a glvalue of one type is not modified by a write to a glvalue of a different type (subject to the exceptions noted above).
> 
> Note that many C++ compilers relax this rule, as a non-standard language extension, to allow wrong-type access through the inactive member of a [union](https://en.cppreference.com/w/cpp/language/union.html) (such access is not undefined in C).

This can be somewhat addressed by [laundering](https://en.cppreference.com/w/cpp/utility/launder.html) the pointer before each dereference. To mostly enforce this, this PR makes the `ptr_` field private, instead opting to use a `.get()` method to retrieve the internal pointer. This does not incur any performance penalty.

Ideally, this would be fixed using [`std::start_lifetime_as<T>`](https://en.cppreference.com/w/cpp/memory/start_lifetime_as.html), but that's only in C++23. Laundering at every dereference works instead.

blocked by #343 