### PR TITLE
fix(ci): conda upload step couldn't find anaconda; bump to 1.5.2

### DIFF
--- a/.github/workflows/install-conda.yml
+++ b/.github/workflows/install-conda.yml
@@ -66,7 +66,14 @@ jobs:
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
+          # setup-miniconda activates the "test" env, but anaconda-client
+          # is installed into "base" (see "Install conda-build" step), so
+          # bare `anaconda` is not on PATH here -> exit 127. Run it
+          # explicitly from the base env. (The build step gets away with
+          # bare `conda build` because that's a `conda` subcommand;
+          # `anaconda` is a separate entry-point binary.)
           for pkg in build/conda-output/**/*.conda build/conda-output/**/*.tar.bz2; do
             [ -f "$pkg" ] || continue
-            anaconda -t "$ANACONDA_TOKEN" upload --user iowarp --force "$pkg"
+            conda run -n base --no-capture-output \
+              anaconda -t "$ANACONDA_TOKEN" upload --user iowarp --force "$pkg"
           done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.5.1 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.5.2 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options


### PR DESCRIPTION
## Summary
`Build and Publish Conda Package` failed on the v1.5.1 tag push at **"Upload to Anaconda.org" with exit 127 ("command not found")** — see [run 26125831594](https://github.com/iowarp/clio-core/actions/runs/26125831594).

The upload step only runs on tags (`if: startsWith(github.ref, 'refs/tags/v')`), so the main-push run "succeeded" only because the step was conditionally skipped — the bug was latent for every tag.

## Root cause
`setup-miniconda@v3` activates the **`test`** env, but `anaconda-client` is installed into **`base`** (see "Install conda-build" step). With `bash -l {0}` the login shell activates `test`, so the `anaconda` standalone binary is not on PATH. (The build step gets away with bare `conda build` because that's a `conda` subcommand; `anaconda` is a separate entry-point binary.)

## Fix
Invoke the uploader via `conda run -n base --no-capture-output anaconda ...` so it runs explicitly from the env where `anaconda-client` lives. No activation-state churn; mirrors the workflow's existing "conda-build lives in base" convention.

## Version bump
Bumps `CMakeLists.txt` project VERSION `1.5.1` → `1.5.2`, so a follow-up `v1.5.2` tag clears the `check-version` guard in `build-pip.yml` and releases the conda + pip wheels together. v1.5.1 stays as-is on PyPI/GitHub Releases (just missing from Anaconda).

## Test plan
- [ ] Same workflow re-runs on this PR (publish step skipped on non-tag, so passes as before)
- [ ] After merge + `v1.5.2` tag, "Upload to Anaconda.org" reaches the auth step (whether `ANACONDA_TOKEN` is valid is verifiable only after this PATH fix lands; exit 127 means we never reached the token).

## Caveat
Exit 127 means we never got to the auth handshake, so `ANACONDA_TOKEN` validity is unknown — a wrong/missing token would surface as a different error after this fix. One thing at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)