### PR TITLE
feat: add Intel GPU (SYCL/oneAPI) support for Aurora PVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ option(WRP_CORE_ENABLE_ELF "Enable ELF support (required for CTE adapters)" OFF)
 option(WRP_CORE_ENABLE_OPENMP "Enable the use of OpenMP" OFF)
 option(WRP_CORE_ENABLE_CUDA "Enable CUDA support" OFF)
 option(WRP_CORE_ENABLE_ROCM "Enable ROCm support" OFF)
+option(WRP_CORE_ENABLE_SYCL "Enable Intel GPU support via SYCL/oneAPI (icpx -fsycl)" OFF)
 option(WRP_CORE_ENABLE_JARVIS "Enable Jarvis CI infrastructure installation" OFF)
 
 #------------------------------------------------------------------------------
@@ -180,6 +181,7 @@ set(HSHM_ENABLE_ENCRYPT ${WRP_CORE_ENABLE_ENCRYPT} CACHE BOOL "Enable Encrypt (c
 set(HSHM_ENABLE_ELF ${WRP_CORE_ENABLE_ELF} CACHE BOOL "Enable ELF (controlled by WRP_CORE_ENABLE_ELF)" FORCE)
 set(HSHM_ENABLE_CUDA ${WRP_CORE_ENABLE_CUDA} CACHE BOOL "Enable CUDA (controlled by WRP_CORE_ENABLE_CUDA)" FORCE)
 set(HSHM_ENABLE_ROCM ${WRP_CORE_ENABLE_ROCM} CACHE BOOL "Enable ROCm (controlled by WRP_CORE_ENABLE_ROCM)" FORCE)
+set(HSHM_ENABLE_SYCL ${WRP_CORE_ENABLE_SYCL} CACHE BOOL "Enable SYCL (controlled by WRP_CORE_ENABLE_SYCL)" FORCE)
 set(HSHM_ENABLE_IO_URING ${WRP_CORE_ENABLE_IO_URING} CACHE BOOL "Enable io_uring (controlled by WRP_CORE_ENABLE_IO_URING)" FORCE)
 # Note: Coverage is handled globally via add_compile_options when WRP_CORE_ENABLE_COVERAGE=ON
 # No need for component-level HSHM_ENABLE_COVERAGE
@@ -960,11 +962,14 @@ if(WRP_CORE_ENABLE_TESTS)
         endforeach()
     endfunction()
 
-    foreach(_component_dir
-            context-runtime
-            context-transfer-engine
-            context-assimilation-engine
-            context-exploration-engine)
+    set(_lock_dirs context-runtime context-transfer-engine)
+    if(WRP_CORE_ENABLE_CAE)
+        list(APPEND _lock_dirs context-assimilation-engine)
+    endif()
+    if(WRP_CORE_ENABLE_CEE)
+        list(APPEND _lock_dirs context-exploration-engine)
+    endif()
+    foreach(_component_dir ${_lock_dirs})
         if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${_component_dir}")
             _chimaera_lock_tests_recursive(
                 "${CMAKE_CURRENT_SOURCE_DIR}/${_component_dir}"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,6 +77,30 @@
             }
         },
         {
+            "name": "sycl-debug",
+            "hidden": false,
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build_gpu",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "WRP_CORE_ENABLE_RUNTIME": "ON",
+                "WRP_CORE_ENABLE_CTE": "ON",
+                "WRP_CORE_ENABLE_CAE": "OFF",
+                "WRP_CORE_ENABLE_CEE": "OFF",
+                "WRP_CORE_ENABLE_TESTS": "ON",
+                "WRP_CORE_ENABLE_ELF": "OFF",
+                "WRP_CORE_ENABLE_SYCL": "ON",
+                "WRP_CTE_ENABLE_COMPRESS": "OFF",
+                "WRP_CTE_ENABLE_ADIOS2_ADAPTER": "OFF",
+                "WRP_CORE_ENABLE_GRAY_SCOTT": "OFF",
+                "WRP_CORE_ENABLE_CONDA": "OFF",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "WRP_CORE_ENABLE_ASAN": "OFF",
+                "WRP_CORE_ENABLE_RPATH": "ON",
+                "WRP_CORE_ENABLE_IO_URING": "OFF"
+            }
+        },
+        {
             "name": "debug-adios",
             "hidden": false,
             "generator": "Unix Makefiles",

--- a/cmake/IowarpCoreCommon.cmake
+++ b/cmake/IowarpCoreCommon.cmake
@@ -107,6 +107,36 @@ macro(wrp_core_enable_rocm GPU_RUNTIME CXX_STANDARD)
     endif()
 endmacro()
 
+# Enable Intel GPU / SYCL (oneAPI icpx -fsycl)
+# Note: SYCL flags are NOT applied globally to avoid breaking PCH and non-SYCL
+# targets. Use target_compile_options / target_link_options on SYCL targets,
+# or call wrp_core_apply_sycl_flags(<target>) defined below.
+macro(wrp_core_enable_sycl CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD ${CXX_STANDARD})
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+    # Intel GPU target for Aurora (Ponte Vecchio / PVC)
+    set(SYCL_TARGET "spir64_gen" CACHE STRING "SYCL AOT target (default: spir64_gen for Intel GPU)")
+    set(SYCL_DEVICE "pvc" CACHE STRING "SYCL AOT device (default: pvc for Aurora Ponte Vecchio)")
+
+    message(STATUS "SYCL enabled: target=${SYCL_TARGET} device=${SYCL_DEVICE}")
+endmacro()
+
+# Apply SYCL compile and link flags to a specific target.
+# Call this for each executable or library that contains SYCL device code.
+function(wrp_core_apply_sycl_flags target)
+    target_compile_options(${target} PRIVATE
+        -fsycl
+        -fsycl-targets=${SYCL_TARGET}
+        "SHELL:-Xsycl-target-backend \"-device ${SYCL_DEVICE}\""
+    )
+    target_link_options(${target} PRIVATE
+        -fsycl
+        -fsycl-targets=${SYCL_TARGET}
+        "SHELL:-Xsycl-target-backend \"-device ${SYCL_DEVICE}\""
+    )
+endfunction()
+
 # Function for setting source files for rocm
 function(set_rocm_sources MODE DO_COPY SRC_FILES ROCM_SOURCE_FILES_VAR)
     set(ROCM_SOURCE_FILES ${${ROCM_SOURCE_FILES_VAR}} PARENT_SCOPE)

--- a/context-transport-primitives/CMakeLists.txt
+++ b/context-transport-primitives/CMakeLists.txt
@@ -119,6 +119,10 @@ if(WRP_CORE_ENABLE_ROCM)
     wrp_core_enable_rocm("HIP" 17)
 endif()
 
+if(WRP_CORE_ENABLE_SYCL)
+    wrp_core_enable_sycl(17)
+endif()
+
 # ------------------------------------------------------------------------------
 # Modular dependency targets
 # ------------------------------------------------------------------------------

--- a/context-transport-primitives/benchmark/zmq_ipc_latency_benchmark.cc
+++ b/context-transport-primitives/benchmark/zmq_ipc_latency_benchmark.cc
@@ -52,6 +52,7 @@
  */
 
 #include <zmq.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <chrono>

--- a/context-transport-primitives/include/hermes_shm/constants/macros.h
+++ b/context-transport-primitives/include/hermes_shm/constants/macros.h
@@ -99,6 +99,10 @@
 #define HSHM_ENABLE_CUDA_OR_ROCM 1
 #endif
 
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM || HSHM_ENABLE_SYCL
+#define HSHM_ENABLE_GPU 1
+#endif
+
 /** Detect GPU compilers.
  * These combine the CMake build flag (HSHM_ENABLE_CUDA / HSHM_ENABLE_ROCM)
  * with the actual compiler detection (__CUDACC__ / __HIPCC__) so that GPU
@@ -117,6 +121,13 @@
 #define HSHM_IS_ROCM_COMPILER 0
 #endif
 
+/** Detect SYCL compiler (Intel oneAPI icpx -fsycl) */
+#if HSHM_ENABLE_SYCL && defined(SYCL_LANGUAGE_VERSION)
+#define HSHM_IS_SYCL_COMPILER 1
+#else
+#define HSHM_IS_SYCL_COMPILER 0
+#endif
+
 #if HSHM_IS_CUDA_COMPILER || HSHM_IS_ROCM_COMPILER
 #define HSHM_IS_GPU_COMPILER 1
 #else
@@ -130,6 +141,10 @@
 
 #if HSHM_IS_ROCM_COMPILER
 #include <hip/hip_runtime.h>
+#endif
+
+#if HSHM_IS_SYCL_COMPILER
+#include <sycl/sycl.hpp>
 #endif
 
 /** Macros for CUDA functions.

--- a/context-transport-primitives/include/hermes_shm/memory/backend/gpu_shm_mmap.h
+++ b/context-transport-primitives/include/hermes_shm/memory/backend/gpu_shm_mmap.h
@@ -34,7 +34,7 @@
 #ifndef HSHM_INCLUDE_MEMORY_BACKEND_GPU_SHM_MMAP_H
 #define HSHM_INCLUDE_MEMORY_BACKEND_GPU_SHM_MMAP_H
 
-#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM || HSHM_ENABLE_SYCL
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -285,6 +285,6 @@ class GpuShmMmap : public MemoryBackend, public UrlMemoryBackend {
 
 }  // namespace hshm::ipc
 
-#endif  // HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
+#endif  // HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM || HSHM_ENABLE_SYCL
 
 #endif  // HSHM_INCLUDE_MEMORY_BACKEND_GPU_SHM_MMAP_H

--- a/context-transport-primitives/include/hermes_shm/util/gpu_api.h
+++ b/context-transport-primitives/include/hermes_shm/util/gpu_api.h
@@ -46,6 +46,9 @@ struct GpuIpcMemHandle {
 #if HSHM_ENABLE_ROCM
   hipIpcMemHandle_t rocm_;
 #endif
+#if HSHM_ENABLE_SYCL
+  void *sycl_ptr_;  // SYCL USM pointers are directly shareable; store base ptr
+#endif
 };
 
 class GpuApi {
@@ -55,6 +58,9 @@ class GpuApi {
     CUDA_ERROR_CHECK(cudaSetDevice(gpu_id));
 #elif HSHM_ENABLE_ROCM
     HIP_ERROR_CHECK(hipSetDevice(gpu_id));
+#elif HSHM_ENABLE_SYCL
+    // SYCL device selection is done via queue construction; no global set
+    (void)gpu_id;
 #endif
   }
 
@@ -62,9 +68,14 @@ class GpuApi {
     int ngpu = 0;
 #if HSHM_ENABLE_ROCM
     HIP_ERROR_CHECK(hipGetDeviceCount(&ngpu));
-#endif
-#if HSHM_ENABLE_CUDA
+#elif HSHM_ENABLE_CUDA
     CUDA_ERROR_CHECK(cudaGetDeviceCount(&ngpu));
+#elif HSHM_ENABLE_SYCL
+    auto platforms = sycl::platform::get_platforms();
+    for (auto &p : platforms) {
+      auto devs = p.get_devices(sycl::info::device_type::gpu);
+      ngpu += static_cast<int>(devs.size());
+    }
 #endif
     return ngpu;
   }
@@ -72,9 +83,10 @@ class GpuApi {
   static void Synchronize() {
 #if HSHM_ENABLE_ROCM
     HIP_ERROR_CHECK(hipDeviceSynchronize());
-#endif
-#if HSHM_ENABLE_CUDA
+#elif HSHM_ENABLE_CUDA
     CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+#elif HSHM_ENABLE_SYCL
+    SyclQueue().wait_and_throw();
 #endif
   }
 
@@ -119,11 +131,12 @@ class GpuApi {
     T *ptr;
     HIP_ERROR_CHECK(hipMallocManaged(&ptr, size));
     return ptr;
-#endif
-#if HSHM_ENABLE_CUDA
+#elif HSHM_ENABLE_CUDA
     T *ptr;
     CUDA_ERROR_CHECK(cudaMallocManaged(&ptr, size));
     return ptr;
+#elif HSHM_ENABLE_SYCL
+    return static_cast<T *>(sycl::malloc_shared(size, SyclQueue()));
 #endif
     return nullptr;
   }
@@ -133,10 +146,13 @@ class GpuApi {
 #if HSHM_ENABLE_ROCM
     HIP_ERROR_CHECK(
         hipHostRegister((void *)ptr, size, hipHostRegisterPortable));
-#endif
-#if HSHM_ENABLE_CUDA
+#elif HSHM_ENABLE_CUDA
     CUDA_ERROR_CHECK(
         cudaHostRegister((void *)ptr, size, cudaHostRegisterPortable));
+#elif HSHM_ENABLE_SYCL
+    // SYCL USM host memory doesn't require explicit registration;
+    // use sycl::malloc_host for GPU-accessible host allocations when needed.
+    (void)ptr; (void)size;
 #endif
   }
 
@@ -144,9 +160,10 @@ class GpuApi {
   static void UnregisterHostMemory(T *ptr) {
 #if HSHM_ENABLE_ROCM
     HIP_ERROR_CHECK(hipHostUnregister((void *)ptr));
-#endif
-#if HSHM_ENABLE_CUDA
+#elif HSHM_ENABLE_CUDA
     CUDA_ERROR_CHECK(cudaHostUnregister((void *)ptr));
+#elif HSHM_ENABLE_SYCL
+    (void)ptr;
 #endif
   }
 
@@ -154,9 +171,10 @@ class GpuApi {
   static void Memcpy(T *dst, T *src, size_t size) {
 #if HSHM_ENABLE_ROCM
     HIP_ERROR_CHECK(hipMemcpy(dst, src, size, hipMemcpyDefault));
-#endif
-#if HSHM_ENABLE_CUDA
+#elif HSHM_ENABLE_CUDA
     CUDA_ERROR_CHECK(cudaMemcpy(dst, src, size, cudaMemcpyDefault));
+#elif HSHM_ENABLE_SYCL
+    SyclQueue().memcpy(dst, src, size).wait_and_throw();
 #endif
   }
 
@@ -193,9 +211,10 @@ class GpuApi {
   static void Free(T *ptr) {
 #if HSHM_ENABLE_ROCM
     HIP_ERROR_CHECK(hipFree(ptr));
-#endif
-#if HSHM_ENABLE_CUDA
+#elif HSHM_ENABLE_CUDA
     CUDA_ERROR_CHECK(cudaFree(ptr));
+#elif HSHM_ENABLE_SYCL
+    sycl::free(ptr, SyclQueue());
 #endif
   }
 
@@ -205,6 +224,13 @@ class GpuApi {
            (threadIdx.y + blockIdx.y * blockDim.y) * (blockDim.x * gridDim.x) +
            (threadIdx.z + blockIdx.z * blockDim.z) *
                (blockDim.x * gridDim.x * blockDim.y * gridDim.y);
+  }
+#endif
+
+#if HSHM_ENABLE_SYCL
+  static sycl::queue &SyclQueue() {
+    static sycl::queue q{sycl::gpu_selector_v};
+    return q;
   }
 #endif
 };

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -52,6 +52,7 @@
 #define HSHM_MSAN_UNPOISON(ptr, size) ((void)0)
 #endif
 #if HSHM_ENABLE_PROCFS_SYSINFO
+#include <limits.h>
 #include <dlfcn.h>
 #include <signal.h>
 // LINUX

--- a/context-transport-primitives/test/unit/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 add_subdirectory(io)
 
-if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
+if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM OR WRP_CORE_ENABLE_SYCL)
     add_subdirectory(gpu)
 endif()
 

--- a/context-transport-primitives/test/unit/gpu/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/gpu/CMakeLists.txt
@@ -39,6 +39,20 @@ if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
 
   add_subdirectory(runtime)
 
-else()
-  message(STATUS "GPU tests disabled (WRP_CORE_ENABLE_CUDA and WRP_CORE_ENABLE_ROCM are both OFF)")
+endif()
+
+if(WRP_CORE_ENABLE_SYCL)
+  message(STATUS "Building SYCL GPU unit tests (Intel oneAPI)")
+  add_executable(test_gpu_sycl test_gpu_sycl.cc)
+  target_compile_definitions(test_gpu_sycl PRIVATE HSHM_ENABLE_SYCL=1)
+  wrp_core_apply_sycl_flags(test_gpu_sycl)
+  target_link_libraries(test_gpu_sycl
+    Catch2::Catch2WithMain
+  )
+  add_test(NAME test_gpu_sycl COMMAND test_gpu_sycl)
+  set_tests_properties(test_gpu_sycl PROPERTIES LABELS "gpu;sycl")
+endif()
+
+if(NOT WRP_CORE_ENABLE_CUDA AND NOT WRP_CORE_ENABLE_ROCM AND NOT WRP_CORE_ENABLE_SYCL)
+  message(STATUS "GPU tests disabled (WRP_CORE_ENABLE_CUDA, WRP_CORE_ENABLE_ROCM, and WRP_CORE_ENABLE_SYCL are all OFF)")
 endif()

--- a/context-transport-primitives/test/unit/gpu/test_gpu_sycl.cc
+++ b/context-transport-primitives/test/unit/gpu/test_gpu_sycl.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Intel GPU unit test using SYCL/oneAPI
+ *
+ * Tests Intel GPU compute using SYCL USM (Unified Shared Memory) on
+ * Aurora's Intel Data Center GPU Max (Ponte Vecchio / PVC).
+ *
+ * Uses #ifdef HSHM_ENABLE_SYCL so this file compiles only when SYCL is
+ * enabled. Existing CUDA/ROCm code is not affected since no CUDA/ROCm
+ * headers or keywords are used here.
+ */
+
+#ifdef HSHM_ENABLE_SYCL
+
+#include <catch2/catch_all.hpp>
+#include <sycl/sycl.hpp>
+
+/**
+ * Test: GpuSyclVectorFill
+ *
+ * Allocates SYCL shared arrays, dispatches kernels, and verifies results on
+ * the CPU. Tests basic GPU dispatch and USM data access patterns.
+ */
+// Use a single TEST_CASE with one SECTION to avoid recreating the SYCL queue
+// across Catch2 section re-runs, which can cause segfaults on Intel GPU.
+TEST_CASE("GpuSyclVectorFill", "[gpu][sycl]") {
+  // Static queue: constructed once for the lifetime of the process.
+  static sycl::queue q{sycl::gpu_selector_v};
+
+  SECTION("IntelGpuKernels") {
+    INFO("Device: " << q.get_device().get_info<sycl::info::device::name>());
+
+    // --- Test 1: parallel_for fill ---
+    {
+      constexpr size_t kSize = 256;
+      int *buf = sycl::malloc_shared<int>(kSize, q);
+      REQUIRE(buf != nullptr);
+      for (size_t i = 0; i < kSize; ++i) buf[i] = -1;
+      q.parallel_for(sycl::range<1>(kSize), [=](sycl::id<1> idx) {
+         buf[idx] = static_cast<int>(idx.get(0));
+       }).wait();
+      for (size_t i = 0; i < kSize; ++i) {
+        REQUIRE(buf[i] == static_cast<int>(i));
+      }
+      sycl::free(buf, q);
+    }
+
+    // --- Test 2: parallel_for scale ---
+    {
+      constexpr size_t kSize = 512;
+      int *data = sycl::malloc_shared<int>(kSize, q);
+      int *out = sycl::malloc_shared<int>(kSize, q);
+      REQUIRE(data != nullptr);
+      REQUIRE(out != nullptr);
+      for (size_t i = 0; i < kSize; ++i) { data[i] = static_cast<int>(i); out[i] = 0; }
+      q.parallel_for(sycl::range<1>(kSize), [=](sycl::id<1> idx) {
+         out[idx] = data[idx] * 2;
+       }).wait();
+      for (size_t i = 0; i < kSize; ++i) {
+        REQUIRE(out[i] == static_cast<int>(i * 2));
+      }
+      sycl::free(data, q);
+      sycl::free(out, q);
+    }
+  }
+}
+
+#else  // HSHM_ENABLE_SYCL not defined
+
+#include <catch2/catch_all.hpp>
+
+TEST_CASE("GpuSyclVectorFill_Disabled", "[gpu][sycl]") {
+  SUCCEED("SYCL not enabled in this build");
+}
+
+#endif  // HSHM_ENABLE_SYCL

--- a/intel_gpu_sycl_support.md
+++ b/intel_gpu_sycl_support.md
@@ -1,0 +1,223 @@
+# Intel GPU SYCL Support for clio-core on Aurora
+
+## Overview
+
+Added Intel GPU (oneAPI/SYCL) support to clio-core, enabling GPU testing on
+Aurora's Intel Data Center GPU Max 1550 (Ponte Vecchio / PVC). The
+implementation follows the existing CUDA/ROCm pattern and uses `#ifdef` guards
+throughout so no existing code is affected.
+
+## New Script: `~/bin/core_gpu`
+
+Submits a `ctest -D Experimental` PBS job using the Intel oneAPI compiler
+(`icpx -fsycl`) targeting Aurora's Intel GPU.
+
+```bash
+~/bin/core_gpu          # submit job
+qstat -x <JOBID>        # monitor
+# output: ~/clio-core/ctest_experimental_gpu.out
+```
+
+PBS configuration mirrors `~/bin/core_icx`:
+- Queue: `debug`, Account: `gpu_hack`
+- Modules: `gcc/13.4.0`, `oneapi/release/2025.3.1`
+- Conda env: `iowarp`
+- CDash: site=`aurora`, buildname=`sycl/r/gpu`
+- Build dir: `build_gpu` (separate from `build` and `build_icx`)
+- CTest filter: `-L gpu -LE docker`
+
+## CMake Changes
+
+### New option (`CMakeLists.txt`)
+
+```cmake
+option(WRP_CORE_ENABLE_SYCL "Enable Intel GPU support via SYCL/oneAPI (icpx -fsycl)" OFF)
+set(HSHM_ENABLE_SYCL ${WRP_CORE_ENABLE_SYCL} CACHE BOOL "..." FORCE)
+```
+
+### New preset (`CMakePresets.json`)
+
+```json
+{
+    "name": "sycl-debug",
+    "binaryDir": "${sourceDir}/build_gpu",
+    "cacheVariables": {
+        "WRP_CORE_ENABLE_SYCL": "ON",
+        "WRP_CORE_ENABLE_CAE": "OFF",
+        "WRP_CORE_ENABLE_CEE": "OFF",
+        "WRP_CTE_ENABLE_COMPRESS": "OFF",
+        ...
+    }
+}
+```
+
+### New macros (`cmake/IowarpCoreCommon.cmake`)
+
+```cmake
+# Sets CXX standard and SYCL AOT cache variables (no global flags).
+macro(wrp_core_enable_sycl CXX_STANDARD)
+
+# Applies -fsycl flags to a specific target only.
+function(wrp_core_apply_sycl_flags target)
+```
+
+> **Important:** `-fsycl` is applied **per-target**, not globally.
+> Setting it globally breaks precompiled headers via `clang-offload-bundler`.
+
+### GPU subdirectory inclusion (`context-transport-primitives/test/unit/CMakeLists.txt`)
+
+```cmake
+# Before
+if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
+    add_subdirectory(gpu)
+endif()
+
+# After
+if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM OR WRP_CORE_ENABLE_SYCL)
+    add_subdirectory(gpu)
+endif()
+```
+
+### Disabled-component CMake bug fix (`CMakeLists.txt`)
+
+The `_chimaera_lock_tests_recursive` function previously called
+`get_directory_property(DIRECTORY ...)` on directories that were never added
+via `add_subdirectory` (e.g., CAE/CEE when disabled), causing a fatal CMake
+error. Fixed by only iterating over enabled components:
+
+```cmake
+set(_lock_dirs context-runtime context-transfer-engine)
+if(WRP_CORE_ENABLE_CAE)
+    list(APPEND _lock_dirs context-assimilation-engine)
+endif()
+if(WRP_CORE_ENABLE_CEE)
+    list(APPEND _lock_dirs context-exploration-engine)
+endif()
+```
+
+## Header Changes
+
+### `constants/macros.h`
+
+Added SYCL compiler detection after the existing ROCm block:
+
+```cpp
+#if HSHM_ENABLE_SYCL && defined(SYCL_LANGUAGE_VERSION)
+#define HSHM_IS_SYCL_COMPILER 1
+#else
+#define HSHM_IS_SYCL_COMPILER 0
+#endif
+
+#if HSHM_IS_SYCL_COMPILER
+#include <sycl/sycl.hpp>
+#endif
+```
+
+Added `HSHM_ENABLE_GPU` combining all three backends:
+
+```cpp
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM || HSHM_ENABLE_SYCL
+#define HSHM_ENABLE_GPU 1
+#endif
+```
+
+> **Critical:** `HSHM_IS_SYCL_COMPILER` is **not** included in
+> `HSHM_IS_GPU_COMPILER`. That macro gates `__device__`/`__host__`
+> attributes, which are CUDA/ROCm-only. SYCL uses standard C++ lambdas
+> and does not support these keywords.
+
+### `util/gpu_api.h`
+
+Added SYCL implementations for all `GpuApi` methods via `#elif HSHM_ENABLE_SYCL`:
+
+| Method | SYCL implementation |
+|--------|---------------------|
+| `SetDevice` | no-op (device selected at queue construction) |
+| `GetDeviceCount` | `sycl::platform::get_platforms()` iteration |
+| `Synchronize` | `SyclQueue().wait_and_throw()` |
+| `MallocManaged` | `sycl::malloc_shared(size, SyclQueue())` |
+| `RegisterHostMemory` | no-op (USM host memory needs no registration) |
+| `UnregisterHostMemory` | no-op |
+| `Memcpy` | `SyclQueue().memcpy(...).wait_and_throw()` |
+| `Free` | `sycl::free(ptr, SyclQueue())` |
+
+Added a static queue helper:
+
+```cpp
+#if HSHM_ENABLE_SYCL
+  static sycl::queue &SyclQueue() {
+    static sycl::queue q{sycl::gpu_selector_v};
+    return q;
+  }
+#endif
+```
+
+### `memory/backend/gpu_shm_mmap.h`
+
+Extended the include guard:
+
+```cpp
+// Before
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
+
+// After
+#if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM || HSHM_ENABLE_SYCL
+```
+
+Note: `GpuApi::RegisterHostMemory` is a no-op for SYCL, so `GpuShmMmap`
+compiles but POSIX-shm memory is **not** accessible from SYCL kernels
+(not a USM allocation). Use `sycl::malloc_shared` for GPU-accessible buffers.
+
+## New SYCL Test
+
+### `context-transport-primitives/test/unit/gpu/test_gpu_sycl.cc`
+
+Tests Intel GPU kernels using SYCL USM. The entire test body is guarded with
+`#ifdef HSHM_ENABLE_SYCL` so it compiles as a no-op in non-SYCL builds.
+
+Two `parallel_for` tests:
+1. **ParallelFill** — fill 256 elements with their index, verify on CPU
+2. **ParallelScaleAndAccumulate** — scale 512 elements by 2, verify on CPU
+
+> **Important:** The `sycl::queue` is declared `static` to ensure it is
+> constructed only once per process. Catch2 re-executes the `TEST_CASE` body
+> for each `SECTION`, and constructing a new `sycl::queue{sycl::gpu_selector_v}`
+> on each re-entry causes a SEGFAULT on Intel GPU (PVC).
+
+### `context-transport-primitives/test/unit/gpu/CMakeLists.txt`
+
+```cmake
+if(WRP_CORE_ENABLE_SYCL)
+  add_executable(test_gpu_sycl test_gpu_sycl.cc)
+  target_compile_definitions(test_gpu_sycl PRIVATE HSHM_ENABLE_SYCL=1)
+  wrp_core_apply_sycl_flags(test_gpu_sycl)
+  target_link_libraries(test_gpu_sycl Catch2::Catch2WithMain)
+  add_test(NAME test_gpu_sycl COMMAND test_gpu_sycl)
+  set_tests_properties(test_gpu_sycl PROPERTIES LABELS "gpu;sycl")
+endif()
+```
+
+## Test Results
+
+Verified on Aurora compute node `x4418c6s1b0n0` (PBS job 8409833):
+
+```
+Device: Intel(R) Data Center GPU Max 1550
+Compiler: Intel(R) oneAPI DPC++/C++ Compiler 2025.3.2
+
+100% tests passed, 0 tests failed out of 1
+Total Test time (real) = 0.24 sec
+```
+
+Results submitted to CDash at `my.cdash.org` under project `HERMES`,
+site `aurora`, buildname `sycl/r/gpu`.
+
+## Lessons Learned
+
+| Issue | Root cause | Fix |
+|-------|-----------|-----|
+| PCH build failure (`clang-offload-bundler: invalid file type 'pchi'`) | `-fsycl` applied globally via `CMAKE_CXX_FLAGS` | Apply SYCL flags per-target with `wrp_core_apply_sycl_flags()` |
+| `unknown type name '__device__'` compile error | `HSHM_IS_SYCL_COMPILER` included in `HSHM_IS_GPU_COMPILER`, enabling CUDA-style macros | Exclude SYCL from `HSHM_IS_GPU_COMPILER` |
+| CMake configure error on `sycl-debug` preset | `_chimaera_lock_tests_recursive` called on disabled CAE/CEE directories | Only iterate enabled component directories |
+| `test_gpu_sycl` target not found | GPU test subdir gated on CUDA/ROCm only | Add `OR WRP_CORE_ENABLE_SYCL` to the subdirectory guard |
+| SEGFAULT on second Catch2 SECTION | `sycl::queue` reconstructed per section re-run | Declare queue as `static` |


### PR DESCRIPTION
Enables GPU testing on Aurora's Intel Data Center GPU Max 1550 (Ponte Vecchio) using Intel oneAPI icpx -fsycl.

Changes:
- CMakeLists.txt: add WRP_CORE_ENABLE_SYCL option and HSHM_ENABLE_SYCL alias; fix _chimaera_lock_tests_recursive crashing on disabled CAE/CEE directories
- CMakePresets.json: add sycl-debug preset (build_gpu dir)
- cmake/IowarpCoreCommon.cmake: add wrp_core_enable_sycl() macro and wrp_core_apply_sycl_flags() function (per-target, not global, to avoid breaking precompiled headers)
- macros.h: add HSHM_IS_SYCL_COMPILER detection and HSHM_ENABLE_GPU; keep SYCL out of HSHM_IS_GPU_COMPILER (__device__/__host__ are CUDA/ROCm-only)
- gpu_api.h: add SYCL implementations for all GpuApi methods via #elif HSHM_ENABLE_SYCL guards; add SyclQueue() static helper
- gpu_shm_mmap.h: extend include guard to || HSHM_ENABLE_SYCL
- system_info.cc: add missing #include <limits.h> for PATH_MAX (icpx is stricter than gcc about implicit includes)
- zmq_ipc_latency_benchmark.cc: add missing #include <unistd.h> for unlink()
- test/unit/CMakeLists.txt: include gpu/ subdir for SYCL builds
- test/unit/gpu/CMakeLists.txt: add test_gpu_sycl target with wrp_core_apply_sycl_flags()
- test/unit/gpu/test_gpu_sycl.cc: new SYCL GPU test using parallel_for with sycl::malloc_shared USM; static sycl::queue to avoid SEGFAULT on PVC from Catch2 section re-runs
- intel_gpu_sycl_support.md: implementation notes and lessons learned

Verified on Aurora (PBS job 8410909): 0 compiler errors, all tests pass including test_gpu_sycl on Intel Data Center GPU Max 1550.