### PR TITLE
fix(tests): consolidate redundant entries to reduce shutdown-race flake

### DIFF
--- a/context-runtime/modules/MOD_NAME/test/CMakeLists.txt
+++ b/context-runtime/modules/MOD_NAME/test/CMakeLists.txt
@@ -166,288 +166,43 @@ set_target_properties(${STREAMING_TEST_TARGET} PROPERTIES
 
 # Enable CTest integration if testing is enabled
 if(WRP_CORE_ENABLE_TESTS)
-  # Flush Correctness Tests
-  add_test(
-    NAME cr_flush_basic_tests
-    COMMAND ${FLUSH_TEST_TARGET} "[flush][admin]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_flush_basic_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_flush_work_orchestrator_tests
-    COMMAND ${FLUSH_TEST_TARGET} "[flush][mod_name]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_flush_work_orchestrator_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_flush_stress_tests
-    COMMAND ${FLUSH_TEST_TARGET} "[flush]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_flush_stress_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  # Comprehensive flush test (runs all tests, no filter)
+  # Each binary is registered once and runs all its Catch2 sections in a single
+  # chimaera init/finalize cycle.  The previous setup added ~22 filtered ctest
+  # entries over the same 4 binaries, which forced ~22 init/finalize cycles
+  # serialized via RESOURCE_LOCK and exposed the chimaera shutdown ZMQ race.
   add_test(
     NAME cr_all_flush_tests
     COMMAND ${FLUSH_TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(cr_all_flush_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
 
-  # CoMutex Tests
-  add_test(
-    NAME cr_comutex_basic_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[comutex][basic]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_comutex_basic_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_comutex_concurrent_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[comutex][concurrent]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_comutex_concurrent_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_corwlock_basic_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[corwlock][basic]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_corwlock_basic_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_corwlock_readers_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[corwlock][readers]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_corwlock_readers_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_corwlock_writers_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[corwlock][writers]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_corwlock_writers_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_corwlock_interaction_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[corwlock][interaction]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_corwlock_interaction_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_tasknode_grouping_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[tasknode][grouping]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_tasknode_grouping_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_comutex_error_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[comutex][error]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_comutex_error_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_comutex_performance_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[comutex][performance]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_comutex_performance_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_comutex_integration_tests
-    COMMAND ${COMUTEX_TEST_TARGET} "[integration]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_comutex_integration_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  # Comprehensive CoMutex test (runs all tests, no filter)
   add_test(
     NAME cr_all_comutex_tests
     COMMAND ${COMUTEX_TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(cr_all_comutex_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
 
-  # Wait Functionality Tests
-  add_test(
-    NAME cr_wait_test_basic_tests
-    COMMAND ${WAIT_FUNCTIONALITY_TEST_TARGET} "[wait_test][basic]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_wait_test_basic_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_wait_test_recursive_tests
-    COMMAND ${WAIT_FUNCTIONALITY_TEST_TARGET} "[wait_test][recursive]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_wait_test_recursive_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_wait_test_async_tests
-    COMMAND ${WAIT_FUNCTIONALITY_TEST_TARGET} "[wait_test][async]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_wait_test_async_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_wait_test_edge_cases_tests
-    COMMAND ${WAIT_FUNCTIONALITY_TEST_TARGET} "[wait_test][edge_cases]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_wait_test_edge_cases_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  # Comprehensive Wait functionality test (runs all tests, no filter)
   add_test(
     NAME cr_all_wait_functionality_tests
     COMMAND ${WAIT_FUNCTIONALITY_TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(cr_all_wait_functionality_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
 
-  # Streaming Tests
-  add_test(
-    NAME cr_streaming_small_tests
-    COMMAND ${STREAMING_TEST_TARGET} "[streaming][small]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_streaming_small_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_streaming_large_tests
-    COMMAND ${STREAMING_TEST_TARGET} "[streaming][large]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_streaming_large_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_streaming_concurrent_tests
-    COMMAND ${STREAMING_TEST_TARGET} "[streaming][concurrent]"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_streaming_concurrent_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  # Comprehensive Streaming test (runs all tests, no filter)
   add_test(
     NAME cr_all_streaming_tests
     COMMAND ${STREAMING_TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(cr_all_streaming_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
 
-  # Set test properties
   set_tests_properties(
-    cr_flush_basic_tests
-    cr_flush_work_orchestrator_tests
-    cr_flush_stress_tests
     cr_all_flush_tests
-    cr_comutex_basic_tests
-    cr_comutex_concurrent_tests
-    cr_corwlock_basic_tests
-    cr_corwlock_readers_tests
-    cr_corwlock_writers_tests
-    cr_corwlock_interaction_tests
-    cr_tasknode_grouping_tests
-    cr_comutex_error_tests
-    cr_comutex_performance_tests
-    cr_comutex_integration_tests
     cr_all_comutex_tests
-    cr_wait_test_basic_tests
-    cr_wait_test_recursive_tests
-    cr_wait_test_async_tests
-    cr_wait_test_edge_cases_tests
     cr_all_wait_functionality_tests
-    cr_streaming_small_tests
-    cr_streaming_large_tests
-    cr_streaming_concurrent_tests
     cr_all_streaming_tests
     PROPERTIES
-      TIMEOUT 180
+      TIMEOUT 300
       ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHIMAERA_TEST_MODE=1"
-  )
-
-  # Mark all MOD_NAME tests as msan_skip (they use ZMQ which is uninstrumented)
-  set_tests_properties(
-    cr_flush_basic_tests
-    cr_flush_work_orchestrator_tests
-    cr_flush_stress_tests
-    cr_all_flush_tests
-    cr_comutex_basic_tests
-    cr_comutex_concurrent_tests
-    cr_corwlock_basic_tests
-    cr_corwlock_readers_tests
-    cr_corwlock_writers_tests
-    cr_corwlock_interaction_tests
-    cr_tasknode_grouping_tests
-    cr_comutex_error_tests
-    cr_comutex_performance_tests
-    cr_comutex_integration_tests
-    cr_all_comutex_tests
-    cr_wait_test_basic_tests
-    cr_wait_test_recursive_tests
-    cr_wait_test_async_tests
-    cr_wait_test_edge_cases_tests
-    cr_all_wait_functionality_tests
-    cr_streaming_small_tests
-    cr_streaming_large_tests
-    cr_streaming_concurrent_tests
-    cr_all_streaming_tests
-    PROPERTIES LABELS "msan_skip;asan_skip"
+      LABELS "msan_skip;asan_skip"
   )
 
   # GPU Client Process Tests

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -640,77 +640,17 @@ endif()
 # Enable CTest integration if testing is enabled
 if(WRP_CORE_ENABLE_TESTS)
   # Core Runtime Tests
+  # Single ctest entry runs the whole binary in one chimaera init/finalize cycle.
+  # Previously 8 redundant entries each invoked the full unfiltered binary, which
+  # serialized via RESOURCE_LOCK but multiplied chimaera shutdown ZMQ-race exposure.
   add_test(
-    NAME cr_runtime_initialization_tests
+    NAME cr_chimaera_unit_tests
     COMMAND ${TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(cr_runtime_initialization_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_client_initialization_tests
-    COMMAND ${TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_client_initialization_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_mod_name_task_tests
-    COMMAND ${TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_mod_name_task_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_error_handling_tests
-    COMMAND ${TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_error_handling_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_concurrent_tests
-    COMMAND ${TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_concurrent_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_memory_tests
-    COMMAND ${TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_memory_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_performance_tests
-    COMMAND ${TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_performance_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  # Comprehensive core test
-  add_test(
-    NAME cr_all_chimaera_tests
-    COMMAND ${TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_all_chimaera_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+  set_tests_properties(cr_chimaera_unit_tests PROPERTIES
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;CHIMAERA_TEST_MODE=1;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+    TIMEOUT 600
   )
 
   # IPC AllocateBuffer Tests
@@ -787,89 +727,16 @@ if(WRP_CORE_ENABLE_TESTS)
   )
 
   # Per-Process Shared Memory Tests
+  # Single ctest entry runs the binary in one chimaera init/finalize cycle.
+  # Previously 9 redundant entries each invoked the full unfiltered binary.
   add_test(
-    NAME cr_per_process_shm_increase_memory_tests
+    NAME cr_per_process_shm_tests
     COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(cr_per_process_shm_increase_memory_tests PROPERTIES
+  set_tests_properties(cr_per_process_shm_tests PROPERTIES
     ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_per_process_shm_medium_alloc_tests
-    COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_per_process_shm_medium_alloc_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_per_process_shm_large_alloc_tests
-    COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_per_process_shm_large_alloc_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-    TIMEOUT 300  # 5 minute timeout for large allocation test
-  )
-
-  add_test(
-    NAME cr_per_process_shm_multiple_large_tests
-    COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_per_process_shm_multiple_large_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-    TIMEOUT 300
-  )
-
-  add_test(
-    NAME cr_per_process_shm_patterns_tests
-    COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_per_process_shm_patterns_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-    TIMEOUT 300
-  )
-
-  add_test(
-    NAME cr_per_process_shm_free_tests
-    COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_per_process_shm_free_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_per_process_shm_tofullptr_tests
-    COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_per_process_shm_tofullptr_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
-  add_test(
-    NAME cr_per_process_shm_stress_tests
-    COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_per_process_shm_stress_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-    TIMEOUT 600  # 10 minute timeout for stress test
-  )
-
-  add_test(
-    NAME cr_per_process_shm_info_tests
-    COMMAND ${PER_PROCESS_SHM_TEST_TARGET}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-  )
-  set_tests_properties(cr_per_process_shm_info_tests PROPERTIES
-    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+    TIMEOUT 600
   )
 
   # Autogen Coverage Tests (requires CAE)
@@ -1099,21 +966,6 @@ if(WRP_CORE_ENABLE_TESTS)
     TIMEOUT 300
   )
 
-  # Set test properties for timeout and environment
-  set_tests_properties(
-    cr_runtime_initialization_tests
-    cr_client_initialization_tests
-    cr_mod_name_task_tests
-    cr_error_handling_tests
-    cr_concurrent_tests
-    cr_memory_tests
-    cr_performance_tests
-    cr_all_chimaera_tests
-    PROPERTIES
-      TIMEOUT 180
-      ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;CHIMAERA_TEST_MODE=1;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
-  )
-
   # Unordered Map LL Tests (standalone test with custom main)
   add_test(
     NAME cr_unordered_map_ll_tests
@@ -1127,14 +979,7 @@ if(WRP_CORE_ENABLE_TESTS)
 
   # Mark all CR runtime tests as msan_skip (they use ZMQ which is uninstrumented)
   set_tests_properties(
-    cr_runtime_initialization_tests
-    cr_client_initialization_tests
-    cr_mod_name_task_tests
-    cr_error_handling_tests
-    cr_concurrent_tests
-    cr_memory_tests
-    cr_performance_tests
-    cr_all_chimaera_tests
+    cr_chimaera_unit_tests
     cr_ipc_allocate_buffer_basic_tests
     cr_ipc_allocate_buffer_types_tests
     cr_ipc_allocate_buffer_sizes_tests
@@ -1143,15 +988,7 @@ if(WRP_CORE_ENABLE_TESTS)
     cr_ipc_allocate_buffer_error_tests
     cr_ipc_allocate_buffer_alignment_tests
     cr_ipc_allocate_buffer_documentation_tests
-    cr_per_process_shm_increase_memory_tests
-    cr_per_process_shm_medium_alloc_tests
-    cr_per_process_shm_large_alloc_tests
-    cr_per_process_shm_multiple_large_tests
-    cr_per_process_shm_patterns_tests
-    cr_per_process_shm_free_tests
-    cr_per_process_shm_tofullptr_tests
-    cr_per_process_shm_stress_tests
-    cr_per_process_shm_info_tests
+    cr_per_process_shm_tests
     cr_streaming_small_output_tests
     cr_streaming_large_output_tests
     cr_streaming_bitfield_tests

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -510,145 +510,15 @@ add_test(NAME cte_tag_large
 add_test(NAME cte_tag_edge
     COMMAND test_tag_operations "Tag - Edge")
 
-# Add test_core_client_config tests - comprehensive Client and Config API coverage tests
-add_test(NAME cte_client_config_default
-    COMMAND test_core_client_config "Config - Default")
+# Single-process runs of test_core_client_config / test_core_runtime_coverage.
+# Previously each Catch2 SECTION was registered as a standalone ctest entry
+# (27 + 19), which serialized via RESOURCE_LOCK but multiplied chimaera
+# init/finalize cycles and exposed shutdown ZMQ races.
+add_test(NAME cte_client_config_all
+    COMMAND test_core_client_config)
 
-add_test(NAME cte_client_config_file
-    COMMAND test_core_client_config "Config - Load from Valid YAML File")
-
-add_test(NAME cte_client_config_invalid_file
-    COMMAND test_core_client_config "Config - Load from Invalid File Path")
-
-add_test(NAME cte_client_config_empty_path
-    COMMAND test_core_client_config "Config - Load from Empty Path")
-
-add_test(NAME cte_client_config_string
-    COMMAND test_core_client_config "Config - Load from Valid YAML String")
-
-add_test(NAME cte_client_config_empty_string
-    COMMAND test_core_client_config "Config - Load from Empty String")
-
-add_test(NAME cte_client_config_invalid_yaml
-    COMMAND test_core_client_config "Config - Load from Invalid YAML")
-
-add_test(NAME cte_client_config_environment
-    COMMAND test_core_client_config "Config - Load from Environment")
-
-add_test(NAME cte_client_config_save
-    COMMAND test_core_client_config "Config - Save to File")
-
-add_test(NAME cte_client_list_targets
-    COMMAND test_core_client_config "Client - AsyncListTargets")
-
-add_test(NAME cte_client_stat_targets
-    COMMAND test_core_client_config "Client - AsyncStatTargets")
-
-add_test(NAME cte_client_get_target_info
-    COMMAND test_core_client_config "Client - AsyncGetTargetInfo")
-
-add_test(NAME cte_client_unregister_target
-    COMMAND test_core_client_config "Client - AsyncUnregisterTarget")
-
-add_test(NAME cte_client_get_or_create_tag
-    COMMAND test_core_client_config "Client - AsyncGetOrCreateTag Direct")
-
-add_test(NAME cte_client_del_tag_by_id
-    COMMAND test_core_client_config "Client - AsyncDelTag by ID")
-
-add_test(NAME cte_client_del_tag_by_name
-    COMMAND test_core_client_config "Client - AsyncDelTag by Name")
-
-add_test(NAME cte_client_get_tag_size
-    COMMAND test_core_client_config "Client - AsyncGetTagSize")
-
-add_test(NAME cte_client_putblob
-    COMMAND test_core_client_config "Client - AsyncPutBlob Direct")
-
-add_test(NAME cte_client_getblob
-    COMMAND test_core_client_config "Client - AsyncGetBlob Direct")
-
-add_test(NAME cte_client_delblob
-    COMMAND test_core_client_config "Client - AsyncDelBlob")
-
-add_test(NAME cte_client_reorganize_blob
-    COMMAND test_core_client_config "Client - AsyncReorganizeBlob Direct")
-
-add_test(NAME cte_client_get_blob_score
-    COMMAND test_core_client_config "Client - AsyncGetBlobScore Direct")
-
-add_test(NAME cte_client_get_blob_size
-    COMMAND test_core_client_config "Client - AsyncGetBlobSize Direct")
-
-add_test(NAME cte_client_get_contained_blobs
-    COMMAND test_core_client_config "Client - AsyncGetContainedBlobs Direct")
-
-add_test(NAME cte_client_tag_query
-    COMMAND test_core_client_config "Client - AsyncTagQuery")
-
-add_test(NAME cte_client_blob_query
-    COMMAND test_core_client_config "Client - AsyncBlobQuery")
-
-add_test(NAME cte_client_poll_telemetry
-    COMMAND test_core_client_config "Client - AsyncPollTelemetryLog")
-
-# Add test_core_runtime_coverage tests - comprehensive runtime method coverage
-add_test(NAME cte_runtime_get_target_info_success
-    COMMAND test_core_runtime_coverage "Runtime - GetTargetInfo Success Path")
-
-add_test(NAME cte_runtime_get_target_info_error
-    COMMAND test_core_runtime_coverage "Runtime - GetTargetInfo NonExistent Target")
-
-add_test(NAME cte_runtime_unregister_success
-    COMMAND test_core_runtime_coverage "Runtime - UnregisterTarget Success")
-
-add_test(NAME cte_runtime_unregister_error
-    COMMAND test_core_runtime_coverage "Runtime - UnregisterTarget NonExistent")
-
-add_test(NAME cte_runtime_delblob_success
-    COMMAND test_core_runtime_coverage "Runtime - DelBlob Success Path")
-
-add_test(NAME cte_runtime_delblob_nonexistent
-    COMMAND test_core_runtime_coverage "Runtime - DelBlob NonExistent Blob")
-
-add_test(NAME cte_runtime_delblob_empty
-    COMMAND test_core_runtime_coverage "Runtime - DelBlob Empty Name")
-
-add_test(NAME cte_runtime_get_blob_score_success
-    COMMAND test_core_runtime_coverage "Runtime - GetBlobScore Success")
-
-add_test(NAME cte_runtime_get_blob_score_nonexistent
-    COMMAND test_core_runtime_coverage "Runtime - GetBlobScore NonExistent Blob")
-
-add_test(NAME cte_runtime_get_blob_score_empty
-    COMMAND test_core_runtime_coverage "Runtime - GetBlobScore Empty Name")
-
-add_test(NAME cte_runtime_get_blob_size_success
-    COMMAND test_core_runtime_coverage "Runtime - GetBlobSize Success")
-
-add_test(NAME cte_runtime_get_blob_size_error
-    COMMAND test_core_runtime_coverage "Runtime - GetBlobSize NonExistent")
-
-add_test(NAME cte_runtime_get_tag_size
-    COMMAND test_core_runtime_coverage "Runtime - GetTagSize Success")
-
-add_test(NAME cte_runtime_deltag_by_name
-    COMMAND test_core_runtime_coverage "Runtime - DelTag by Name Success")
-
-add_test(NAME cte_runtime_deltag_by_id
-    COMMAND test_core_runtime_coverage "Runtime - DelTag by ID Success")
-
-add_test(NAME cte_runtime_get_contained_blobs_success
-    COMMAND test_core_runtime_coverage "Runtime - GetContainedBlobs Success")
-
-add_test(NAME cte_runtime_get_contained_blobs_empty
-    COMMAND test_core_runtime_coverage "Runtime - GetContainedBlobs Empty Tag")
-
-add_test(NAME cte_runtime_list_targets
-    COMMAND test_core_runtime_coverage "Runtime - ListTargets Success")
-
-add_test(NAME cte_runtime_stat_targets
-    COMMAND test_core_runtime_coverage "Runtime - StatTargets Success")
+add_test(NAME cte_runtime_coverage_all
+    COMMAND test_core_runtime_coverage)
 
 # Set test properties for proper execution environment
 set_tests_properties(
@@ -717,64 +587,16 @@ set_tests_properties(
         ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
 )
 
-set_tests_properties(
-    cte_client_config_default
-    cte_client_config_file
-    cte_client_config_invalid_file
-    cte_client_config_empty_path
-    cte_client_config_string
-    cte_client_config_empty_string
-    cte_client_config_invalid_yaml
-    cte_client_config_environment
-    cte_client_config_save
-    cte_client_list_targets
-    cte_client_stat_targets
-    cte_client_get_target_info
-    cte_client_unregister_target
-    cte_client_get_or_create_tag
-    cte_client_del_tag_by_id
-    cte_client_del_tag_by_name
-    cte_client_get_tag_size
-    cte_client_putblob
-    cte_client_getblob
-    cte_client_delblob
-    cte_client_reorganize_blob
-    cte_client_get_blob_score
-    cte_client_get_blob_size
-    cte_client_get_contained_blobs
-    cte_client_tag_query
-    cte_client_blob_query
-    cte_client_poll_telemetry
-    PROPERTIES
-        TIMEOUT 300  # 5 minute timeout for each test
-        LABELS "unit;core;cte;client;config"
-        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+set_tests_properties(cte_client_config_all PROPERTIES
+    TIMEOUT 600
+    LABELS "unit;core;cte;client;config"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
 )
 
-set_tests_properties(
-    cte_runtime_get_target_info_success
-    cte_runtime_get_target_info_error
-    cte_runtime_unregister_success
-    cte_runtime_unregister_error
-    cte_runtime_delblob_success
-    cte_runtime_delblob_nonexistent
-    cte_runtime_delblob_empty
-    cte_runtime_get_blob_score_success
-    cte_runtime_get_blob_score_nonexistent
-    cte_runtime_get_blob_score_empty
-    cte_runtime_get_blob_size_success
-    cte_runtime_get_blob_size_error
-    cte_runtime_get_tag_size
-    cte_runtime_deltag_by_name
-    cte_runtime_deltag_by_id
-    cte_runtime_get_contained_blobs_success
-    cte_runtime_get_contained_blobs_empty
-    cte_runtime_list_targets
-    cte_runtime_stat_targets
-    PROPERTIES
-        TIMEOUT 300  # 5 minute timeout for each test
-        LABELS "unit;core;cte;runtime;coverage"
-        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+set_tests_properties(cte_runtime_coverage_all PROPERTIES
+    TIMEOUT 600
+    LABELS "unit;core;cte;runtime;coverage"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
 )
 
 # Add tiered storage stress tests
@@ -886,52 +708,8 @@ set_tests_properties(
     cte_tag_async
     cte_tag_large
     cte_tag_edge
-    cte_client_config_default
-    cte_client_config_file
-    cte_client_config_invalid_file
-    cte_client_config_empty_path
-    cte_client_config_string
-    cte_client_config_empty_string
-    cte_client_config_invalid_yaml
-    cte_client_config_environment
-    cte_client_config_save
-    cte_client_list_targets
-    cte_client_stat_targets
-    cte_client_get_target_info
-    cte_client_unregister_target
-    cte_client_get_or_create_tag
-    cte_client_del_tag_by_id
-    cte_client_del_tag_by_name
-    cte_client_get_tag_size
-    cte_client_putblob
-    cte_client_getblob
-    cte_client_delblob
-    cte_client_reorganize_blob
-    cte_client_get_blob_score
-    cte_client_get_blob_size
-    cte_client_get_contained_blobs
-    cte_client_tag_query
-    cte_client_blob_query
-    cte_client_poll_telemetry
-    cte_runtime_get_target_info_success
-    cte_runtime_get_target_info_error
-    cte_runtime_unregister_success
-    cte_runtime_unregister_error
-    cte_runtime_delblob_success
-    cte_runtime_delblob_nonexistent
-    cte_runtime_delblob_empty
-    cte_runtime_get_blob_score_success
-    cte_runtime_get_blob_score_nonexistent
-    cte_runtime_get_blob_score_empty
-    cte_runtime_get_blob_size_success
-    cte_runtime_get_blob_size_error
-    cte_runtime_get_tag_size
-    cte_runtime_deltag_by_name
-    cte_runtime_deltag_by_id
-    cte_runtime_get_contained_blobs_success
-    cte_runtime_get_contained_blobs_empty
-    cte_runtime_list_targets
-    cte_runtime_stat_targets
+    cte_client_config_all
+    cte_runtime_coverage_all
     cte_tiered_storage_all
     cte_reorganize_all
     PROPERTIES LABELS "msan_skip"
@@ -958,6 +736,8 @@ set_tests_properties(
     cte_tag_large
     cte_tag_edge
     cte_functional_all
+    cte_client_config_all
+    cte_runtime_coverage_all
     cte_tiered_storage_all
     cte_reorganize_all
     PROPERTIES RESOURCE_LOCK "chimaera_runtime"

--- a/context-transfer-engine/test/unit/test_core_client_config.cc
+++ b/context-transfer-engine/test/unit/test_core_client_config.cc
@@ -95,6 +95,9 @@ class CoreClientConfigFixture {
       bool success = chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
       REQUIRE(success);
 
+      // Drain ZMQ background threads in main() before static dtors fire.
+      SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
       success = wrp_cte::core::WRP_CTE_CLIENT_INIT();

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -161,6 +161,10 @@ class CTECoreFunctionalTestFixture {
       REQUIRE(success);
     }
 
+    // Drain ZMQ background threads in main() before static dtors fire — the
+    // shutdown race here used to produce flaky timeouts under repeated runs.
+    SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+
     // Generate unique pool ID for this test session
     int rand_id = 1000 + rand() % 9000;  // Random ID 1000-9999
     core_pool_id_ = chi::PoolId(static_cast<chi::u32>(rand_id), 0);

--- a/context-transfer-engine/test/unit/test_core_runtime_coverage.cc
+++ b/context-transfer-engine/test/unit/test_core_runtime_coverage.cc
@@ -69,6 +69,8 @@ public:
       if (!success) {
         throw std::runtime_error("CHIMAERA_INIT failed");
       }
+      // Drain ZMQ background threads in main() before static dtors fire.
+      SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
       // Step 2: Initialize CTE client subsystem (CRITICAL!)


### PR DESCRIPTION
This PR makes all tests [pass](https://my.cdash.org/builds/3525300/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22PASSED%22%7D%7D%5D%7D) on Ares.

---

Several test binaries that initialize the full Chimaera runtime were each registered as many ctest entries (one per Catch2 SECTION or filtered tag). Even though those entries serialized via RESOURCE_LOCK "chimaera_runtime", running the same binary N times multiplied the chimaera init/finalize cycles, so the ZMQ shutdown race surfaced as non-deterministic timeouts on CDash.

Consolidate to a single ctest entry per binary so each binary goes through exactly one init/finalize cycle:

  - cr_chimaera_unit_tests           (was 8 entries on chimaera_unit_tests)
  - cr_per_process_shm_tests         (was 9 entries)
  - cte_client_config_all            (was 27 entries on test_core_client_config)
  - cte_runtime_coverage_all         (was 19 entries on test_core_runtime_coverage)
  - cr_all_flush/comutex/wait/streaming  (was ~22 filtered entries)

Also register chi::CHIMAERA_FINALIZE as the simple_test framework's g_test_finalize hook in the CTE fixtures, so ZMQ background threads get drained inside main() before static destructors fire.