### PR TITLE
fix(lightbeam): replace #ifdef with #if for HSHM_ENABLE_ZMQ guards

### DIFF
--- a/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
@@ -311,7 +311,7 @@ void TestSocketTransportWithEM() {
   std::cout << "[SocketTransport With EventManager] Test passed!\n";
 }
 
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
 #include <hermes_shm/lightbeam/zmq_transport.h>
 
 void TestZmqTransportWithEM() {
@@ -382,7 +382,7 @@ int main() {
 #endif
   TestSocketTransportWithEM();
 
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
   TestZmqTransportWithEM();
 #else
   std::cout << "\n[Skipped] ZmqTransport With EventManager (ZMQ not enabled)\n";

--- a/context-transport-primitives/test/unit/lightbeam/lightbeam_transport_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/lightbeam_transport_test.cc
@@ -42,7 +42,7 @@
 using namespace hshm::lbm;
 
 void TestZeroMQ() {
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
   std::cout << "\n==== Testing ZeroMQ ====\n";
 
   std::string addr = "127.0.0.1";

--- a/context-transport-primitives/test/unit/lightbeam/test_lightbeam_new.cc
+++ b/context-transport-primitives/test/unit/lightbeam/test_lightbeam_new.cc
@@ -58,7 +58,7 @@ class TestMeta : public LbmMeta<> {
 void TestBasicTransfer() {
   std::cout << "\n==== Testing Basic Transfer with New API ====\n";
 
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
   // Create server
   std::string addr = "127.0.0.1";
   std::string protocol = "tcp";
@@ -135,7 +135,7 @@ void TestBasicTransfer() {
 void TestMultipleBulks() {
   std::cout << "\n==== Testing Multiple Bulks Transfer ====\n";
 
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
   std::string addr = "127.0.0.1";
   std::string protocol = "tcp";
   int port = 8196;


### PR DESCRIPTION
## Summary

- `#ifdef HSHM_ENABLE_ZMQ` evaluates to **true** when ZMQ is disabled because the macro is defined as `0` (not undefined)
- `zmq_transport.h` guards `ZeroMqTransport` with `#if HSHM_ENABLE_ZMQ` (value check), so the class is never declared when ZMQ is off
- This mismatch causes a compile error: `ZeroMqTransport was not declared in this scope`
- Fix: use `#if HSHM_ENABLE_ZMQ` consistently in all three affected lightbeam test files

## Test plan

- [ ] Build with `-DWRP_CORE_ENABLE_ZMQ=OFF` (default) — no compile errors in lightbeam tests
- [ ] Build with `-DWRP_CORE_ENABLE_ZMQ=ON` — ZMQ tests compile and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)