### PR TITLE
fix: GPU Compilation errors

### DIFF
--- a/context-assimilation-engine/core/include/wrp_cae/core/autogen/core_methods.h
+++ b/context-assimilation-engine/core/include/wrp_cae/core/autogen/core_methods.h
@@ -10,17 +10,20 @@
 namespace wrp_cae::core {
 
 namespace Method {
-// Inherited methods
-GLOBAL_CONST chi::u32 kCreate = 0;
-GLOBAL_CONST chi::u32 kDestroy = 1;
-GLOBAL_CONST chi::u32 kMonitor = 9;
 
-// core-specific methods
-GLOBAL_CONST chi::u32 kParseOmni = 10;
-GLOBAL_CONST chi::u32 kProcessHdf5Dataset = 11;
-GLOBAL_CONST chi::u32 kExportData = 12;
+enum : chi::u32 {
+  // Inherited methods
+  kCreate = 0,
+  kDestroy = 1,
+  kMonitor = 9,
 
-GLOBAL_CONST chi::u32 kMaxMethodId = 13;
+  // core-specific methods
+  kParseOmni = 10,
+  kProcessHdf5Dataset = 11,
+  kExportData = 12,
+
+  kMaxMethodId = 13,
+};
 }  // namespace Method
 
 }  // namespace wrp_cae::core

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -61,7 +61,9 @@
 #include "hermes_shm/memory/backend/gpu_malloc.h"
 #include "hermes_shm/memory/backend/gpu_shm_mmap.h"
 #if defined(__x86_64__) || defined(__i386__)
+#ifndef __CUDACC__
 #include <immintrin.h>
+#endif
 #endif
 #endif
 

--- a/context-runtime/include/chimaera/ipc_manager.h
+++ b/context-runtime/include/chimaera/ipc_manager.h
@@ -60,12 +60,10 @@
 #include "hermes_shm/memory/allocator/arena_allocator.h"
 #include "hermes_shm/memory/backend/gpu_malloc.h"
 #include "hermes_shm/memory/backend/gpu_shm_mmap.h"
-#if defined(__x86_64__) || defined(__i386__)
-#ifndef __CUDACC__
+#if (defined(__x86_64__) || defined(__i386__)) && !HSHM_IS_GPU_COMPILER
 #include <immintrin.h>
