### PR TITLE
Fix spack CI: dump build log on failure, unify HDF5 VOL option

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -26,5 +26,9 @@ jobs:
         run: |
           . ./spack/share/spack/setup-env.sh
           spack repo add installers/spack
-          spack install iowarp+posix
+          spack install iowarp+posix || {
+            echo "=== SPACK BUILD LOG ==="
+            find /tmp -name "spack-stage-iowarp-*" -name "*.log" -exec cat {} \;
+            exit 1
+          }
           spack load iowarp+posix


### PR DESCRIPTION
## Summary
- Dump spack build log on failure so we can see the actual compile error
- Unify HDF5 VOL control under `WRP_CTE_ENABLE_HDF5_VOL` (OFF by default)
- Guard VOL adapter behind the new flag

## Context
Spack CI failed after PR #389 merge but the build log wasn't visible. These changes add log dumping and ensure the HDF5 VOL adapter (which requires HDF5 >= 2.0) isn't built with spack's HDF5 1.14.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)