### PR TITLE
Add FUSE adapter improvements, copy-workspace test, and manual deploy scripts

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -356,7 +356,7 @@
                 "WRP_CORE_ENABLE_COVERAGE": "OFF",
                 "WRP_CORE_ENABLE_ZMQ": "ON",
                 "WRP_CORE_ENABLE_CEREAL": "ON",
-                "HSHM_LOG_LEVEL": "1",
+                "HSHM_LOG_LEVEL": "3",
                 "WRP_CORE_ENABLE_IO_URING": "ON"
             }
         },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -356,7 +356,7 @@
                 "WRP_CORE_ENABLE_COVERAGE": "OFF",
                 "WRP_CORE_ENABLE_ZMQ": "ON",
                 "WRP_CORE_ENABLE_CEREAL": "ON",
-                "HSHM_LOG_LEVEL": "3",
+                "HSHM_LOG_LEVEL": "1",
                 "WRP_CORE_ENABLE_IO_URING": "ON"
             }
         },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -332,6 +332,35 @@
             }
         },
         {
+            "name": "release-fuse",
+            "displayName": "Release with FUSE adapter",
+            "hidden": false,
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "WRP_CORE_ENABLE_RUNTIME": "ON",
+                "WRP_CORE_ENABLE_CTE": "ON",
+                "WRP_CORE_ENABLE_CAE": "ON",
+                "WRP_CORE_ENABLE_CEE": "ON",
+                "WRP_CORE_ENABLE_TESTS": "ON",
+                "WRP_CORE_ENABLE_ELF": "OFF",
+                "WRP_CTE_ENABLE_COMPRESS": "OFF",
+                "WRP_CTE_ENABLE_FUSE_ADAPTER": "ON",
+                "WRP_CORE_ENABLE_GRAY_SCOTT": "OFF",
+                "WRP_CTE_ENABLE_ADIOS2_ADAPTER": "OFF",
+                "WRP_CORE_ENABLE_CONDA": "OFF",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "WRP_CORE_ENABLE_ASAN": "OFF",
+                "WRP_CORE_ENABLE_PYTHON": "ON",
+                "WRP_CORE_ENABLE_COVERAGE": "OFF",
+                "WRP_CORE_ENABLE_ZMQ": "ON",
+                "WRP_CORE_ENABLE_CEREAL": "ON",
+                "HSHM_LOG_LEVEL": "1",
+                "WRP_CORE_ENABLE_IO_URING": "ON"
+            }
+        },
+        {
             "name": "llm-debug",
             "hidden": false,
             "generator": "Unix Makefiles",

--- a/context-transfer-engine/adapter/libfuse/fuse_cte.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.cc
@@ -92,6 +92,18 @@ static int cte_fuse_getattr(const char *path, struct stat *stbuf,
     return 0;
   }
 
+  // Check if path is an explicit directory (sentinel tag with trailing /)
+  // or an implicit directory (any tags under this prefix).
+  // Check directories BEFORE files so that "mkdir foo && touch foo" doesn't
+  // shadow the directory with a file of the same name.
+  if (CteTagExists(p + "/") || CteDirExists(p)) {
+    stbuf->st_mode = S_IFDIR | 0755;
+    stbuf->st_nlink = 2;
+    stbuf->st_uid = getuid();
+    stbuf->st_gid = getgid();
+    return 0;
+  }
+
   // Check if path is a file (tag exists with this exact name)
   if (CteTagExists(p)) {
     auto tag_id = CteGetOrCreateTag(p);
@@ -100,15 +112,6 @@ static int cte_fuse_getattr(const char *path, struct stat *stbuf,
     stbuf->st_uid = getuid();
     stbuf->st_gid = getgid();
     stbuf->st_size = static_cast<off_t>(CteGetTagSize(tag_id));
-    return 0;
-  }
-
-  // Check if path is an implicit directory (any tags under this prefix)
-  if (CteDirExists(p)) {
-    stbuf->st_mode = S_IFDIR | 0755;
-    stbuf->st_nlink = 2;
-    stbuf->st_uid = getuid();
-    stbuf->st_gid = getgid();
     return 0;
   }
 
@@ -147,8 +150,35 @@ static int cte_fuse_readdir(const char *path, void *buf,
     filler(buf, name.c_str(), nullptr, 0, static_cast<fuse_fill_dir_flags>(0));
   }
 
-  // List implicit subdirectories
+  // List implicit subdirectories (dirs with files beneath them)
   auto subdirs = CteListSubdirs(p);
+
+  // Also find explicit empty directories (sentinel tags ending with /).
+  // Sentinel tags under "/a/b" look like "/a/b/childdir/" — match with
+  // regex "^/a/b/[^/]+/$" to find direct child sentinels.
+  {
+    auto *cte_client = WRP_CTE_CLIENT;
+    std::string escaped = RegexEscape(p);
+    if (!escaped.empty() && escaped.back() != '/') escaped += '/';
+    std::string regex = "^" + escaped + "[^/]+/$";
+    auto task = cte_client->AsyncTagQuery(regex);
+    task.Wait();
+    if (task->GetReturnCode() == 0) {
+      size_t prefix_len = p.size();
+      if (!p.empty() && p.back() != '/') prefix_len++;
+      for (const auto &sentinel : task->results_) {
+        // Extract dirname: strip prefix and trailing /
+        if (sentinel.size() > prefix_len + 1) {
+          std::string dirname = sentinel.substr(prefix_len,
+                                                sentinel.size() - prefix_len - 1);
+          if (std::find(subdirs.begin(), subdirs.end(), dirname) == subdirs.end()) {
+            subdirs.push_back(dirname);
+          }
+        }
+      }
+    }
+  }
+
   for (const auto &name : subdirs) {
     // Avoid duplicates if a file and subdir have the same name
     if (std::find(files.begin(), files.end(), name) == files.end()) {
@@ -161,10 +191,13 @@ static int cte_fuse_readdir(const char *path, void *buf,
 }
 
 static int cte_fuse_mkdir(const char *path, mode_t mode) {
-  (void)path;
   (void)mode;
-  // Directories are implicit — they exist when files are created beneath them.
-  // mkdir succeeds silently.
+  std::string p(path);
+  // Create a sentinel tag with a trailing "/" to mark an explicit directory.
+  // This lets getattr report the directory before any files exist under it.
+  std::string sentinel = p + "/";
+  auto tag_id = CteGetOrCreateTag(sentinel);
+  if (tag_id.IsNull()) return -EIO;
   return 0;
 }
 
@@ -174,7 +207,11 @@ static int cte_fuse_rmdir(const char *path) {
   auto files = CteListDirectChildren(p);
   auto subdirs = CteListSubdirs(p);
   if (!files.empty() || !subdirs.empty()) return -ENOTEMPTY;
-  // Empty implicit directory — nothing to do
+  // Delete the sentinel tag if it exists
+  std::string sentinel = p + "/";
+  if (CteTagExists(sentinel)) {
+    CteDelTag(sentinel);
+  }
   return 0;
 }
 

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -2524,7 +2524,7 @@ chi::TaskResume Runtime::ModifyExistingData(
 
   ++mod_count;
   if (mod_count % 100 == 0) {
-    HLOG(kInfo,
+    HLOG(kDebug,
          "[ModifyExistingData] ops={} setup={:.3f} ms vec_alloc={:.3f} ms "
          "async_send={:.3f} ms co_await={:.3f} ms",
          mod_count, t_setup_ms, t_vec_alloc_ms, t_async_send_ms, t_co_await_ms);

--- a/context-transfer-engine/test/unit/adapters/libfuse/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/adapters/libfuse/CMakeLists.txt
@@ -70,6 +70,48 @@ set_tests_properties(
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
 )
 
-install(TARGETS test_fuse_adapter RUNTIME DESTINATION bin)
+# ------------------------------------------------------------------------------
+# Copy-workspace test: ingests /workspace into CTE, reads back, verifies
+# ------------------------------------------------------------------------------
+
+add_executable(test_fuse_copy_workspace
+    test_fuse_copy_workspace.cc
+)
+
+target_include_directories(test_fuse_copy_workspace PRIVATE
+    ${WRP_CTE_ROOT}
+)
+
+target_link_libraries(test_fuse_copy_workspace
+    wrp_cte_core_runtime
+    wrp_cte_core_client
+    chimaera::admin_runtime
+    chimaera::admin_client
+    chimaera::bdev_runtime
+    chimaera::bdev_client
+    hshm::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# Copy CTE config to build directory
+add_custom_command(TARGET test_fuse_copy_workspace POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_CURRENT_SOURCE_DIR}/cte_config.yaml
+        ${CMAKE_CURRENT_BINARY_DIR}/cte_config.yaml
+)
+
+add_test(NAME fuse_copy_workspace
+    COMMAND test_fuse_copy_workspace "Ingest and verify")
+
+set_tests_properties(
+    fuse_copy_workspace
+    PROPERTIES
+        TIMEOUT 600
+        LABELS "unit;adapter;fuse;copy_workspace"
+        ENVIRONMENT "CHI_WITH_RUNTIME=1;HSHM_LOG_LEVEL=error;WRP_RUNTIME_CONF=${CMAKE_CURRENT_SOURCE_DIR}/cte_config.yaml;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+        RESOURCE_LOCK "chimaera_runtime"
+)
+
+install(TARGETS test_fuse_adapter test_fuse_copy_workspace RUNTIME DESTINATION bin)
 
 message(STATUS "FUSE adapter tests configured successfully")

--- a/context-transfer-engine/test/unit/adapters/libfuse/cte_config.yaml
+++ b/context-transfer-engine/test/unit/adapters/libfuse/cte_config.yaml
@@ -1,0 +1,21 @@
+# CTE Configuration for FUSE adapter copy-workspace test
+# RAM-only storage — sized to hold /workspace source files
+compose:
+  - mod_name: wrp_cte_core
+    pool_name: wrp_cte
+    pool_query: local
+    pool_id: 512.0
+
+    targets:
+      neighborhood: 1
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    storage:
+      - path: "ram::cte_fuse_ram"
+        bdev_type: "ram"
+        capacity_limit: "16GB"
+        score: 0.0
+
+    dpe:
+      dpe_type: "max_bw"

--- a/context-transfer-engine/test/unit/adapters/libfuse/test_fuse_copy_workspace.cc
+++ b/context-transfer-engine/test/unit/adapters/libfuse/test_fuse_copy_workspace.cc
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * FUSE ADAPTER — COPY /workspace TEST
+ *
+ * Walks /workspace (skipping build directories), copies every regular file
+ * into CTE via the FUSE page-based helpers, then reads each file back and
+ * verifies byte-for-byte equality with the original.
+ *
+ * This exercises the full FUSE data path at scale:
+ *   CteGetOrCreateTag  -> tag creation (thousands of files)
+ *   CtePutBlob         -> page-aligned writes (hundreds of MB)
+ *   CteGetTagSize      -> metadata query
+ *   CteGetBlob         -> page-aligned reads
+ *   CteTagExists       -> tag existence check
+ *   CteDelTag          -> cleanup
+ */
+
+#include <chimaera/chimaera.h>
+#include <chimaera/bdev/bdev_client.h>
+#include <wrp_cte/core/core_client.h>
+#include <wrp_cte/core/core_tasks.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <vector>
+
+#include "adapter/libfuse/fuse_cte.h"
+#include "simple_test.h"
+
+namespace fs = std::filesystem;
+using namespace wrp::cae::fuse;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Root of the source tree to copy */
+static const std::string kWorkspaceRoot = "/workspace";
+
+/** Maximum individual file size we'll copy (skip huge files) */
+static constexpr size_t kMaxFileSize = 4 * 1024 * 1024;  // 4 MB
+
+/** Maximum total bytes to ingest (keeps RAM usage bounded) */
+static constexpr size_t kMaxTotalBytes = 512 * 1024 * 1024;  // 512 MB
+
+/** Directories to skip (build artifacts, git, caches) */
+static const std::vector<std::string> kSkipDirs = {
+    "build", "build_debug", "build_release", "build_socket",
+    ".git", ".ppi-jarvis", ".jarvis-private", ".jarvis-shared",
+    "__pycache__", "node_modules", ".cache", ".ssh-host",
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Check whether a path component matches any skip directory */
+static bool ShouldSkip(const fs::path &path) {
+  for (const auto &component : path) {
+    for (const auto &skip : kSkipDirs) {
+      if (component == skip) return true;
+    }
+  }
+  return false;
+}
+
+/** Read an entire file from disk into a byte vector */
+static std::vector<char> ReadFileFromDisk(const fs::path &path) {
+  std::ifstream ifs(path, std::ios::binary | std::ios::ate);
+  if (!ifs) return {};
+  auto size = static_cast<size_t>(ifs.tellg());
+  ifs.seekg(0);
+  std::vector<char> buf(size);
+  ifs.read(buf.data(), static_cast<std::streamsize>(size));
+  return buf;
+}
+
+/**
+ * Write a buffer into CTE as page-indexed blobs under the given tag.
+ * Mirrors the I/O path that cte_fuse_write() would take.
+ */
+static bool WriteFileToCte(const wrp_cte::core::TagId &tag_id,
+                           const char *data, size_t size) {
+  size_t offset = 0;
+  while (offset < size) {
+    size_t page = offset / kDefaultPageSize;
+    size_t poff = offset % kDefaultPageSize;
+    size_t chunk = std::min(kDefaultPageSize - poff, size - offset);
+    if (!CtePutBlob(tag_id, std::to_string(page), data + offset, chunk, poff)) {
+      return false;
+    }
+    offset += chunk;
+  }
+  return true;
+}
+
+/**
+ * Read a file back from CTE page-by-page.
+ * Mirrors the I/O path that cte_fuse_read() would take.
+ */
+static std::vector<char> ReadFileFromCte(const wrp_cte::core::TagId &tag_id,
+                                         size_t size) {
+  std::vector<char> buf(size);
+  size_t offset = 0;
+  while (offset < size) {
+    size_t page = offset / kDefaultPageSize;
+    size_t poff = offset % kDefaultPageSize;
+    size_t chunk = std::min(kDefaultPageSize - poff, size - offset);
+    if (!CteGetBlob(tag_id, std::to_string(page), buf.data() + offset,
+                    chunk, poff)) {
+      return {};
+    }
+    offset += chunk;
+  }
+  return buf;
+}
+
+/** Collect eligible files under /workspace */
+static std::vector<fs::path> CollectFiles() {
+  std::vector<fs::path> files;
+  size_t total = 0;
+  std::error_code ec;
+
+  for (auto it = fs::recursive_directory_iterator(
+           kWorkspaceRoot, fs::directory_options::skip_permission_denied, ec);
+       it != fs::recursive_directory_iterator(); ++it) {
+    if (ec) { it.increment(ec); continue; }
+
+    const auto &entry = *it;
+
+    // Skip excluded directories
+    if (entry.is_directory() && ShouldSkip(entry.path())) {
+      it.disable_recursion_pending();
+      continue;
+    }
+
+    if (!entry.is_regular_file(ec)) continue;
+    if (ec) continue;
+
+    auto fsize = entry.file_size(ec);
+    if (ec || fsize == 0 || fsize > kMaxFileSize) continue;
+
+    if (total + fsize > kMaxTotalBytes) break;
+
+    files.push_back(entry.path());
+    total += fsize;
+  }
+
+  return files;
+}
+
+// ============================================================================
+// Test fixture
+// ============================================================================
+
+class CopyWorkspaceFixture {
+ public:
+  static inline bool g_initialized = false;
+
+  CopyWorkspaceFixture() {
+    if (!g_initialized) {
+      bool success = chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
+      REQUIRE(success);
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+      success = wrp_cte::core::WRP_CTE_CLIENT_INIT();
+      REQUIRE(success);
+
+      auto *cte_client = WRP_CTE_CLIENT;
+      REQUIRE(cte_client != nullptr);
+      cte_client->Init(wrp_cte::core::kCtePoolId);
+
+      wrp_cte::core::CreateParams params;
+      auto create_task = cte_client->AsyncCreate(
+          chi::PoolQuery::Dynamic(), wrp_cte::core::kCtePoolName,
+          wrp_cte::core::kCtePoolId, params);
+      create_task.Wait();
+      REQUIRE(create_task->GetReturnCode() == 0);
+
+      g_initialized = true;
+      INFO("CTE runtime initialized for copy-workspace tests");
+    }
+  }
+};
+
+// ============================================================================
+// Ingested file record
+// ============================================================================
+
+struct IngestedFile {
+  fs::path disk_path;
+  std::string tag_name;
+  wrp_cte::core::TagId tag_id;
+  size_t size;
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+TEST_CASE("FUSE Copy Workspace - Ingest and verify files",
+          "[fuse][copy_workspace]") {
+  auto *fixture = hshm::Singleton<CopyWorkspaceFixture>::GetInstance();
+  (void)fixture;
+
+  auto files = CollectFiles();
+  REQUIRE(!files.empty());
+  INFO("Collected " << files.size() << " files to copy");
+
+  // Phase 1: Ingest — create tags and write page blobs
+  std::vector<IngestedFile> ingested;
+
+  size_t total_bytes = 0;
+  for (const auto &path : files) {
+    auto data = ReadFileFromDisk(path);
+    if (data.empty()) continue;
+
+    std::string tag_name = path.string();
+    auto tag_id = CteGetOrCreateTag(tag_name);
+    REQUIRE(!tag_id.IsNull());
+
+    REQUIRE(WriteFileToCte(tag_id, data.data(), data.size()));
+    ingested.push_back({path, tag_name, tag_id, data.size()});
+    total_bytes += data.size();
+  }
+
+  REQUIRE(!ingested.empty());
+  INFO("Ingested " << ingested.size() << " files, "
+                    << total_bytes << " bytes total");
+
+  // Phase 2: Verify — read back every file and compare byte-for-byte
+  size_t verified = 0;
+  for (const auto &entry : ingested) {
+    // Check tag size matches
+    size_t cte_size = CteGetTagSize(entry.tag_id);
+    REQUIRE(cte_size == entry.size);
+
+    // Read back from CTE
+    auto cte_data = ReadFileFromCte(entry.tag_id, entry.size);
+    REQUIRE(cte_data.size() == entry.size);
+
+    // Read original from disk
+    auto disk_data = ReadFileFromDisk(entry.disk_path);
+    REQUIRE(disk_data.size() == entry.size);
+
+    // Byte-for-byte comparison
+    REQUIRE(memcmp(cte_data.data(), disk_data.data(), entry.size) == 0);
+    ++verified;
+  }
+
+  INFO("Verified " << verified << " files byte-for-byte");
+  REQUIRE(verified == ingested.size());
+
+  // Phase 3: Spot-check tag existence via CteTagExists
+  size_t spot_check = std::min(ingested.size(), static_cast<size_t>(20));
+  for (size_t i = 0; i < spot_check; ++i) {
+    REQUIRE(CteTagExists(ingested[i].tag_name));
+  }
+  INFO("Spot-checked " << spot_check << " tags via CteTagExists");
+
+  // Phase 4: Cleanup — delete all tags
+  size_t deleted = 0;
+  for (const auto &entry : ingested) {
+    CteDelTag(entry.tag_name);
+    ++deleted;
+  }
+  INFO("Cleaned up " << deleted << " tags");
+
+  // Spot-check that a few tags are actually gone
+  size_t check_count = std::min(ingested.size(), static_cast<size_t>(10));
+  for (size_t i = 0; i < check_count; ++i) {
+    REQUIRE_FALSE(CteTagExists(ingested[i].tag_name));
+  }
+  INFO("Post-cleanup spot-check passed");
+}
+
+SIMPLE_TEST_MAIN()

--- a/jarvis_iowarp/jarvis_iowarp/wrp_adapters/pkg.py
+++ b/jarvis_iowarp/jarvis_iowarp/wrp_adapters/pkg.py
@@ -77,6 +77,13 @@ class WrpAdapters(Interceptor):
                 'help': 'Intercepts NVIDIA GPUDirect Storage operations'
             },
             {
+                'name': 'adios2',
+                'msg': 'Enable ADIOS2 IOWarp engine plugin',
+                'type': bool,
+                'default': False,
+                'help': 'Sets ADIOS2_PLUGIN_PATH so ADIOS2 discovers the iowarp_engine plugin'
+            },
+            {
                 'name': 'include',
                 'msg': 'Path patterns to include for interception (list)',
                 'type': list,
@@ -160,8 +167,17 @@ class WrpAdapters(Interceptor):
             self.log(f'Found libwrp_cte_nvidia_gds.so at {nvidia_gds_lib}')
             has_one = True
 
+        if self.config['adios2']:
+            adios2_lib = self.find_library('iowarp_engine')
+            if adios2_lib is None:
+                raise Exception('Could not find iowarp_engine library')
+            self.env['ADIOS2_PLUGIN_PATH'] = str(pathlib.Path(adios2_lib).parent)
+            self.env['WRP_CTE_ROOT'] = str(pathlib.Path(adios2_lib).parent.parent)
+            self.log(f'Found libiowarp_engine.so at {adios2_lib}')
+            has_one = True
+
         if not has_one:
-            raise Exception('No WRP CTE adapter selected. Please enable at least one adapter (posix, mpiio, stdio, vfd, or nvidia_gds).')
+            raise Exception('No WRP CTE adapter selected. Please enable at least one adapter (posix, mpiio, stdio, vfd, nvidia_gds, or adios2).')
 
         # Generate CAE configuration
         self._generate_cae_config()
@@ -208,6 +224,11 @@ class WrpAdapters(Interceptor):
         if self.config['nvidia_gds']:
             self.prepend_env('LD_PRELOAD', self.env['WRP_CTE_NVIDIA_GDS'])
             self.log(f"Added NVIDIA GDS adapter to LD_PRELOAD")
+
+        # Configure ADIOS2 plugin path
+        if self.config['adios2']:
+            self.setenv('ADIOS2_PLUGIN_PATH', self.env['ADIOS2_PLUGIN_PATH'])
+            self.log(f"Set ADIOS2_PLUGIN_PATH to {self.env['ADIOS2_PLUGIN_PATH']}")
 
     def _generate_cae_config(self):
         """

--- a/test/fuse-manual/copy_workspace.sh
+++ b/test/fuse-manual/copy_workspace.sh
@@ -34,17 +34,39 @@ fi
 info "Copying /workspace into $MOUNT_POINT/workspace/ ..."
 info "  (excluding build dirs, .git, caches)"
 
-rsync -a --info=progress2 \
-    --exclude='build*' \
-    --exclude='.git' \
-    --exclude='.ppi-jarvis' \
-    --exclude='.jarvis-private' \
-    --exclude='.jarvis-shared' \
-    --exclude='.ssh-host' \
-    --exclude='__pycache__' \
-    --exclude='node_modules' \
-    --exclude='.cache' \
-    /workspace/ "$MOUNT_POINT/workspace/"
+EXCLUDES="build|build_debug|build_release|build_socket|\.git|\.ppi-jarvis|\.jarvis-private|\.jarvis-shared|\.ssh-host|__pycache__|node_modules|\.cache"
+
+if command -v rsync &>/dev/null; then
+    rsync -a --info=progress2 \
+        --exclude='build*' \
+        --exclude='.git' \
+        --exclude='.ppi-jarvis' \
+        --exclude='.jarvis-private' \
+        --exclude='.jarvis-shared' \
+        --exclude='.ssh-host' \
+        --exclude='__pycache__' \
+        --exclude='node_modules' \
+        --exclude='.cache' \
+        /workspace/ "$MOUNT_POINT/workspace/"
+else
+    info "rsync not found, using find+cp (slower)..."
+    cd /workspace
+    find . -not -path "./.git/*" \
+           -not -path "./build*" \
+           -not -path "./.ppi-jarvis/*" \
+           -not -path "./.jarvis-private/*" \
+           -not -path "./.jarvis-shared/*" \
+           -not -path "./.ssh-host/*" \
+           -not -path "./__pycache__/*" \
+           -not -path "./.cache/*" \
+           -not -name "*.o" \
+           -type f | while IFS= read -r f; do
+        dir="$MOUNT_POINT/workspace/$(dirname "$f")"
+        mkdir -p "$dir" 2>/dev/null || true
+        cp "$f" "$dir/" 2>/dev/null || true
+    done
+    cd - >/dev/null
+fi
 
 ok "Copy complete"
 

--- a/test/fuse-manual/copy_workspace.sh
+++ b/test/fuse-manual/copy_workspace.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Copy /workspace into the FUSE-mounted CTE filesystem and verify
+# Usage: ./copy_workspace.sh [mount_point]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PID_DIR="$SCRIPT_DIR/.pids"
+
+if [ -f "$PID_DIR/mount_point" ]; then
+    MOUNT_POINT="$(cat "$PID_DIR/mount_point")"
+else
+    MOUNT_POINT="${1:-/tmp/cte_fuse_mount}"
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $1"; }
+ok()    { echo -e "${GREEN}[OK]${NC}   $1"; }
+fail()  { echo -e "${RED}[FAIL]${NC} $1"; }
+
+# --- Preflight ---------------------------------------------------------------
+
+if ! mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+    echo -e "${RED}[ERR]${NC}  FUSE not mounted at $MOUNT_POINT — run ./start.sh first" >&2
+    exit 1
+fi
+
+# --- Copy --------------------------------------------------------------------
+
+info "Copying /workspace into $MOUNT_POINT/workspace/ ..."
+info "  (excluding build dirs, .git, caches)"
+
+rsync -a --info=progress2 \
+    --exclude='build*' \
+    --exclude='.git' \
+    --exclude='.ppi-jarvis' \
+    --exclude='.jarvis-private' \
+    --exclude='.jarvis-shared' \
+    --exclude='.ssh-host' \
+    --exclude='__pycache__' \
+    --exclude='node_modules' \
+    --exclude='.cache' \
+    /workspace/ "$MOUNT_POINT/workspace/"
+
+ok "Copy complete"
+
+# --- Verify ------------------------------------------------------------------
+
+info "Verifying a sample of files..."
+
+FAILURES=0
+CHECKED=0
+
+verify_file() {
+    local src="$1"
+    local dst="$MOUNT_POINT/workspace/${src#/workspace/}"
+    if [ ! -f "$dst" ]; then
+        fail "Missing: $dst"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    if ! cmp -s "$src" "$dst"; then
+        fail "Mismatch: $src"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    CHECKED=$((CHECKED + 1))
+}
+
+# Check known files
+verify_file /workspace/CMakeLists.txt
+verify_file /workspace/README.md
+verify_file /workspace/CMakePresets.json
+verify_file /workspace/context-transfer-engine/adapter/libfuse/fuse_cte.h
+verify_file /workspace/context-transfer-engine/adapter/libfuse/fuse_cte.cc
+verify_file /workspace/context-transfer-engine/adapter/libfuse/CMakeLists.txt
+
+# Check some random source files
+for f in $(find /workspace/context-transfer-engine/core/src -name '*.cc' -maxdepth 1 2>/dev/null | head -5); do
+    verify_file "$f"
+done
+
+for f in $(find /workspace/context-runtime/src -name '*.cc' -maxdepth 1 2>/dev/null | head -5); do
+    verify_file "$f"
+done
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    ok "All $CHECKED sampled files verified byte-for-byte"
+else
+    fail "$FAILURES of $((CHECKED + FAILURES)) files failed verification"
+    exit 1
+fi
+
+# --- Summary -----------------------------------------------------------------
+
+TOTAL_FILES=$(find "$MOUNT_POINT/workspace/" -type f 2>/dev/null | wc -l)
+TOTAL_SIZE=$(du -sh "$MOUNT_POINT/workspace/" 2>/dev/null | cut -f1)
+
+echo ""
+echo "========================================="
+echo "  Files copied:  $TOTAL_FILES"
+echo "  Total size:    $TOTAL_SIZE"
+echo "  Mount point:   $MOUNT_POINT/workspace/"
+echo ""
+echo "Browse with:  ls $MOUNT_POINT/workspace/"
+echo "========================================="

--- a/test/fuse-manual/cte_config.yaml
+++ b/test/fuse-manual/cte_config.yaml
@@ -1,0 +1,27 @@
+---
+# CTE Configuration for FUSE manual testing
+# RAM-only storage, sized for copying /workspace source tree
+
+runtime:
+  num_threads: 4
+  queue_depth: 1024
+
+compose:
+  - mod_name: wrp_cte_core
+    pool_name: wrp_cte
+    pool_query: local
+    pool_id: "512.0"
+
+    targets:
+      neighborhood: 1
+      default_target_timeout_ms: 30000
+      poll_period_ms: 5000
+
+    storage:
+      - path: "ram::cte_fuse_ram"
+        bdev_type: "ram"
+        capacity_limit: "4GB"
+        score: 0.0
+
+    dpe:
+      dpe_type: "max_bw"

--- a/test/fuse-manual/start.sh
+++ b/test/fuse-manual/start.sh
@@ -62,7 +62,9 @@ ok "Chimaera runtime started (PID $RUNTIME_PID)"
 # --- Start FUSE daemon -------------------------------------------------------
 
 info "Mounting FUSE filesystem at $MOUNT_POINT ..."
-wrp_cte_fuse "$MOUNT_POINT" -f &
+# Run FUSE daemon as a pure client — connect to the already-running
+# runtime instead of trying to start its own.
+CHI_WITH_RUNTIME=0 wrp_cte_fuse "$MOUNT_POINT" -f &
 FUSE_PID=$!
 echo "$FUSE_PID" > "$PID_DIR/fuse.pid"
 echo "$MOUNT_POINT" > "$PID_DIR/mount_point"

--- a/test/fuse-manual/start.sh
+++ b/test/fuse-manual/start.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Start IOWarp runtime + FUSE filesystem
+# Usage: ./start.sh [mount_point]
+#
+# After running this, the FUSE mount is live and you can:
+#   cp -r /workspace/* /tmp/cte_fuse_mount/
+#   ls /tmp/cte_fuse_mount/
+#   diff /workspace/README.md /tmp/cte_fuse_mount/README.md
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_BIN="$REPO_ROOT/build/bin"
+MOUNT_POINT="${1:-/tmp/cte_fuse_mount}"
+PID_DIR="$SCRIPT_DIR/.pids"
+
+export PATH="$BUILD_BIN:$PATH"
+export LD_LIBRARY_PATH="$BUILD_BIN:${LD_LIBRARY_PATH:-}"
+export WRP_RUNTIME_CONF="$SCRIPT_DIR/cte_config.yaml"
+export HSHM_LOG_LEVEL=info
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $1"; }
+ok()    { echo -e "${GREEN}[OK]${NC}   $1"; }
+die()   { echo -e "${RED}[ERR]${NC}  $1" >&2; exit 1; }
+
+# --- Preflight checks -------------------------------------------------------
+
+[ -x "$BUILD_BIN/chimaera" ]      || die "chimaera not found — build with: cmake --preset release-fuse && cmake --build build -j\$(nproc)"
+[ -x "$BUILD_BIN/wrp_cte_fuse" ]  || die "wrp_cte_fuse not found — build with: cmake --preset release-fuse && cmake --build build -j\$(nproc)"
+command -v fusermount3 &>/dev/null || die "fusermount3 not found — install fuse3: sudo apt install fuse3"
+[ -c /dev/fuse ]                   || die "/dev/fuse not available"
+
+# --- Cleanup any previous run -----------------------------------------------
+
+if [ -f "$PID_DIR/fuse.pid" ] && kill -0 "$(cat "$PID_DIR/fuse.pid")" 2>/dev/null; then
+    info "Stopping previous FUSE daemon..."
+    "$SCRIPT_DIR/stop.sh" 2>/dev/null || true
+fi
+
+mkdir -p "$PID_DIR" "$MOUNT_POINT"
+
+# --- Start Chimaera runtime -------------------------------------------------
+
+info "Starting Chimaera runtime..."
+export CHI_SERVER_CONF="$WRP_RUNTIME_CONF"
+chimaera runtime start &
+RUNTIME_PID=$!
+echo "$RUNTIME_PID" > "$PID_DIR/runtime.pid"
+sleep 3
+
+if ! kill -0 "$RUNTIME_PID" 2>/dev/null; then
+    die "Chimaera runtime failed to start"
+fi
+ok "Chimaera runtime started (PID $RUNTIME_PID)"
+
+# --- Start FUSE daemon -------------------------------------------------------
+
+info "Mounting FUSE filesystem at $MOUNT_POINT ..."
+wrp_cte_fuse "$MOUNT_POINT" -f &
+FUSE_PID=$!
+echo "$FUSE_PID" > "$PID_DIR/fuse.pid"
+echo "$MOUNT_POINT" > "$PID_DIR/mount_point"
+sleep 2
+
+if ! kill -0 "$FUSE_PID" 2>/dev/null; then
+    die "wrp_cte_fuse failed to start"
+fi
+ok "FUSE filesystem mounted (PID $FUSE_PID)"
+
+# --- Done --------------------------------------------------------------------
+
+echo ""
+echo "========================================="
+echo "IOWarp FUSE filesystem is ready!"
+echo "  Mount point:  $MOUNT_POINT"
+echo "  Runtime PID:  $RUNTIME_PID"
+echo "  FUSE PID:     $FUSE_PID"
+echo ""
+echo "Try:"
+echo "  cp -r /workspace/README.md $MOUNT_POINT/"
+echo "  cat $MOUNT_POINT/README.md"
+echo "  rsync -av --exclude='build*' --exclude='.git' /workspace/ $MOUNT_POINT/workspace/"
+echo ""
+echo "Stop with:  ./stop.sh"
+echo "========================================="

--- a/test/fuse-manual/stop.sh
+++ b/test/fuse-manual/stop.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Stop IOWarp runtime + FUSE filesystem
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_BIN="$REPO_ROOT/build/bin"
+PID_DIR="$SCRIPT_DIR/.pids"
+
+export PATH="$BUILD_BIN:$PATH"
+export LD_LIBRARY_PATH="$BUILD_BIN:${LD_LIBRARY_PATH:-}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC} $1"; }
+ok()    { echo -e "${GREEN}[OK]${NC}   $1"; }
+
+# --- Unmount FUSE ------------------------------------------------------------
+
+if [ -f "$PID_DIR/mount_point" ]; then
+    MOUNT_POINT="$(cat "$PID_DIR/mount_point")"
+    if mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+        info "Unmounting $MOUNT_POINT ..."
+        fusermount3 -u "$MOUNT_POINT" 2>/dev/null || true
+        sleep 1
+    fi
+fi
+
+# --- Kill FUSE daemon --------------------------------------------------------
+
+if [ -f "$PID_DIR/fuse.pid" ]; then
+    FUSE_PID="$(cat "$PID_DIR/fuse.pid")"
+    if kill -0 "$FUSE_PID" 2>/dev/null; then
+        info "Stopping FUSE daemon (PID $FUSE_PID)..."
+        kill "$FUSE_PID" 2>/dev/null || true
+        wait "$FUSE_PID" 2>/dev/null || true
+    fi
+    rm -f "$PID_DIR/fuse.pid"
+    ok "FUSE daemon stopped"
+fi
+
+# --- Stop Chimaera runtime ---------------------------------------------------
+
+if [ -f "$PID_DIR/runtime.pid" ]; then
+    RUNTIME_PID="$(cat "$PID_DIR/runtime.pid")"
+    if kill -0 "$RUNTIME_PID" 2>/dev/null; then
+        info "Stopping Chimaera runtime (PID $RUNTIME_PID)..."
+        kill "$RUNTIME_PID" 2>/dev/null || true
+        wait "$RUNTIME_PID" 2>/dev/null || true
+    fi
+    rm -f "$PID_DIR/runtime.pid"
+    ok "Chimaera runtime stopped"
+fi
+
+# --- Cleanup -----------------------------------------------------------------
+
+rm -f "$PID_DIR/mount_point"
+rmdir "$PID_DIR" 2>/dev/null || true
+
+if [ -n "$MOUNT_POINT" ] && [ -d "$MOUNT_POINT" ]; then
+    rmdir "$MOUNT_POINT" 2>/dev/null || true
+fi
+
+ok "All cleaned up"


### PR DESCRIPTION
## Summary
- **FUSE mkdir fix**: `mkdir` now creates a sentinel tag so directories exist immediately in `getattr`/`readdir`, enabling `cp -r` and `rsync` workflows
- **Copy-workspace unit test**: ingests all of `/workspace` (18K+ files, ~500MB) into CTE via FUSE page helpers, verifies every file byte-for-byte
- **Manual deploy scripts** (`test/fuse-manual/`): `start.sh`, `stop.sh`, `copy_workspace.sh` for hands-on FUSE testing
- **release-fuse cmake preset**: Release build with `WRP_CTE_ENABLE_FUSE_ADAPTER=ON`
- **ADIOS2 wrp_adapter**: adds `ADIOS2_PLUGIN_PATH` support to the interceptor package
- **Logging fix**: demoted `ModifyExistingData` per-op profiling log from `kInfo` to `kDebug`
- **jarvis-cd**: pulled latest dev (container support, spack install manager)

## Test plan
- [x] `test_fuse_copy_workspace`: 18,622 files ingested, verified, cleaned up
- [x] `test_fuse_adapter`: all 10 existing tests pass
- [x] Manual FUSE deploy: `mkdir`, `cp`, `cat`, `diff`, `ls`, `rm` all verified
- [x] Gray-scott pipeline verified with BP5 engine
- [x] Build succeeds with `cmake --preset release-fuse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)