### PR TITLE
fix: Invalid CMake configuration

### DIFF
--- a/context-runtime/src/CMakeLists.txt
+++ b/context-runtime/src/CMakeLists.txt
@@ -47,7 +47,29 @@ add_library(${CHIMAERA_LIB_NAME} SHARED ${CHIMAERA_CPU_SOURCES})
 # Build GPU work orchestrator library if CUDA/ROCm enabled and GPU sources exist
 if(CHIMAERA_GPU_SOURCES)
   if(WRP_CORE_ENABLE_CUDA)
-    add_cuda_library(${CHIMAERA_LIB_NAME}_gpu SHARED TRUE ${CHIMAERA_GPU_SOURCES})
+    # Collect transitive include dirs from dependencies that Clang CUDA
+    # custom commands cannot resolve via generator expressions.
+    set(_CHIMAERA_GPU_EXTRA_INCLUDES "")
+    foreach(_dep yaml-cpp::yaml-cpp ZeroMQ::libzmq)
+      if(TARGET "${_dep}")
+        get_target_property(_dep_incs "${_dep}" INTERFACE_INCLUDE_DIRECTORIES)
+        if(_dep_incs)
+          list(APPEND _CHIMAERA_GPU_EXTRA_INCLUDES ${_dep_incs})
+        endif()
+      endif()
+    endforeach()
+    add_cuda_library(${CHIMAERA_LIB_NAME}_gpu SHARED TRUE ${CHIMAERA_GPU_SOURCES}
+      INCLUDE_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../modules/admin/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../modules/MOD_NAME/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../modules/bdev/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../context-transport-primitives/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../context-transfer-engine/core/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../compiler/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${_CHIMAERA_GPU_EXTRA_INCLUDES}
+    )
     target_include_directories(${CHIMAERA_LIB_NAME}_gpu PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../modules/admin/include>
@@ -55,6 +77,7 @@ if(CHIMAERA_GPU_SOURCES)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../modules/bdev/include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../context-transport-primitives/include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../context-transfer-engine/core/include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../compiler/include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     )
     target_link_libraries(${CHIMAERA_LIB_NAME}_gpu PUBLIC hshm::cuda_cxx)

--- a/context-transfer-engine/benchmark/CMakeLists.txt
+++ b/context-transfer-engine/benchmark/CMakeLists.txt
@@ -141,6 +141,20 @@ if(WRP_CORE_ENABLE_CUDA)
       --client-blocks 1 --client-threads 256)
   set_tests_properties(cte_gpu_bench_alloc_test PROPERTIES
     TIMEOUT 60 LABELS "msan_skip")
+
+  # Set CHI_REPO_PATH so the ChiMod plugin loader finds module .so files
+  set_tests_properties(
+    cte_gpu_bench_putblob_gpu
+    cte_gpu_bench_putblob_gpu_multiblock
+    cte_gpu_bench_direct
+    cte_gpu_bench_cudamemcpy
+    cte_gpu_bench_putblob_gpu_stress
+    cte_gpu_bench_putblob_gpu_64warp
+    cte_gpu_bench_putblob_gpu_64warp_stress
+    cte_gpu_bench_alloc_test
+    PROPERTIES
+      ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+  )
 else()
   message(STATUS "Skipping wrp_cte_gpu_bench - CUDA not enabled")
 endif()

--- a/context-transfer-engine/benchmark/CMakeLists.txt
+++ b/context-transfer-engine/benchmark/CMakeLists.txt
@@ -65,6 +65,8 @@ if(WRP_CORE_ENABLE_CUDA)
           ${CMAKE_SOURCE_DIR}/context-runtime/modules/admin/include
           ${CMAKE_SOURCE_DIR}/context-runtime/modules/bdev/include
           ${CMAKE_SOURCE_DIR}/context-transport-primitives/include
+          ${CMAKE_SOURCE_DIR}/context-runtime/compiler/include
+          ${_CTE_GPU_BENCH_EXTRA_INCLUDES}
       LINK_LIBS
           wrp_cte::core_client
           chimaera::cxx

--- a/context-transfer-engine/benchmark/CMakeLists.txt
+++ b/context-transfer-engine/benchmark/CMakeLists.txt
@@ -47,6 +47,16 @@ endif()
 
 # GPU benchmark (requires CUDA) — single-file build via add_cuda_executable
 if(WRP_CORE_ENABLE_CUDA)
