### PR TITLE
pipelines: iowarp_apptainer_test (apptainer variant of container_test)

### DIFF
--- a/jarvis_iowarp/pipelines/container/iowarp_apptainer_test.yaml
+++ b/jarvis_iowarp/pipelines/container/iowarp_apptainer_test.yaml
@@ -1,0 +1,51 @@
+# Pipeline: IOWarp runtime + CTE + ADIOS2 Gray-Scott (Apptainer variant)
+# Purpose: Smoke test the IOWarp container stack on HPC where only
+# Apptainer is available (Aurora, etc.). Mirrors iowarp_container_test.yaml
+# but builds a SIF natively via 'apptainer build --fakeroot' and starts a
+# persistent 'apptainer instance' for the pipeline.
+#
+# Notes:
+#  - install_manager: container is required so deploy_mode=container is
+#    not overwritten back to 'default'.
+#  - container_engine: apptainer makes jarvis_cd.core.pipeline call
+#    _build_apptainer_native (no docker/podman dependency) and
+#    _start_containerized_pipeline's apptainer branch (instance start +
+#    sshd inside the instance on container_ssh_port).
+#  - No seccomp tweak needed: apptainer doesn't apply Docker's profile,
+#    so io_uring works for IOWarp's bdev backend out of the box.
+#  - engine: iowarp on adios2_gray_scott routes its writes through the
+#    IOWarp ADIOS2 engine, which talks to the chimaera runtime started
+#    by wrp_runtime. No FUSE / LD_PRELOAD interceptor is involved.
+
+name: iowarp_apptainer_test
+
+install_manager: container
+container_engine: apptainer
+container_base: ubuntu:24.04
+container_ssh_port: 2233
+
+pkgs:
+  # Library packages — embedded into the SIF via %post (each contributes
+  # its build.sh). Must precede wrp_runtime so its build sees them.
+  - pkg_type: builtin.hdf5
+    deploy_mode: container
+  - pkg_type: builtin.adios2
+    deploy_mode: container
+  - pkg_type: builtin.compress_libs
+    deploy_mode: container
+
+  - pkg_type: jarvis_iowarp.wrp_runtime
+    deploy_mode: container
+    git_branch: transparent-compress
+    cmake_preset: release-adapter
+    port: 9413
+    sleep: 2
+
+  - pkg_type: jarvis_iowarp.wrp_cte
+    deploy_mode: container
+
+  - pkg_type: jarvis_iowarp.adios2_gray_scott
+    deploy_mode: container
+    engine: iowarp
+    nprocs: 1
+    steps: 10


### PR DESCRIPTION
## Summary
Adds an Apptainer counterpart to \`jarvis_iowarp/pipelines/container/iowarp_container_test.yaml\` so the IOWarp container stack can be exercised on HPC sites that only expose Apptainer (Aurora, Polaris, etc.). Same package list (hdf5, adios2, compress_libs, wrp_runtime, wrp_cte, adios2_gray_scott with \`engine: iowarp\`).

## Differences vs the existing docker yaml
- \`container_engine: apptainer\` → jarvis-cd routes through \`_build_apptainer_native\` + \`apptainer instance start\`.
- \`container_ssh_port: 2233\` matches what jarvis-cd auto-launches inside the instance.
- No \`security_opt: seccomp=unconfined\` — apptainer doesn't apply Docker's profile, so \`io_uring\` works for IOWarp's bdev backend by default.

## Test plan
- [x] Validated on Aurora compute node \`x4305c0s6b0n0\` with the two upstream jarvis-cd PRs applied:
  - grc-iit/jarvis-cd#136 (\`instance://\` wrap so chimaera persists across exec calls)
  - grc-iit/jarvis-cd#137 (proxy forwarding into the SIF \`%post\` + \`pkg-config\` for compress_libs)
- [x] Build: 509 MB SIF in ~12 min; chimaera, gray-scott, iowarp ADIOS2 plugin all present.
- [x] Run: \`chimaera runtime\` starts inside instance, CTE \`Successfully connected to runtime (generation=…, server_pid=21)\`, \`gray-scott\` opens IowarpEngine, writes step 10 through CTE, engine reports 32.2 ms wall / 26.4 ms I/O / 5.8 ms compute / 81.9% I/O.
- [ ] Reviewer confirm both upstream PRs are required (they are, but worth a sanity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)