### PR TITLE
fix(msan): add msan_skip labels to tests with uninstrumented memory

### DIFF
--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -882,6 +882,7 @@ if(WRP_CORE_ENABLE_TESTS)
   set_tests_properties(cr_autogen_coverage_tests PROPERTIES
     ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
     TIMEOUT 300
+    LABELS "msan_skip"
   )
   endif()  # WRP_CORE_ENABLE_CAE
 

--- a/context-transfer-engine/test/integration/restart/CMakeLists.txt
+++ b/context-transfer-engine/test/integration/restart/CMakeLists.txt
@@ -27,7 +27,7 @@ add_test(NAME cte_restart_integration
 set_tests_properties(cte_restart_integration
     PROPERTIES
         TIMEOUT 300
-        LABELS "integration;restart;cte"
+        LABELS "integration;restart;cte;msan_skip"
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};BIN_DIR=${CMAKE_BINARY_DIR}/bin"
 )
 

--- a/context-transport-primitives/test/unit/allocator/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/allocator/CMakeLists.txt
@@ -92,12 +92,15 @@ add_test(NAME ctp_thread_allocator_multithread COMMAND
 add_test(NAME ctp_hshm_malloc COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_hshm_malloc_exec)
 
-# Skip under MSan: buddy allocator and hshm malloc use raw mmap/brk memory
-# regions that MSan cannot instrument (no instrumented allocator backing).
+# Skip under MSan: buddy allocator, thread/partitioned allocator, and hshm
+# malloc all use raw mmap/brk memory that MSan cannot instrument (no
+# instrumented allocator backing).
 set_tests_properties(
   ctp_buddy_allocator
   ctp_buddy_compaction
   ctp_hshm_malloc
+  ctp_thread_allocator
+  ctp_thread_allocator_multithread
   PROPERTIES LABELS "msan_skip"
 )
 

--- a/context-transport-primitives/test/unit/util/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/util/CMakeLists.txt
@@ -32,8 +32,11 @@ add_test(NAME ctp_numbers COMMAND
 
 # Skip under MSan: uses precompiled Catch2 (FatalConditionHandler/sigaction
 # false positives) and yaml-cpp (uninstrumented) for config parsing.
+# ctp_numbers uses the same Catch2 harness, producing identical sigaction
+# false positives even though the tested code is pure arithmetic.
 set_tests_properties(
   ctp_config_parse
+  ctp_numbers
   PROPERTIES LABELS "msan_skip"
 )
 


### PR DESCRIPTION
## Summary

Fixes 5 failing tests from CDash build [3517830](https://my.cdash.org/builds/3517830/dynamic_analysis) (all `use-of-uninitialized-value`, all false positives from uninstrumented memory):

| Test | Defects | Root cause |
|------|---------|------------|
| `ctp_numbers` | 215 | Catch2 `FatalConditionHandler`/`sigaction` — same as existing `ctp_config_parse` skip |
| `ctp_thread_allocator` | 36 | `PartitionedAllocator` on `PosixMmap` (raw mmap) — same as existing `ctp_buddy_allocator` skip |
| `ctp_thread_allocator_multithread` | 3 | Same as above |
| `cr_autogen_coverage_tests` | 119 | Calls `CHIMAERA_INIT` → ZMQ (uninstrumented) |
| `cte_restart_integration` | 203 | Multi-process test using full CTE/ZMQ runtime stack (uninstrumented) |

The `CI/run_sanitizers.sh` already excludes `msan_skip`-labelled tests (`EXCLUDE_LABEL="manual|msan_skip"`); this PR extends that label to the newly-added tests.

## Test plan
- [ ] Rerun MSan CI (`--msan`) and confirm the 5 tests are excluded and no new defects appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)