### PR TITLE
fix(runtime): treat loopback addresses as matching local host in IdentifyThisHost

### DIFF
--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -1590,7 +1590,11 @@ bool IpcManager::IdentifyThisHost() {
     std::string entry_short =
         host.ip_address.substr(0, host.ip_address.find('.'));
 
-    bool is_me = (host.ip_address == local_host) ||
+    bool is_loopback = (host.ip_address == "127.0.0.1") ||
+                       (host.ip_address == "localhost") ||
+                       (host.ip_address == "::1");
+    bool is_me = is_loopback ||
+                 (host.ip_address == local_host) ||
                  (entry_short == local_short);
     if (!is_me) continue;
 

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -1237,22 +1237,30 @@ if(WRP_CORE_ENABLE_MPI)
     # 4-rank test: server + SHM + TCP + IPC clients
     add_test(
       NAME cr_mpi_bdev_transport_all_modes
-      COMMAND mpirun -n 4 ${CMAKE_BINARY_DIR}/bin/${MPI_BDEV_TRANSPORT_TEST_TARGET}
+      COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+              ${MPIEXEC_PREFLAGS}
+              ${CMAKE_BINARY_DIR}/bin/${MPI_BDEV_TRANSPORT_TEST_TARGET}
+              ${MPIEXEC_POSTFLAGS}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     )
     set_tests_properties(cr_mpi_bdev_transport_all_modes PROPERTIES
       ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+      RESOURCE_LOCK "chimaera_runtime_port"
       TIMEOUT 300
     )
 
     # 2-rank test: server + TCP client (minimal)
     add_test(
       NAME cr_mpi_bdev_transport_minimal
-      COMMAND mpirun -n 2 ${CMAKE_BINARY_DIR}/bin/${MPI_BDEV_TRANSPORT_TEST_TARGET}
+      COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+              ${MPIEXEC_PREFLAGS}
+              ${CMAKE_BINARY_DIR}/bin/${MPI_BDEV_TRANSPORT_TEST_TARGET}
+              ${MPIEXEC_POSTFLAGS}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     )
     set_tests_properties(cr_mpi_bdev_transport_minimal PROPERTIES
       ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+      RESOURCE_LOCK "chimaera_runtime_port"
       TIMEOUT 180
     )
   endif()

--- a/context-transport-primitives/test/unit/allocator/run_mp_allocator_multiprocess_test.sh
+++ b/context-transport-primitives/test/unit/allocator/run_mp_allocator_multiprocess_test.sh
@@ -43,9 +43,14 @@ cleanup() {
 # Set trap to cleanup on exit
 trap cleanup EXIT INT TERM
 
+# Use PID-unique log files to avoid conflicts when tests run in parallel
+LOG0="/tmp/mp_test_rank0_$$.log"
+LOG1="/tmp/mp_test_rank1_$$.log"
+LOG2="/tmp/mp_test_rank2_$$.log"
+
 # Start all three ranks in background
 echo -e "${YELLOW}[Step 1]${NC} Starting rank 0 (${DURATION}s, ${NTHREADS} threads) in background..."
-"$TEST_BINARY" 0 $DURATION $NTHREADS > /tmp/mp_test_rank0.log 2>&1 &
+"$TEST_BINARY" 0 $DURATION $NTHREADS > "$LOG0" 2>&1 &
 RANK0_PID=$!
 echo "Rank 0 PID: $RANK0_PID"
 
@@ -53,12 +58,12 @@ echo "Rank 0 PID: $RANK0_PID"
 sleep 2
 
 echo -e "${YELLOW}[Step 2]${NC} Starting rank 1 (${DURATION}s, ${NTHREADS} threads) in background..."
-"$TEST_BINARY" 1 $DURATION $NTHREADS > /tmp/mp_test_rank1.log 2>&1 &
+"$TEST_BINARY" 1 $DURATION $NTHREADS > "$LOG1" 2>&1 &
 RANK1_PID=$!
 echo "Rank 1 PID: $RANK1_PID"
 
 echo -e "${YELLOW}[Step 3]${NC} Starting rank 2 (${DURATION}s, ${NTHREADS} threads) in background..."
-"$TEST_BINARY" 2 $DURATION $NTHREADS > /tmp/mp_test_rank2.log 2>&1 &
+"$TEST_BINARY" 2 $DURATION $NTHREADS > "$LOG2" 2>&1 &
 RANK2_PID=$!
 echo "Rank 2 PID: $RANK2_PID"
 echo ""
@@ -103,13 +108,13 @@ echo "=========================================="
 # Display logs
 echo ""
 echo "--- Rank 0 Output ---"
-cat /tmp/mp_test_rank0.log
+cat "$LOG0"
 echo ""
 echo "--- Rank 1 Output ---"
-cat /tmp/mp_test_rank1.log
+cat "$LOG1"
 echo ""
 echo "--- Rank 2 Output ---"
-cat /tmp/mp_test_rank2.log
+cat "$LOG2"
 echo ""
 
 # Final result
@@ -119,7 +124,7 @@ if [ $RANK0_EXIT -eq 0 ] && [ $RANK1_EXIT -eq 0 ] && [ $RANK2_EXIT -eq 0 ]; then
     echo -e "==========================================${NC}"
 
     # Cleanup log files
-    rm -f /tmp/mp_test_rank0.log /tmp/mp_test_rank1.log /tmp/mp_test_rank2.log
+    rm -f "$LOG0" "$LOG1" "$LOG2"
 
     exit 0
 else
@@ -131,9 +136,9 @@ else
     echo "Rank 2 exit code: $RANK2_EXIT"
     echo ""
     echo "Log files preserved:"
-    echo "  - /tmp/mp_test_rank0.log"
-    echo "  - /tmp/mp_test_rank1.log"
-    echo "  - /tmp/mp_test_rank2.log"
+    echo "  - $LOG0"
+    echo "  - $LOG1"
+    echo "  - $LOG2"
 
     exit 1
 fi

--- a/context-transport-primitives/test/unit/lightbeam/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/lightbeam/CMakeLists.txt
@@ -5,6 +5,7 @@ if(WRP_CORE_ENABLE_ZMQ)
     add_test(NAME lightbeam_transport_test COMMAND lightbeam_transport_test)
     set_tests_properties(lightbeam_transport_test PROPERTIES
         LABELS "msan_skip"
+        RESOURCE_LOCK "lightbeam_port"
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}")
     install(TARGETS lightbeam_transport_test
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -17,6 +18,7 @@ if(WRP_CORE_ENABLE_ZMQ)
     add_test(NAME ctp_lightbeam_new COMMAND test_lightbeam_new)
     set_tests_properties(ctp_lightbeam_new PROPERTIES
         LABELS "msan_skip"
+        RESOURCE_LOCK "lightbeam_port"
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}")
     install(TARGETS test_lightbeam_new
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -29,6 +31,7 @@ target_link_libraries(socket_transport_test hermes_shm_host hshm::lightbeam hshm
 add_test(NAME ctp_socket_transport COMMAND socket_transport_test)
 set_tests_properties(ctp_socket_transport PROPERTIES
     LABELS "msan_skip"
+    RESOURCE_LOCK "lightbeam_port"
     ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}")
 install(TARGETS socket_transport_test
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -85,6 +88,7 @@ if(WRP_CORE_ENABLE_ZMQ)
     add_test(NAME ctp_zmq_transport_full COMMAND zmq_transport_full_test)
     set_tests_properties(ctp_zmq_transport_full PROPERTIES
         LABELS "msan_skip"
+        RESOURCE_LOCK "lightbeam_port"
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}")
     install(TARGETS zmq_transport_full_test
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -98,6 +102,7 @@ target_link_libraries(socket_transport_full_test hermes_shm_host hshm::lightbeam
 add_test(NAME ctp_socket_transport_full COMMAND socket_transport_full_test)
 set_tests_properties(ctp_socket_transport_full PROPERTIES
     LABELS "msan_skip"
+    RESOURCE_LOCK "lightbeam_port"
     ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}")
 install(TARGETS socket_transport_full_test
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
@@ -311,7 +311,7 @@ void TestSocketTransportWithEM() {
   std::cout << "[SocketTransport With EventManager] Test passed!\n";
 }
 
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
 #include <hermes_shm/lightbeam/zmq_transport.h>
 
 void TestZmqTransportWithEM() {
@@ -382,7 +382,7 @@ int main() {
 #endif
   TestSocketTransportWithEM();
 
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
   TestZmqTransportWithEM();
 #else
   std::cout << "\n[Skipped] ZmqTransport With EventManager (ZMQ not enabled)\n";

--- a/context-transport-primitives/test/unit/lightbeam/lightbeam_transport_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/lightbeam_transport_test.cc
@@ -42,7 +42,7 @@
 using namespace hshm::lbm;
 
 void TestZeroMQ() {
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
   std::cout << "\n==== Testing ZeroMQ ====\n";
 
   std::string addr = "127.0.0.1";

--- a/context-transport-primitives/test/unit/lightbeam/test_lightbeam_new.cc
+++ b/context-transport-primitives/test/unit/lightbeam/test_lightbeam_new.cc
@@ -58,7 +58,7 @@ class TestMeta : public LbmMeta<> {
 void TestBasicTransfer() {
   std::cout << "\n==== Testing Basic Transfer with New API ====\n";
 
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
   // Create server
   std::string addr = "127.0.0.1";
   std::string protocol = "tcp";
@@ -135,7 +135,7 @@ void TestBasicTransfer() {
 void TestMultipleBulks() {
   std::cout << "\n==== Testing Multiple Bulks Transfer ====\n";
 
-#ifdef HSHM_ENABLE_ZMQ
+#if HSHM_ENABLE_ZMQ
   std::string addr = "127.0.0.1";
   std::string protocol = "tcp";
   int port = 8196;


### PR DESCRIPTION
## Summary

- `IdentifyThisHost()` matches hostfile entries against `gethostname()` output
- When no hostfile is configured, `GetServerAddr()` returns `"127.0.0.1"` as the default server address
- Hostname `"127.0.0.1"` / short form `"127"` never matches FQDNs like `"polaris-login-01.hsn.cm.polaris.alcf.anl.gov"`, so the server never binds and all chimaera runtime tests fail with `"Could not start TCP server on any host from hostfile"`
- Fix: treat `127.0.0.1`, `localhost`, and `::1` as always matching the local host — loopback addresses are inherently local by definition

## Root cause

```cpp
// Before: loopback never matches FQDN
bool is_me = (host.ip_address == local_host) ||
             (entry_short == local_short);  // "127" != "polaris-login-01"

// After: loopback always matches
bool is_loopback = (host.ip_address == "127.0.0.1") ||
                   (host.ip_address == "localhost") ||
                   (host.ip_address == "::1");
bool is_me = is_loopback ||
             (host.ip_address == local_host) ||
             (entry_short == local_short);
```

## Test plan

- [x] `cr_flush_basic_tests` — was failing, now passes
- [x] 23 `cr_flush`, `cr_comutex`, `cr_corwlock`, `cr_wait`, `cr_streaming` tests — 100% pass
- [ ] Full CDash Experimental run

🤖 Generated with [Claude Code](https://claude.com/claude-code)