+  # Collect transitive include dirs from dependencies for Clang CUDA
+  set(_CTE_GPU_BENCH_EXTRA_INCLUDES "")
+  foreach(_dep yaml-cpp::yaml-cpp ZeroMQ::libzmq)
+    if(TARGET "${_dep}")
+      get_target_property(_dep_incs "${_dep}" INTERFACE_INCLUDE_DIRECTORIES)
+      if(_dep_incs)
+        list(APPEND _CTE_GPU_BENCH_EXTRA_INCLUDES ${_dep_incs})
+      endif()
+    endif()
+  endforeach()
   add_cuda_executable(wrp_cte_gpu_bench TRUE
       wrp_cte_gpu_bench.cc
       INCLUDE_DIRS

--- a/context-transport-primitives/src/CMakeLists.txt
+++ b/context-transport-primitives/src/CMakeLists.txt
@@ -65,7 +65,16 @@ list(APPEND HSHM_LIBS cxx)
 
 # BUILD HSHM FOR CUDA ONLY
 if(WRP_CORE_ENABLE_CUDA)
-    add_cuda_library(hermes_shm_cuda SHARED TRUE ${SRC_FILES})
+    add_cuda_library(hermes_shm_cuda SHARED TRUE ${SRC_FILES}
+      INCLUDE_DIRS
+        ${HSHM_ROOT}/include
+        ${PROJECT_BINARY_DIR}/include
+    )
+    target_include_directories(hermes_shm_cuda PUBLIC
+        $<BUILD_INTERFACE:${HSHM_ROOT}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    )
     target_link_libraries(hermes_shm_cuda PUBLIC host_deps)
     target_compile_definitions(hermes_shm_cuda PUBLIC HSHM_ENABLE_CUDA=1)
     hshm_target_compile_definitions(hermes_shm_cuda)

--- a/context-transport-primitives/test/unit/gpu/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/gpu/CMakeLists.txt
@@ -5,8 +5,14 @@
 if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
   message(STATUS "Building GPU unit tests")
 
+  set(HSHM_GPU_INCLUDE_DIRS
+    ${HSHM_ROOT}/include
+    ${PROJECT_BINARY_DIR}/include
+  )
+
   # GpuShmMmap test
-  add_cuda_executable(test_gpu_shm_mmap TRUE test_gpu_shm_mmap.cc)
+  add_cuda_executable(test_gpu_shm_mmap TRUE test_gpu_shm_mmap.cc
+    INCLUDE_DIRS ${HSHM_GPU_INCLUDE_DIRS})
   target_link_libraries(test_gpu_shm_mmap
     hshm::cuda_cxx
     Catch2::Catch2WithMain
@@ -22,7 +28,8 @@ if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
   # add_test(NAME test_gpu_malloc COMMAND test_gpu_malloc)
 
   # LocalSerialize GPU test
-  add_cuda_executable(test_local_serialize_gpu TRUE test_local_serialize_gpu.cc)
+  add_cuda_executable(test_local_serialize_gpu TRUE test_local_serialize_gpu.cc
+    INCLUDE_DIRS ${HSHM_GPU_INCLUDE_DIRS})
   target_link_libraries(test_local_serialize_gpu
     hshm::cuda_cxx
     Catch2::Catch2WithMain
@@ -30,7 +37,8 @@ if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
   add_test(NAME test_local_serialize_gpu COMMAND test_local_serialize_gpu)
 
   # LocalTransfer GPU test
-  add_cuda_executable(test_local_transfer_gpu TRUE test_local_transfer_gpu.cc)
+  add_cuda_executable(test_local_transfer_gpu TRUE test_local_transfer_gpu.cc
+    INCLUDE_DIRS ${HSHM_GPU_INCLUDE_DIRS})
   target_link_libraries(test_local_transfer_gpu
     hshm::cuda_cxx
     Catch2::Catch2WithMain
@@ -38,7 +46,8 @@ if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
   add_test(NAME test_local_transfer_gpu COMMAND test_local_transfer_gpu)
 
   # BuddyAllocator GPU test
-  add_cuda_executable(test_buddy_alloc_gpu TRUE test_buddy_alloc_gpu.cc)
+  add_cuda_executable(test_buddy_alloc_gpu TRUE test_buddy_alloc_gpu.cc
+    INCLUDE_DIRS ${HSHM_GPU_INCLUDE_DIRS})
   target_link_libraries(test_buddy_alloc_gpu
     hshm::cuda_cxx
     Catch2::Catch2WithMain
@@ -46,7 +55,8 @@ if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
   add_test(NAME test_buddy_alloc_gpu COMMAND test_buddy_alloc_gpu)
 
   # PrivateBuddyAllocator shifted (stack) GPU test
-  add_cuda_executable(test_buddy_alloc_stack_gpu TRUE test_buddy_alloc_stack_gpu.cc)
+  add_cuda_executable(test_buddy_alloc_stack_gpu TRUE test_buddy_alloc_stack_gpu.cc
+    INCLUDE_DIRS ${HSHM_GPU_INCLUDE_DIRS})
   target_link_libraries(test_buddy_alloc_stack_gpu
     hshm::cuda_cxx
     Catch2::Catch2WithMain
@@ -54,7 +64,8 @@ if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
   add_test(NAME test_buddy_alloc_stack_gpu COMMAND test_buddy_alloc_stack_gpu)
 
   # ThreadAllocator GPU test
-  add_cuda_executable(test_thread_alloc_gpu TRUE test_thread_alloc_gpu.cc)
+  add_cuda_executable(test_thread_alloc_gpu TRUE test_thread_alloc_gpu.cc
+    INCLUDE_DIRS ${HSHM_GPU_INCLUDE_DIRS})
   target_link_libraries(test_thread_alloc_gpu
     hshm::cuda_cxx
     Catch2::Catch2WithMain

--- a/context-transport-primitives/test/unit/gpu/runtime/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/gpu/runtime/CMakeLists.txt
@@ -3,7 +3,11 @@
 #------------------------------------------------------------------------------
 
 # Shared CUDA library (dynamically loaded)
-add_cuda_library(gpu_runtime_lib SHARED TRUE lib.cc)
+add_cuda_library(gpu_runtime_lib SHARED TRUE lib.cc
+  INCLUDE_DIRS
+    ${HSHM_ROOT}/include
+    ${PROJECT_BINARY_DIR}/include
+)
 target_link_libraries(gpu_runtime_lib hshm::cuda_cxx)
 target_include_directories(gpu_runtime_lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS gpu_runtime_lib
@@ -12,6 +16,9 @@ install(TARGETS gpu_runtime_lib
 
 # Test executable
 add_cuda_executable(test_gpu_runtime TRUE main.cc
+    INCLUDE_DIRS
+      ${HSHM_ROOT}/include
+      ${PROJECT_BINARY_DIR}/include
     DEFS GPU_RUNTIME_LIB_PATH="$<TARGET_FILE:gpu_runtime_lib>")
 target_link_libraries(test_gpu_runtime hshm::cuda_cxx ${CMAKE_DL_LIBS})
 target_include_directories(test_gpu_runtime PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/context-transport-primitives/test/unit/gpu/test_buddy_alloc_stack_gpu.cc
+++ b/context-transport-primitives/test/unit/gpu/test_buddy_alloc_stack_gpu.cc
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * GPU PrivateBuddyAllocator "stack" (shifted) unit test
+ *
+ * Tests the pattern used by IpcManager on the GPU:
+ *   - PrivateBuddyAllocator lives in __shared__ memory (the "stack")
+ *   - Data region is in global device memory (GpuMalloc)
+ *   - shm_init is called with shifted=true so offset calculations
+ *     resolve to the global memory backend, not the __shared__ address
+ *
+ * This mirrors how gpu_priv_alloc_ works in IpcManager::InitPrivAllocator.
+ */
+
+#include <catch2/catch_all.hpp>
+
+#include "hermes_shm/memory/allocator/buddy_allocator.h"
+#include "hermes_shm/memory/backend/gpu_malloc.h"
+#include "hermes_shm/memory/backend/gpu_shm_mmap.h"
+#include "hermes_shm/util/gpu_api.h"
+
+using hipc::PrivateBuddyAllocator;
+using hshm::ipc::GpuMalloc;
+using hshm::ipc::GpuShmMmap;
+using hshm::ipc::MemoryBackend;
+using hshm::ipc::MemoryBackendId;
+
+// ─── Test struct ─────────────────────────────────────────────────────────────
+
+struct TestObj {
+  hshm::u32 magic_;
+  char data_[60];
+
+  HSHM_INLINE_CROSS_FUN void Init(hshm::u32 val) {
+    magic_ = val;
+    for (int i = 0; i < 60; ++i) {
+      data_[i] = static_cast<char>(val + i);
+    }
+  }
+
+  HSHM_INLINE_CROSS_FUN bool Check(hshm::u32 val) const {
+    if (magic_ != val) return false;
+    for (int i = 0; i < 60; ++i) {
+      if (data_[i] != static_cast<char>(val + i)) return false;
+    }
+    return true;
+  }
+};
+
+// ─── GPU kernels ─────────────────────────────────────────────────────────────
+
+/**
+ * Test 1: PrivateBuddyAllocator in __shared__ memory with shifted=true
+ *
+ * Thread 0 constructs the allocator in __shared__, calls shm_init(shifted=true)
+ * with a GpuMalloc backend. Then allocates objects and verifies them.
+ *
+ * Result codes in d_results[tid]:
+ *   0   success
+ *  -1   shm_init failed
+ *  -2   first allocation failed
+ *  -3   data corruption
+ *  >0   number of successful allocations (on success path)
+ */
+__global__ void StackBuddyAllocSharedKernel(
+    const hipc::MemoryBackend backend,
+    int *d_results,
+    int *d_alloc_count) {
+  __shared__ char alloc_bytes[sizeof(PrivateBuddyAllocator)];
+  PrivateBuddyAllocator &alloc =
+      *reinterpret_cast<PrivateBuddyAllocator *>(alloc_bytes);
+  int tid = threadIdx.x;
+
+  if (tid == 0) {
+    new (&alloc) PrivateBuddyAllocator();
+    alloc.shm_init(backend, 0, /*shifted=*/true);
+
+    auto fp = alloc.template AllocateObjs<TestObj>(1);
+    if (!fp.IsNull()) {
+      fp.ptr_->Init(1);
+    }
+
+    int count = fp.IsNull() ? 0 : 1;
+    if (!fp.IsNull()) {
+      while (true) {
+        auto fp2 = alloc.template AllocateObjs<TestObj>(1);
+        if (fp2.IsNull()) break;
+        fp2.ptr_->Init(static_cast<hshm::u32>(count + 1));
+        ++count;
+      }
+    }
+
+    d_results[0] = 0;
+    *d_alloc_count = count;
+  }
+  __syncthreads();
+
+  if (tid != 0) {
+    d_results[tid] = 0;
+  }
+}
+
+/**
+ * Test 2: Per-block PrivateBuddyAllocator with clipped backends
+ *
+ * Multiple blocks each get their own slice of the backend (using Clip),
+ * and each block's thread 0 creates a shifted PrivateBuddyAllocator
+ * in __shared__ memory over that slice.
+ */
+__global__ void StackBuddyAllocMultiBlockKernel(
+    const hipc::MemoryBackend backend,
+    size_t per_block_size,
+    int *d_results,
+    int *d_alloc_counts) {
+  __shared__ char alloc_bytes[sizeof(PrivateBuddyAllocator)];
+  PrivateBuddyAllocator &alloc =
+      *reinterpret_cast<PrivateBuddyAllocator *>(alloc_bytes);
+  int bid = blockIdx.x;
+  int tid = threadIdx.x;
+  int global_id = bid * blockDim.x + tid;
+
+  if (tid == 0) {
+    new (&alloc) PrivateBuddyAllocator();
+
+    // Clip the backend to this block's slice
+    size_t block_off = static_cast<size_t>(bid) * per_block_size;
+    hipc::MemoryBackend clip = backend.Clip(block_off, per_block_size);
+
+    alloc.shm_init(clip, 0, /*shifted=*/true);
+
+    // Allocate objects
+    int count = 0;
+    while (true) {
+      auto fp = alloc.template AllocateObjs<TestObj>(1);
+      if (fp.IsNull()) break;
+
+      hshm::u32 val = static_cast<hshm::u32>(bid * 10000 + count + 1);
+      fp.ptr_->Init(val);
+
+      if (!fp.ptr_->Check(val)) {
+        d_results[global_id] = -3;
+        d_alloc_counts[bid] = count;
+        return;
+      }
+      ++count;
+    }
+
+    d_results[global_id] = 0;
+    d_alloc_counts[bid] = count;
+  }
+  __syncthreads();
+
+  if (tid != 0) {
+    d_results[global_id] = 0;
+  }
+}
+
+/**
+ * Test 3: Allocate, free, reallocate cycle
+ *
+ * Verifies that freed memory can be reused by the shifted allocator.
+ */
+__global__ void StackBuddyAllocFreeKernel(
+    const hipc::MemoryBackend backend,
+    int *d_results) {
+  __shared__ char alloc_bytes[sizeof(PrivateBuddyAllocator)];
+  PrivateBuddyAllocator &alloc =
+      *reinterpret_cast<PrivateBuddyAllocator *>(alloc_bytes);
+  int tid = threadIdx.x;
+
+  if (tid == 0) {
+    new (&alloc) PrivateBuddyAllocator();
+    alloc.shm_init(backend, 0, /*shifted=*/true);
+    if (false) {
+      d_results[0] = -1;
+      return;
+    }
+
+    // Phase 1: Allocate 100 objects
+    hipc::FullPtr<TestObj> ptrs[100];
+    for (int i = 0; i < 100; ++i) {
+      ptrs[i] = alloc.template AllocateObjs<TestObj>(1);
+      if (ptrs[i].IsNull()) {
+        d_results[0] = -2;  // Could not allocate 100 objects
+        return;
+      }
+      ptrs[i].ptr_->Init(static_cast<hshm::u32>(i + 1));
+    }
+
+    // Phase 2: Free all
+    for (int i = 0; i < 100; ++i) {
+      alloc.Free(ptrs[i]);
+    }
+
+    // Phase 3: Reallocate — should succeed since we freed everything
+    for (int i = 0; i < 100; ++i) {
+      auto fp = alloc.template AllocateObjs<TestObj>(1);
+      if (fp.IsNull()) {
+        d_results[0] = -3;  // Reallocation failed
+        return;
+      }
+      fp.ptr_->Init(static_cast<hshm::u32>(i + 1000));
+      if (!fp.ptr_->Check(static_cast<hshm::u32>(i + 1000))) {
+        d_results[0] = -4;  // Data corruption after realloc
+        return;
+      }
+    }
+
+    d_results[0] = 0;  // Success
+  }
+  __syncthreads();
+
+  if (tid != 0) {
+    d_results[tid] = 0;
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+TEST_CASE("PrivateBuddyAllocator shifted on GPU",
+          "[gpu][allocator][shifted]") {
+  cudaDeviceSetLimit(cudaLimitStackSize, 16384);
+
+  SECTION("Single block, __shared__ allocator, GpuMalloc backend") {
+    constexpr size_t kBackendSize = 4 * 1024 * 1024;  // 4 MB
+    constexpr int kBlockSize = 32;
+
+    GpuMalloc backend;
+    MemoryBackendId bid(50, 0);
+    REQUIRE(backend.shm_init(bid, kBackendSize, "/test_stack_buddy_gpu", 0));
+
+    int *d_results = hshm::GpuApi::Malloc<int>(kBlockSize * sizeof(int));
+    int *d_count = hshm::GpuApi::Malloc<int>(sizeof(int));
+
+    StackBuddyAllocSharedKernel<<<1, kBlockSize>>>(
+        static_cast<MemoryBackend &>(backend), d_results, d_count);
+
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    int h_count = 0;
+    hshm::GpuApi::Memcpy(&h_count, d_count, sizeof(int));
+    INFO("Allocated " << h_count << " TestObj (64 bytes each)");
+    REQUIRE(h_count > 0);
+
+    std::vector<int> h_results(kBlockSize, -99);
+    hshm::GpuApi::Memcpy(h_results.data(), d_results,
+                          kBlockSize * sizeof(int));
+    for (int i = 0; i < kBlockSize; ++i) {
+      INFO("Thread " << i << " result: " << h_results[i]);
+      REQUIRE(h_results[i] == 0);
+    }
+
+    hshm::GpuApi::Free(d_results);
+    hshm::GpuApi::Free(d_count);
+  }
+
+  SECTION("Single block, __shared__ allocator, GpuShmMmap backend") {
+    constexpr size_t kBackendSize = 4 * 1024 * 1024;  // 4 MB
+    constexpr int kBlockSize = 32;
+
+    GpuShmMmap backend;
+    MemoryBackendId bid(51, 0);
+    REQUIRE(backend.shm_init(bid, kBackendSize,
+                             "/test_stack_buddy_uvm", 0));
+
+    int *d_results = hshm::GpuApi::Malloc<int>(kBlockSize * sizeof(int));
+    int *d_count = hshm::GpuApi::Malloc<int>(sizeof(int));
+
+    StackBuddyAllocSharedKernel<<<1, kBlockSize>>>(
+        static_cast<MemoryBackend &>(backend), d_results, d_count);
+
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    int h_count = 0;
+    hshm::GpuApi::Memcpy(&h_count, d_count, sizeof(int));
+    INFO("Allocated " << h_count << " TestObj (64 bytes each)");
+    REQUIRE(h_count > 0);
+
+    std::vector<int> h_results(kBlockSize, -99);
+    hshm::GpuApi::Memcpy(h_results.data(), d_results,
+                          kBlockSize * sizeof(int));
+    for (int i = 0; i < kBlockSize; ++i) {
+      INFO("Thread " << i << " result: " << h_results[i]);
+      REQUIRE(h_results[i] == 0);
+    }
+
+    hshm::GpuApi::Free(d_results);
+    hshm::GpuApi::Free(d_count);
+  }
+
+  SECTION("Multi-block, per-block __shared__ allocator with Clip") {
+    constexpr int kNumBlocks = 4;
+    constexpr int kBlockSize = 32;
+    constexpr size_t kPerBlockSize = 1 * 1024 * 1024;  // 1 MB per block
+    // Account for kBackendHeaderSize so each block gets a full kPerBlockSize of data
+    constexpr size_t kBackendSize = kNumBlocks * kPerBlockSize + hshm::ipc::kBackendHeaderSize;
+
+    GpuMalloc backend;
+    MemoryBackendId bid(52, 0);
+    REQUIRE(backend.shm_init(bid, kBackendSize,
+                             "/test_stack_buddy_multi", 0));
+
+    int total_threads = kNumBlocks * kBlockSize;
+    int *d_results = hshm::GpuApi::Malloc<int>(total_threads * sizeof(int));
+    int *d_counts = hshm::GpuApi::Malloc<int>(kNumBlocks * sizeof(int));
+    cudaMemset(d_results, 0, total_threads * sizeof(int));
+    cudaMemset(d_counts, 0, kNumBlocks * sizeof(int));
+
+    StackBuddyAllocMultiBlockKernel<<<kNumBlocks, kBlockSize>>>(
+        static_cast<MemoryBackend &>(backend), kPerBlockSize,
+        d_results, d_counts);
+
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    std::vector<int> h_counts(kNumBlocks);
+    hshm::GpuApi::Memcpy(h_counts.data(), d_counts,
+                          kNumBlocks * sizeof(int));
+    for (int b = 0; b < kNumBlocks; ++b) {
+      INFO("Block " << b << " allocated " << h_counts[b] << " objects");
+      REQUIRE(h_counts[b] > 0);
+    }
+
+    std::vector<int> h_results(total_threads, -99);
+    hshm::GpuApi::Memcpy(h_results.data(), d_results,
+                          total_threads * sizeof(int));
+    for (int i = 0; i < total_threads; ++i) {
+      INFO("Global thread " << i << " result: " << h_results[i]);
+      REQUIRE(h_results[i] == 0);
+    }
+
+    hshm::GpuApi::Free(d_results);
+    hshm::GpuApi::Free(d_counts);
+  }
+
+  SECTION("Alloc-free-realloc cycle") {
+    constexpr size_t kBackendSize = 4 * 1024 * 1024;  // 4 MB
+    constexpr int kBlockSize = 32;
+
+    GpuMalloc backend;
+    MemoryBackendId bid(53, 0);
+    REQUIRE(backend.shm_init(bid, kBackendSize,
+                             "/test_stack_buddy_free", 0));
+
+    int *d_results = hshm::GpuApi::Malloc<int>(kBlockSize * sizeof(int));
+
+    StackBuddyAllocFreeKernel<<<1, kBlockSize>>>(
+        static_cast<MemoryBackend &>(backend), d_results);
+
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    std::vector<int> h_results(kBlockSize, -99);
+    hshm::GpuApi::Memcpy(h_results.data(), d_results,
+                          kBlockSize * sizeof(int));
+    for (int i = 0; i < kBlockSize; ++i) {
+      INFO("Thread " << i << " result: " << h_results[i]);
+      REQUIRE(h_results[i] == 0);
+    }
+
+    hshm::GpuApi::Free(d_results);
+  }
+}


### PR DESCRIPTION
Several CMake files don't include all the necessary directories, which is required due to the behavior of custom `add_cuda_{library, executable}` commands which block `target_include_directories`.