-#endif
-#endif
-#endif
+#endif  // x86 && !GPU_COMPILER
+#endif  // HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
 
 namespace chi {
 
@@ -1858,7 +1856,10 @@ class IpcManager {
     // without clflush they may not reach DRAM before the GPU (on discrete
     // PCIe) reads them.  Must flush the entire allocation (header + ring
     // buffer data written by ShmTransport::Send above).
-#if defined(__x86_64__) || defined(__i386__)
+    // Suppressed under GPU compilers: this TU is compiled by NVCC for device-
+    // callable host wrappers; the actual CPU server path that needs clflush
+    // is compiled by g++ where HSHM_IS_GPU_COMPILER is 0.
+#if (defined(__x86_64__) || defined(__i386__)) && !HSHM_IS_GPU_COMPILER
     {
       const char *base = reinterpret_cast<const char *>(future_shm);
       for (const char *cl = base; cl < base + alloc_size; cl += 64) {

--- a/context-runtime/modules/MOD_NAME/include/chimaera/MOD_NAME/autogen/MOD_NAME_methods.h
+++ b/context-runtime/modules/MOD_NAME/include/chimaera/MOD_NAME/autogen/MOD_NAME_methods.h
@@ -12,20 +12,23 @@
 namespace chimaera::MOD_NAME {
 
 namespace Method {
-// Inherited methods
-GLOBAL_CONST chi::u32 kCreate = 0;
-GLOBAL_CONST chi::u32 kDestroy = 1;
-GLOBAL_CONST chi::u32 kMonitor = 9;
 
-// MOD_NAME-specific methods
-GLOBAL_CONST chi::u32 kCustom = 10;
-GLOBAL_CONST chi::u32 kCoMutexTest = 20;
-GLOBAL_CONST chi::u32 kCoRwLockTest = 21;
-GLOBAL_CONST chi::u32 kWaitTest = 23;
-GLOBAL_CONST chi::u32 kTestLargeOutput = 24;
-GLOBAL_CONST chi::u32 kGpuSubmit = 25;
+enum : chi::u32 {
+  // Inherited methods
+  kCreate = 0,
+  kDestroy = 1,
+  kMonitor = 9,
 
-GLOBAL_CONST chi::u32 kMaxMethodId = 26;
+  // MOD_NAME-specific methods
+  kCustom = 10,
+  kCoMutexTest = 20,
+  kCoRwLockTest = 21,
+  kWaitTest = 23,
+  kTestLargeOutput = 24,
+  kGpuSubmit = 25,
+
+  kMaxMethodId = 26,
+};
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {

--- a/context-runtime/modules/admin/include/chimaera/admin/autogen/admin_methods.h
+++ b/context-runtime/modules/admin/include/chimaera/admin/autogen/admin_methods.h
@@ -12,37 +12,40 @@
 namespace chimaera::admin {
 
 namespace Method {
-// Inherited methods
-GLOBAL_CONST chi::u32 kCreate = 0;
-GLOBAL_CONST chi::u32 kDestroy = 1;
-GLOBAL_CONST chi::u32 kMonitor = 9;
 
-// admin-specific methods
-GLOBAL_CONST chi::u32 kGetOrCreatePool = 10;
-GLOBAL_CONST chi::u32 kDestroyPool = 11;
-GLOBAL_CONST chi::u32 kStopRuntime = 12;
-GLOBAL_CONST chi::u32 kFlush = 13;
-GLOBAL_CONST chi::u32 kSend = 14;
-GLOBAL_CONST chi::u32 kRecv = 15;
-GLOBAL_CONST chi::u32 kClientConnect = 16;
-GLOBAL_CONST chi::u32 kSubmitBatch = 18;
-GLOBAL_CONST chi::u32 kWreapDeadIpcs = 19;
-GLOBAL_CONST chi::u32 kClientRecv = 20;
-GLOBAL_CONST chi::u32 kClientSend = 21;
-GLOBAL_CONST chi::u32 kRegisterMemory = 22;
-GLOBAL_CONST chi::u32 kRestartContainers = 23;
-GLOBAL_CONST chi::u32 kAddNode = 24;
-GLOBAL_CONST chi::u32 kChangeAddressTable = 25;
-GLOBAL_CONST chi::u32 kMigrateContainers = 26;
-GLOBAL_CONST chi::u32 kHeartbeat = 27;
-GLOBAL_CONST chi::u32 kHeartbeatProbe = 28;
-GLOBAL_CONST chi::u32 kProbeRequest = 29;
-GLOBAL_CONST chi::u32 kRecoverContainers = 30;
-GLOBAL_CONST chi::u32 kSystemMonitor = 31;
-GLOBAL_CONST chi::u32 kAnnounceShutdown = 32;
-GLOBAL_CONST chi::u32 kRegisterGpuContainer = 33;
+enum : chi::u32 {
+  // Inherited methods
+  kCreate = 0,
+  kDestroy = 1,
+  kMonitor = 9,
 
-GLOBAL_CONST chi::u32 kMaxMethodId = 34;
+  // admin-specific methods
+  kGetOrCreatePool = 10,
+  kDestroyPool = 11,
+  kStopRuntime = 12,
+  kFlush = 13,
+  kSend = 14,
+  kRecv = 15,
+  kClientConnect = 16,
+  kSubmitBatch = 18,
+  kWreapDeadIpcs = 19,
+  kClientRecv = 20,
+  kClientSend = 21,
+  kRegisterMemory = 22,
+  kRestartContainers = 23,
+  kAddNode = 24,
+  kChangeAddressTable = 25,
+  kMigrateContainers = 26,
+  kHeartbeat = 27,
+  kHeartbeatProbe = 28,
+  kProbeRequest = 29,
+  kRecoverContainers = 30,
+  kSystemMonitor = 31,
+  kAnnounceShutdown = 32,
+  kRegisterGpuContainer = 33,
+
+  kMaxMethodId = 34,
+};
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {

--- a/context-runtime/src/chimaera_manager.cc
+++ b/context-runtime/src/chimaera_manager.cc
@@ -298,12 +298,14 @@ bool Chimaera::ServerInit() {
   // Launch GPU work orchestrator after all initial pools are created, so that
   // cudaMalloc calls during GPU container allocation don't deadlock
   // against the persistent GPU work orchestrator.
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
   if (!ipc_manager->LaunchGpuOrchestrator()) {
     HLOG(kError, "Failed to launch GPU work orchestrator");
     is_runtime_mode_ = false;
     runtime_is_initializing_ = false;
     return false;
   }
+#endif
 
   // Start local server last - after all other initialization is complete
   // This ensures clients can connect only when runtime is fully ready

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -957,6 +957,7 @@ void IpcManager::SetGpuOrchestratorBlocks(u32 blocks, u32 threads_per_block) {
 #endif
 }
 
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
 TaskQueue *IpcManager::GetToGpuQueue(size_t gpu_id) {
   if (gpu_id < cpu2gpu_queues_.size()) {
     return cpu2gpu_queues_[gpu_id].ptr_;
@@ -970,6 +971,7 @@ TaskQueue *IpcManager::GetGpuToGpuQueue(size_t gpu_id) {
   }
   return nullptr;
 }
+#endif  // HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
 
 void IpcManager::RegisterGpuAllocator(const hipc::MemoryBackendId &id,
                                        char *data, size_t capacity) {

--- a/context-runtime/util/chimaera_cmd_refresh_repo.cc
+++ b/context-runtime/util/chimaera_cmd_refresh_repo.cc
@@ -216,32 +216,39 @@ class ChiModGenerator {
     std::copy_if(methods.begin(), methods.end(), std::back_inserter(inherited_methods),
                  [](const Method& m) { return m.is_inherited; });
 
-    if (!inherited_methods.empty()) {
-      oss << "// Inherited methods\n";
-      for (const auto& method : inherited_methods) {
-        oss << "GLOBAL_CONST chi::u32 " << method.constant_name << " = " << method.method_id << ";\n";
-      }
-      oss << "\n";
-    }
-
     // Add custom methods
     std::vector<Method> custom_methods;
     std::copy_if(methods.begin(), methods.end(), std::back_inserter(custom_methods),
                  [](const Method& m) { return !m.is_inherited; });
 
-    if (!custom_methods.empty()) {
-      oss << "// " << module_name << "-specific methods\n";
-      for (const auto& method : custom_methods) {
-        oss << "GLOBAL_CONST chi::u32 " << method.constant_name << " = " << method.method_id << ";\n";
+    // Emit a single enum block — enums are visible in device code under NVCC
+    // whereas GLOBAL_CONST variables require special handling to cross the
+    // host/device boundary.
+    oss << "\nenum : chi::u32 {\n";
+
+    if (!inherited_methods.empty()) {
+      oss << "  // Inherited methods\n";
+      for (const auto& method : inherited_methods) {
+        oss << "  " << method.constant_name << " = " << method.method_id << ",\n";
       }
+      oss << "\n";
     }
 
-    // Emit kMaxMethodId (one past the highest method ID)
-    if (!methods.empty()) {
-      oss << "\nGLOBAL_CONST chi::u32 kMaxMethodId = " << (methods.back().method_id + 1) << ";\n";
-    } else {
-      oss << "\nGLOBAL_CONST chi::u32 kMaxMethodId = 0;\n";
+    if (!custom_methods.empty()) {
+      oss << "  // " << module_name << "-specific methods\n";
+      for (const auto& method : custom_methods) {
+        oss << "  " << method.constant_name << " = " << method.method_id << ",\n";
+      }
+      oss << "\n";
     }
+
+    if (!methods.empty()) {
+      oss << "  kMaxMethodId = " << (methods.back().method_id + 1) << ",\n";
+    } else {
+      oss << "  kMaxMethodId = 0,\n";
+    }
+
+    oss << "};\n";
 
     // Emit GetMethodNames() function returning names indexed by method ID
     oss << "\ninline const std::vector<std::string>& GetMethodNames() {\n";

--- a/context-transfer-engine/compressor/include/wrp_cte/compressor/autogen/compressor_methods.h
+++ b/context-transfer-engine/compressor/include/wrp_cte/compressor/autogen/compressor_methods.h
@@ -12,17 +12,20 @@
 namespace wrp_cte::compressor {
 
 namespace Method {
-// Inherited methods
-GLOBAL_CONST chi::u32 kCreate = 0;
-GLOBAL_CONST chi::u32 kDestroy = 1;
-GLOBAL_CONST chi::u32 kMonitor = 9;
 
-// compressor-specific methods
-GLOBAL_CONST chi::u32 kDynamicSchedule = 10;
-GLOBAL_CONST chi::u32 kCompress = 11;
-GLOBAL_CONST chi::u32 kDecompress = 12;
+enum : chi::u32 {
+  // Inherited methods
+  kCreate = 0,
+  kDestroy = 1,
+  kMonitor = 9,
 
-GLOBAL_CONST chi::u32 kMaxMethodId = 13;
+  // compressor-specific methods
+  kDynamicSchedule = 10,
+  kCompress = 11,
+  kDecompress = 12,
+
+  kMaxMethodId = 13,
+};
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {

--- a/context-transfer-engine/core/include/wrp_cte/core/autogen/core_methods.h
+++ b/context-transfer-engine/core/include/wrp_cte/core/autogen/core_methods.h
@@ -12,35 +12,38 @@
 namespace wrp_cte::core {
 
 namespace Method {
-// Inherited methods
-GLOBAL_CONST chi::u32 kCreate = 0;
-GLOBAL_CONST chi::u32 kDestroy = 1;
-GLOBAL_CONST chi::u32 kMonitor = 9;
 
-// core-specific methods
-GLOBAL_CONST chi::u32 kRegisterTarget = 10;
-GLOBAL_CONST chi::u32 kUnregisterTarget = 11;
-GLOBAL_CONST chi::u32 kListTargets = 12;
-GLOBAL_CONST chi::u32 kStatTargets = 13;
-GLOBAL_CONST chi::u32 kGetOrCreateTag = 14;
-GLOBAL_CONST chi::u32 kPutBlob = 15;
-GLOBAL_CONST chi::u32 kGetBlob = 16;
-GLOBAL_CONST chi::u32 kReorganizeBlob = 17;
-GLOBAL_CONST chi::u32 kDelBlob = 18;
-GLOBAL_CONST chi::u32 kDelTag = 19;
-GLOBAL_CONST chi::u32 kGetTagSize = 20;
-GLOBAL_CONST chi::u32 kPollTelemetryLog = 21;
-GLOBAL_CONST chi::u32 kGetBlobScore = 22;
-GLOBAL_CONST chi::u32 kGetBlobSize = 23;
-GLOBAL_CONST chi::u32 kGetContainedBlobs = 24;
-GLOBAL_CONST chi::u32 kGetBlobInfo = 25;
-GLOBAL_CONST chi::u32 kTagQuery = 30;
-GLOBAL_CONST chi::u32 kBlobQuery = 31;
-GLOBAL_CONST chi::u32 kGetTargetInfo = 32;
-GLOBAL_CONST chi::u32 kFlushMetadata = 33;
-GLOBAL_CONST chi::u32 kFlushData = 34;
+enum : chi::u32 {
+  // Inherited methods
+  kCreate = 0,
+  kDestroy = 1,
+  kMonitor = 9,
 
-GLOBAL_CONST chi::u32 kMaxMethodId = 35;
+  // core-specific methods
+  kRegisterTarget = 10,
+  kUnregisterTarget = 11,
+  kListTargets = 12,
+  kStatTargets = 13,
+  kGetOrCreateTag = 14,
+  kPutBlob = 15,
+  kGetBlob = 16,
+  kReorganizeBlob = 17,
+  kDelBlob = 18,
+  kDelTag = 19,
+  kGetTagSize = 20,
+  kPollTelemetryLog = 21,
+  kGetBlobScore = 22,
+  kGetBlobSize = 23,
+  kGetContainedBlobs = 24,
+  kGetBlobInfo = 25,
+  kTagQuery = 30,
+  kBlobQuery = 31,
+  kGetTargetInfo = 32,
+  kFlushMetadata = 33,
+  kFlushData = 34,
+
+  kMaxMethodId = 35,
+};
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {


### PR DESCRIPTION
This fixes various issues blocking CTE from compiling on the GPU. The current unit tests don't actually run on the GPU. Issues have to do with missing guards and the autogenerated code's use of `static constexpr` not being GPU-compatible.