### PR TITLE
Fix Polaris GPU build and test failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -860,6 +860,9 @@ if(WRP_CORE_ENABLE_TESTS)
              rm -rf /tmp/chimaera_memfd 2>/dev/null; \
              rm -rf /tmp/chimaera_${USER} 2>/dev/null; \
              rm -f /dev/shm/sm_segment.* 2>/dev/null; \
+             rm -f /dev/shm/test_buddy_bench_* 2>/dev/null; \
+             rm -f \"${CMAKE_BINARY_DIR}\"/cte_*.dat \"${CMAKE_BINARY_DIR}\"/cte_*.yaml \"${CMAKE_BINARY_DIR}\"/*stress*.bin* \"${CMAKE_BINARY_DIR}\"/*reorganize*.bin* \"${CMAKE_BINARY_DIR}\"/*reorganize*.yaml \"${CMAKE_BINARY_DIR}\"/temp_unregister_test.dat 2>/dev/null; \
+             rm -rf \"${CMAKE_BINARY_DIR}\"/cee_test_data 2>/dev/null; \
              exit 0"
     )
     set_tests_properties(chimaera_pre_test_cleanup PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,28 +846,42 @@ if(WRP_CORE_ENABLE_TESTS)
     include(CTest)
 
     # -----------------------------------------------------------------------
-    # Pre-test cleanup fixture
+    # Test cleanup fixture (pre + post)
     # Kills any orphaned Chimaera server processes and removes leftover shared
-    # state (IPC socket files, shared memory, memfd) that a previous crashed
-    # test run may have left behind.  Runs once before any other CTest test.
+    # state (IPC socket files, shared memory, memfd) plus build-dir test
+    # artifacts.  The pre-test variant runs once before any other CTest test.
+    # The post-test variant is registered as FIXTURES_CLEANUP and is invoked
+    # after every test that requires the fixture, even if those tests fail
+    # or crash, ensuring temp files do not persist between runs.
     # -----------------------------------------------------------------------
+    set(_chimaera_cleanup_cmd
+        "fuser -k 5555/tcp 5558/tcp 9413/tcp 9414/tcp 9416/tcp 2>/dev/null; \
+         rm -f /tmp/chimaera_*.ipc 2>/dev/null; \
+         rm -f /tmp/chimaera_server_timing.log 2>/dev/null; \
+         rm -rf /tmp/chimaera_memfd 2>/dev/null; \
+         rm -rf /tmp/chimaera_${USER} 2>/dev/null; \
+         rm -f /dev/shm/sm_segment.* 2>/dev/null; \
+         rm -f /dev/shm/test_buddy_bench_* 2>/dev/null; \
+         rm -f \"${CMAKE_BINARY_DIR}\"/cte_*.dat* \"${CMAKE_BINARY_DIR}\"/cte_*.yaml \"${CMAKE_BINARY_DIR}\"/*stress*.bin* \"${CMAKE_BINARY_DIR}\"/*reorganize*.bin* \"${CMAKE_BINARY_DIR}\"/*reorganize*.yaml \"${CMAKE_BINARY_DIR}\"/temp_unregister_test.dat 2>/dev/null; \
+         rm -rf \"${CMAKE_BINARY_DIR}\"/cee_test_data 2>/dev/null; \
+         exit 0")
+
     add_test(
         NAME chimaera_pre_test_cleanup
-        COMMAND bash -c
-            "fuser -k 5555/tcp 5558/tcp 9413/tcp 9414/tcp 9416/tcp 2>/dev/null; \
-             rm -f /tmp/chimaera_*.ipc 2>/dev/null; \
-             rm -f /tmp/chimaera_server_timing.log 2>/dev/null; \
-             rm -rf /tmp/chimaera_memfd 2>/dev/null; \
-             rm -rf /tmp/chimaera_${USER} 2>/dev/null; \
-             rm -f /dev/shm/sm_segment.* 2>/dev/null; \
-             rm -f /dev/shm/test_buddy_bench_* 2>/dev/null; \
-             rm -f \"${CMAKE_BINARY_DIR}\"/cte_*.dat \"${CMAKE_BINARY_DIR}\"/cte_*.yaml \"${CMAKE_BINARY_DIR}\"/*stress*.bin* \"${CMAKE_BINARY_DIR}\"/*reorganize*.bin* \"${CMAKE_BINARY_DIR}\"/*reorganize*.yaml \"${CMAKE_BINARY_DIR}\"/temp_unregister_test.dat 2>/dev/null; \
-             rm -rf \"${CMAKE_BINARY_DIR}\"/cee_test_data 2>/dev/null; \
-             exit 0"
+        COMMAND bash -c "${_chimaera_cleanup_cmd}"
     )
     set_tests_properties(chimaera_pre_test_cleanup PROPERTIES
         TIMEOUT 30
-        FIXTURES_SETUP chimaera_pre_test_cleanup_fixture
+        FIXTURES_SETUP chimaera_test_cleanup_fixture
+    )
+
+    add_test(
+        NAME chimaera_post_test_cleanup
+        COMMAND bash -c "${_chimaera_cleanup_cmd}"
+    )
+    set_tests_properties(chimaera_post_test_cleanup PROPERTIES
+        TIMEOUT 30
+        FIXTURES_CLEANUP chimaera_test_cleanup_fixture
     )
 endif()
 
@@ -1030,6 +1044,41 @@ if(WRP_CORE_ENABLE_TESTS)
             _chimaera_lock_tests_recursive(
                 "${CMAKE_CURRENT_SOURCE_DIR}/${_component_dir}"
                 "${_lsan_opts}")
+        endif()
+    endforeach()
+
+    # -----------------------------------------------------------------------
+    # Apply the cleanup fixture to every component test so that the
+    # chimaera_post_test_cleanup hook runs after the whole suite, even when
+    # individual tests fail. Excludes the cleanup fixtures themselves.
+    # -----------------------------------------------------------------------
+    function(_chimaera_require_cleanup_fixture_recursive dir)
+        get_directory_property(_tests DIRECTORY "${dir}" TESTS)
+        foreach(_t ${_tests})
+            if(NOT _t STREQUAL "chimaera_pre_test_cleanup" AND
+               NOT _t STREQUAL "chimaera_post_test_cleanup")
+                set_property(TEST ${_t} DIRECTORY "${dir}" APPEND PROPERTY
+                    FIXTURES_REQUIRED chimaera_test_cleanup_fixture)
+            endif()
+        endforeach()
+        get_directory_property(_subdirs DIRECTORY "${dir}" SUBDIRECTORIES)
+        foreach(_sub ${_subdirs})
+            _chimaera_require_cleanup_fixture_recursive("${_sub}")
+        endforeach()
+    endfunction()
+
+    foreach(_component_dir_pair
+            "context-transport-primitives:WRP_CORE_ENABLE_TESTS"
+            "context-runtime:WRP_CORE_ENABLE_RUNTIME"
+            "context-transfer-engine:WRP_CORE_ENABLE_CTE"
+            "context-assimilation-engine:WRP_CORE_ENABLE_CAE"
+            "context-exploration-engine:WRP_CORE_ENABLE_CEE")
+        string(REPLACE ":" ";" _pair "${_component_dir_pair}")
+        list(GET _pair 0 _component_dir)
+        list(GET _pair 1 _component_flag)
+        if(${_component_flag} AND IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${_component_dir}")
+            _chimaera_require_cleanup_fixture_recursive(
+                "${CMAKE_CURRENT_SOURCE_DIR}/${_component_dir}")
         endif()
     endforeach()
 endif()

--- a/context-exploration-engine/api/test/CMakeLists.txt
+++ b/context-exploration-engine/api/test/CMakeLists.txt
@@ -78,7 +78,8 @@ set_tests_properties(
   PROPERTIES
     TIMEOUT 180
     LABELS "cee;comprehensive;coverage;msan_skip"
-    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHI_TEST_DATA_DIR=${CMAKE_BINARY_DIR}"
+    RESOURCE_LOCK "chimaera_runtime"
 )
 
 #------------------------------------------------------------------------------

--- a/context-exploration-engine/api/test/test_context_comprehensive.cc
+++ b/context-exploration-engine/api/test/test_context_comprehensive.cc
@@ -58,6 +58,11 @@
 
 using namespace iowarp;
 
+static std::string chi_test_data_dir() {
+  const char *d = std::getenv("CHI_TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
 /**
  * Test fixture for CEE comprehensive tests
  */
@@ -135,7 +140,7 @@ public:
       g_initialized = true;
     }
 
-    test_data_dir_ = std::string(std::getenv("HOME")) + "/cee_test_data";
+    test_data_dir_ = chi_test_data_dir() + "/cee_test_data";
     test_binary_file_ = test_data_dir_ + "/test_cee_data.bin";
   }
 

--- a/context-runtime/include/chimaera/gpu/gpu_ipc_manager.h
+++ b/context-runtime/include/chimaera/gpu/gpu_ipc_manager.h
@@ -128,6 +128,15 @@ class IpcManager {
     u32 num_warps = num_threads / 32;
     if (num_warps < 1) num_warps = 1;
     if (gpu_info_.backend.data_ != nullptr) {
+      // Partition the backend so each block initializes its own sub-region.
+      // Without this, all blocks race to placement-new the same allocator.
+#if HSHM_IS_GPU
+      if (num_blocks > 1 && gpu_info_.backend.data_capacity_ > 0) {
+        size_t per_block = gpu_info_.backend.data_capacity_ / num_blocks;
+        gpu_info_.backend.data_ += blockIdx.x * per_block;
+        gpu_info_.backend.data_capacity_ = per_block;
+      }
+#endif
       auto *alloc = reinterpret_cast<hipc::RoundRobinAllocator *>(
           gpu_info_.backend.data_);
       if (alloc->heap_ready_.load() == 1) {

--- a/context-runtime/src/gpu/work_orchestrator_gpu.cc
+++ b/context-runtime/src/gpu/work_orchestrator_gpu.cc
@@ -49,6 +49,9 @@
 
 #if HSHM_ENABLE_CUDA || HSHM_ENABLE_ROCM
 
+#include <time.h>
+#include <unistd.h>
+
 #include "chimaera/ipc_manager.h"
 #include "chimaera/gpu/work_orchestrator.h"
 #include "chimaera/gpu/container.h"
@@ -74,11 +77,6 @@ __global__ void chimaera_gpu_orchestrator(gpu::PoolManager *pool_mgr,
   // num_blocks is used to partition the backend memory among blocks.
   CHIMAERA_GPU_ORCHESTRATOR_INIT(gpu_info, num_blocks);
 
-  // Thread 0 signals that the orchestrator is running
-  if (threadIdx.x == 0) {
-    control->running_flag = 1;
-    __threadfence_system();  // Flush to CPU-visible memory
-  }
   __syncthreads();
 
   // Only thread 0 polls
@@ -100,6 +98,11 @@ __global__ void chimaera_gpu_orchestrator(gpu::PoolManager *pool_mgr,
                 control->cpu2gpu_queue_base,
                 control);
     worker.gpu_info_ptr_ = d_gpu_info;
+
+    // Signal readiness after worker is fully initialized so the CPU
+    // spin-wait in Launch()/Resume() only unblocks when polling is imminent.
+    control->running_flag = 1;
+    __threadfence_system();
 
     // Poll until exit signal — both GPU→GPU and CPU→GPU from same thread
     int loop_count = 0;
@@ -194,7 +197,28 @@ bool gpu::WorkOrchestrator::Launch(const IpcManagerGpuInfo &gpu_info, u32 blocks
 
   launched_num_warps_ = 1;
   is_launched_ = true;
-  HLOG(kInfo, "GPU work orchestrator launched successfully");
+
+  // Wait for the GPU kernel to signal it is actually running.
+  // The first launch can take tens of seconds (CUDA context init, JIT warm-up).
+  // Without this barrier, tasks submitted before running_flag==1 are queued
+  // but never drained because the kernel has not started polling yet.
+  HLOG(kInfo, "Waiting for GPU orchestrator kernel to start...");
+  struct timespec t_start, t_now;
+  clock_gettime(CLOCK_MONOTONIC, &t_start);
+  while (!control_->running_flag) {
+    usleep(50000);
+    clock_gettime(CLOCK_MONOTONIC, &t_now);
+    double elapsed = (t_now.tv_sec - t_start.tv_sec) +
+                     (t_now.tv_nsec - t_start.tv_nsec) * 1e-9;
+    if (elapsed > 60.0) {
+      HLOG(kError, "GPU orchestrator failed to start within 60s");
+      return false;
+    }
+  }
+  clock_gettime(CLOCK_MONOTONIC, &t_now);
+  HLOG(kInfo, "GPU orchestrator is running (started in %.1fs)",
+       (float)((t_now.tv_sec - t_start.tv_sec) +
+               (t_now.tv_nsec - t_start.tv_nsec) * 1e-9));
   return true;
 }
 

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -469,6 +469,11 @@ if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
   add_test(NAME test_buddy_benchmark_gpu COMMAND test_buddy_benchmark_gpu)
+  set_tests_properties(test_buddy_benchmark_gpu PROPERTIES
+    TIMEOUT 120
+    LABELS "gpu;msan_skip"
+    RESOURCE_LOCK "chimaera_runtime"
+  )
 
   # GPU Runtime test executable (pure host code, compiled by g++)
   set(GPU_RUNTIME_TEST_TARGET test_chimaera_gpu_runtime)

--- a/context-transfer-engine/benchmark/CMakeLists.txt
+++ b/context-transfer-engine/benchmark/CMakeLists.txt
@@ -235,6 +235,16 @@ if(WRP_CORE_ENABLE_CUDA)
     PROPERTIES
       ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
   )
+  # Tests that start the Chimaera server must serialize with other server tests
+  set_tests_properties(
+    cte_gpu_bench_client_overhead
+    cte_gpu_bench_client_overhead_multiblock
+    cte_gpu_bench_client_overhead_cpu
+    cte_gpu_bench_stress
+    cte_gpu_synthetic_cte
+    cte_gpu_synthetic_cte_validate
+    PROPERTIES RESOURCE_LOCK "chimaera_runtime"
+  )
 else()
   message(STATUS "Skipping wrp_cte_gpu_bench - CUDA not enabled")
 endif()

--- a/context-transfer-engine/test/unit/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/CMakeLists.txt
@@ -549,7 +549,7 @@ set_tests_properties(
     PROPERTIES
         TIMEOUT 300  # 5 minute timeout
         LABELS "functional;core;cte"
-        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHI_TEST_DATA_DIR=${CMAKE_BINARY_DIR}"
 )
 
 set_tests_properties(
@@ -568,7 +568,7 @@ set_tests_properties(
     PROPERTIES
         TIMEOUT 300  # 5 minute timeout for each test
         LABELS "query;core;cte"
-        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHI_TEST_DATA_DIR=${CMAKE_BINARY_DIR}"
 )
 
 set_tests_properties(
@@ -584,7 +584,7 @@ set_tests_properties(
     PROPERTIES
         TIMEOUT 300  # 5 minute timeout for each test
         LABELS "unit;tag;cte"
-        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHI_TEST_DATA_DIR=${CMAKE_BINARY_DIR}"
 )
 
 set_tests_properties(cte_client_config_all PROPERTIES
@@ -596,7 +596,7 @@ set_tests_properties(cte_client_config_all PROPERTIES
 set_tests_properties(cte_runtime_coverage_all PROPERTIES
     TIMEOUT 600
     LABELS "unit;core;cte;runtime;coverage"
-    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHI_TEST_DATA_DIR=${CMAKE_BINARY_DIR}"
 )
 
 # Add tiered storage stress tests
@@ -611,7 +611,7 @@ set_tests_properties(
     PROPERTIES
         TIMEOUT 300  # 5 minute timeout
         LABELS "stress;tiered;cte"
-        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHI_TEST_DATA_DIR=${CMAKE_BINARY_DIR}"
 )
 
 # Add reorganize blob tests
@@ -626,7 +626,7 @@ set_tests_properties(
     PROPERTIES
         TIMEOUT 300  # 5 minute timeout
         LABELS "unit;reorganize;cte"
-        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHI_TEST_DATA_DIR=${CMAKE_BINARY_DIR}"
 )
 
 if(WRP_CORE_ENABLE_CUDA OR WRP_CORE_ENABLE_ROCM)
@@ -726,6 +726,18 @@ endif()
 # Tests that start a full Chimaera runtime share /tmp/chimaera_iowarp SHM
 # segments and TCP/IPC ports, so they must NOT run in parallel.
 set_tests_properties(
+    cte_query_tag_exact
+    cte_query_tag_wildcard
+    cte_query_tag_alternation
+    cte_query_tag_matchall
+    cte_query_tag_nomatch
+    cte_query_blob_exact
+    cte_query_blob_wildcard
+    cte_query_blob_multitag
+    cte_query_blob_matchall
+    cte_query_blob_no_blob
+    cte_query_blob_no_tag
+    cte_query_local_poolquery
     cte_tag_construction
     cte_tag_putblob
     cte_tag_getblob

--- a/context-transfer-engine/test/unit/test_core_functionality.cc
+++ b/context-transfer-engine/test/unit/test_core_functionality.cc
@@ -65,6 +65,11 @@
 
 #include "simple_test.h"
 
+static std::string chi_test_data_dir() {
+  const char *d = std::getenv("CHI_TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
 using namespace std::chrono_literals;
 
 // Chimaera core includes
@@ -141,7 +146,7 @@ class CTECoreFunctionalTestFixture {
     INFO("=== Initializing CTE Core Functional Test Environment ===");
 
     // Initialize test storage path in /tmp (always writable)
-    test_storage_path_ = "/tmp/cte_functional_test.dat";
+    test_storage_path_ = chi_test_data_dir() + "/cte_functional_test.dat";
 
     // Clean up any existing test file
     if (fs::exists(test_storage_path_)) {

--- a/context-transfer-engine/test/unit/test_core_runtime_coverage.cc
+++ b/context-transfer-engine/test/unit/test_core_runtime_coverage.cc
@@ -49,6 +49,11 @@
 
 using namespace wrp_cte::core;
 
+static std::string chi_test_data_dir() {
+  const char *d = std::getenv("CHI_TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
 /**
  * Test fixture for runtime coverage tests
  * Ensures proper CTE initialization following the established pattern
@@ -100,7 +105,7 @@ public:
       g_initialized = true;
     }
 
-    test_storage_path_ = std::string(std::getenv("HOME")) + "/cte_runtime_test.dat";
+    test_storage_path_ = chi_test_data_dir() + "/cte_runtime_test.dat";
   }
 
   void SetupTarget() {
@@ -196,7 +201,7 @@ TEST_CASE("Runtime - UnregisterTarget Success", "[runtime][target]") {
   auto *client = WRP_CTE_CLIENT;
 
   // Register a temporary target
-  std::string temp_target = std::string(std::getenv("HOME")) + "/temp_unregister_test.dat";
+  std::string temp_target = chi_test_data_dir() + "/temp_unregister_test.dat";
 
   chi::PoolId temp_bdev_pool_id(901, 0);
   size_t temp_target_size = 5 * 1024 * 1024;

--- a/context-transfer-engine/test/unit/test_query.cc
+++ b/context-transfer-engine/test/unit/test_query.cc
@@ -79,6 +79,11 @@
 
  namespace fs = std::filesystem;
 
+static std::string chi_test_data_dir() {
+  const char *d = std::getenv("CHI_TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
  // Global state tracking for initialization (following pattern from other tests)
  namespace {
    bool g_initialized = false;
@@ -157,7 +162,7 @@
        throw std::runtime_error("HOME environment variable is not set");
      }
 
-     test_storage_path_ = home_dir + "/cte_query_test.dat";
+     test_storage_path_ = chi_test_data_dir() + "/cte_query_test.dat";
 
      // Clean up any existing test file
      if (fs::exists(test_storage_path_)) {

--- a/context-transfer-engine/test/unit/test_reorganize_blob.cc
+++ b/context-transfer-engine/test/unit/test_reorganize_blob.cc
@@ -60,6 +60,11 @@
 
 namespace fs = std::filesystem;
 
+static std::string chi_test_data_dir() {
+  const char *d = std::getenv("CHI_TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
 // Test constants for two-tier storage
 static constexpr chi::u64 kDramCapacity = 16 * 1024 * 1024;  // 16MB
 static constexpr chi::u64 kDiskCapacity = 64 * 1024 * 1024;  // 64MB
@@ -84,8 +89,8 @@ class ReorganizeBlobTestFixture {
     // Setup paths
     std::string home_dir = hshm::SystemInfo::Getenv("HOME");
     REQUIRE(!home_dir.empty());
-    config_path_ = home_dir + "/reorganize_blob_config.yaml";
-    file_storage_path_ = home_dir + "/reorganize_blob_storage.bin";
+    config_path_ = chi_test_data_dir() + "/reorganize_blob_config.yaml";
+    file_storage_path_ = chi_test_data_dir() + "/reorganize_blob_storage.bin";
 
     // Clean up existing files
     Cleanup();

--- a/context-transfer-engine/test/unit/test_tag_operations.cc
+++ b/context-transfer-engine/test/unit/test_tag_operations.cc
@@ -56,6 +56,11 @@
 
 namespace fs = std::filesystem;
 
+static std::string chi_test_data_dir() {
+  const char *d = std::getenv("CHI_TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
 /**
  * Test fixture for Tag operation tests
  */
@@ -76,7 +81,7 @@ class TagTestFixture {
     // Initialize test storage path
     std::string home_dir = hshm::SystemInfo::Getenv("HOME");
     REQUIRE(!home_dir.empty());
-    test_storage_path_ = home_dir + "/cte_tag_test.dat";
+    test_storage_path_ = chi_test_data_dir() + "/cte_tag_test.dat";
 
     // Initialize Chimaera and CTE client once
     if (!g_cte_initialized) {

--- a/context-transfer-engine/test/unit/test_tiered_storage_stress.cc
+++ b/context-transfer-engine/test/unit/test_tiered_storage_stress.cc
@@ -57,6 +57,11 @@
 
 namespace fs = std::filesystem;
 
+static std::string chi_test_data_dir() {
+  const char *d = std::getenv("CHI_TEST_DATA_DIR");
+  return (d && *d) ? d : ".";
+}
+
 // Test constants
 static constexpr chi::u64 kDramCapacity = 64 * 1024 * 1024;   // 64MB
 static constexpr chi::u64 kFileCapacity = 256 * 1024 * 1024;  // 256MB
@@ -82,8 +87,8 @@ class TieredStorageStressFixture {
     // Setup paths
     std::string home_dir = hshm::SystemInfo::Getenv("HOME");
     REQUIRE(!home_dir.empty());
-    config_path_ = home_dir + "/tiered_stress_config.yaml";
-    file_storage_path_ = home_dir + "/tiered_stress_storage.bin";
+    config_path_ = chi_test_data_dir() + "/tiered_stress_config.yaml";
+    file_storage_path_ = chi_test_data_dir() + "/tiered_stress_storage.bin";
 
     // Clean up existing files
     Cleanup();

--- a/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
@@ -220,9 +220,13 @@ void TestMultipleEvents() {
   EventManager em;
 
   int pipe1[2] = {}, pipe2[2] = {}, pipe3[2] = {};
-  assert(pipe(pipe1) == 0);
-  assert(pipe(pipe2) == 0);
-  assert(pipe(pipe3) == 0);
+  int rc1 = pipe(pipe1);
+  int rc2 = pipe(pipe2);
+  int rc3 = pipe(pipe3);
+  assert(rc1 == 0);
+  assert(rc2 == 0);
+  assert(rc3 == 0);
+  (void)rc1; (void)rc2; (void)rc3;
 
   em.AddEvent(pipe1[0], kDefaultReadEvent);
   em.AddEvent(pipe2[0], kDefaultReadEvent);

--- a/context-transport-primitives/test/unit/lightbeam/socket_transport_full_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/socket_transport_full_test.cc
@@ -605,7 +605,7 @@ void TestAcceptNewClient() {
   std::cout << "\n==== Testing Socket AcceptNewClient ====\n";
 
   std::string addr = "127.0.0.1";
-  int port = 9200;
+  int port = 9120;
 
   auto server = std::make_unique<SocketTransport>(
       TransportMode::kServer, addr, "tcp", port);

--- a/context-transport-primitives/test/unit/lightbeam/zmq_transport_full_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/zmq_transport_full_test.cc
@@ -271,7 +271,7 @@ void TestGetAddress() {
   std::cout << "\n==== Testing ZMQ GetAddress ====\n";
 
   std::string addr = "127.0.0.1";
-  int port = 8305;
+  int port = 8306;
 
   auto server = std::make_unique<ZeroMqTransport>(
       TransportMode::kServer, addr, "tcp", port);


### PR DESCRIPTION
## Summary
- Replace `<chrono>`/`<thread>` with POSIX headers in CUDA file to fix nvcc/GCC-14 cudafe++ crash
- Move `running_flag = 1` to after `worker.Init()` in GPU orchestrator kernel so Launch() readiness barrier is accurate
- Add per-block backend partitioning in `ClientInitGpu` (guarded by `HSHM_IS_GPU`) to fix multi-block allocator race where all blocks raced to `placement-new` the same address
- Replace hardcoded `$HOME` / `/tmp` test data paths with `CHI_TEST_DATA_DIR` env var (CMake sets it to `CMAKE_BINARY_DIR`; falls back to `.`) to avoid EDQUOT on Lustre-quota-constrained home directories
- Add `RESOURCE_LOCK "chimaera_runtime"` to `cte_query_*`, CEE, `test_buddy_benchmark_gpu`, and CTE GPU bench tests that start Chimaera servers
- Extend `chimaera_pre_test_cleanup` to remove stale test data files from build dir

## Motivation
Fixes #411

## Test plan
- [x] `ctest -R cr_gpu_task_trace` passes
- [x] `ctest -R test_buddy_benchmark_gpu` passes (single, multi, stress)
- [x] `ctest -R cte_query` passes (no EDQUOT)
- [x] `ctest -R CEE` passes
- [x] `ctest -D Experimental -j4` on Polaris shows 0 failures
- [x] No new compiler warnings

## Breaking changes
None. `CHI_TEST_DATA_DIR` is a new optional env var; existing test setups without it continue to work.