### PR TITLE
Refactor pip install paths via scikit-build-core wheel.install-dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.5.1 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.5.3 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options
@@ -1271,7 +1271,14 @@ message(STATUS "")
 #------------------------------------------------------------------------------
 # Pip Package Component
 #------------------------------------------------------------------------------
-set(PIP_PKG_DIR "iowarp_core")
+# All COMPONENT pip_package installs land under iowarp_core/ inside the wheel
+# via scikit-build-core's wheel.install-dir setting (see installers/pip/
+# pyproject.toml).  That means the DESTINATIONs below are package-relative:
+# "lib" -> iowarp_core/lib, "bin" -> iowarp_core/bin, etc.
+#
+# Exception: the .pth file uses DESTINATION ".." to land at site-packages
+# root (one level above the iowarp_core/ package directory) so Python picks
+# it up at startup.
 
 # Shared libraries -> iowarp_core/lib/
 set(PIP_LIB_TARGETS hermes_shm_host chimaera_cxx)
@@ -1293,16 +1300,16 @@ endif()
 
 install(TARGETS ${PIP_LIB_TARGETS}
   COMPONENT pip_package
-  LIBRARY DESTINATION ${PIP_PKG_DIR}/lib
-  ARCHIVE DESTINATION ${PIP_PKG_DIR}/lib
-  RUNTIME DESTINATION ${PIP_PKG_DIR}/bin
-  PUBLIC_HEADER DESTINATION ${PIP_PKG_DIR}/include/chimaera)
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  PUBLIC_HEADER DESTINATION include/chimaera)
 
 # CLI binary -> iowarp_core/bin/
 if(TARGET chimaera)
   install(TARGETS chimaera
     COMPONENT pip_package
-    RUNTIME DESTINATION ${PIP_PKG_DIR}/bin)
+    RUNTIME DESTINATION bin)
   # Also install to PYTHON_SITE_PACKAGES/iowarp_core/bin/ so that
   # `sudo make install` keeps the binary in sync with the Python package,
   # matching how chimaera_runtime_ext.so is installed directly to site-packages.
@@ -1317,17 +1324,17 @@ if(WRP_CORE_ENABLE_PYTHON)
   if(TARGET wrp_cte_core_ext)
     install(TARGETS wrp_cte_core_ext
       COMPONENT pip_package
-      LIBRARY DESTINATION ${PIP_PKG_DIR}/ext)
+      LIBRARY DESTINATION ext)
   endif()
   if(TARGET wrp_cee)
     install(TARGETS wrp_cee
       COMPONENT pip_package
-      LIBRARY DESTINATION ${PIP_PKG_DIR}/ext)
+      LIBRARY DESTINATION ext)
   endif()
   # Context Visualizer -> iowarp_core/visualizer/
   install(DIRECTORY context-visualizer/context_visualizer/
     COMPONENT pip_package
-    DESTINATION ${PIP_PKG_DIR}/visualizer
+    DESTINATION visualizer
     FILES_MATCHING
       PATTERN "*.py"
       PATTERN "*.html"
@@ -1338,13 +1345,15 @@ endif()
 # Default config -> iowarp_core/data/
 install(FILES context-runtime/config/chimaera_default.yaml
   COMPONENT pip_package
-  DESTINATION ${PIP_PKG_DIR}/data)
+  DESTINATION data)
 
 # .pth file at site-packages root so "import wrp_cee" works without
 # explicitly importing iowarp_core first (triggers _setup() at startup).
+# DESTINATION ".." escapes wheel.install-dir (= iowarp_core/) by one level
+# so the file lands at platlib root.
 install(FILES installers/pip/iowarp_core.pth
   COMPONENT pip_package
-  DESTINATION .)
+  DESTINATION ..)
 
 #------------------------------------------------------------------------------
 # CPack Configuration

--- a/installers/pip/pyproject.toml
+++ b/installers/pip/pyproject.toml
@@ -43,6 +43,12 @@ cmake.source-dir = "../.."
 cmake.build-type = "Release"
 install.components = ["pip_package"]
 wheel.packages = ["iowarp_core"]
+# Sets CMAKE_INSTALL_PREFIX = <wheel>/platlib/iowarp_core, so every install()
+# DESTINATION is package-relative ("lib", "bin", "ext", ...) instead of having
+# to manually prefix each one with iowarp_core/.  The single exception is the
+# .pth file, which uses DESTINATION ".." in CMakeLists.txt to escape one level
+# up so it lands at site-packages root.
+wheel.install-dir = "iowarp_core"
 build-dir = "build/{wheel_tag}"
 
 [tool.scikit-build.cmake.define]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,13 @@ cmake.source-dir = "."
 cmake.build-type = "Release"
 install.components = ["pip_package"]
 wheel.packages = ["installers/pip/iowarp_core"]
+# Sets CMAKE_INSTALL_PREFIX = <wheel>/platlib/iowarp_core, so every install()
+# DESTINATION is package-relative ("lib", "bin", "ext", ...) instead of having
+# to manually prefix each one with iowarp_core/.  The single exception is the
+# .pth file, which uses DESTINATION ".." in CMakeLists.txt to escape one level
+# up so it lands at site-packages root.  Must stay in sync with the
+# installers/pip/pyproject.toml copy used by local `pip install installers/pip`.
+wheel.install-dir = "iowarp_core"
 build-dir = "build/{wheel_tag}"
 
 [tool.scikit-build.cmake.define]


### PR DESCRIPTION
## Summary
- Add `wheel.install-dir = "iowarp_core"` to `installers/pip/pyproject.toml` so scikit-build-core prepends `iowarp_core/` to every `install()` destination automatically.
- Strip the `${PIP_PKG_DIR}/...` prefix from every COMPONENT `pip_package` install() in `CMakeLists.txt`. Bare GNUInstallDirs-style destinations (`lib`, `bin`, `ext`, `visualizer`, `data`) are now sufficient.
- `iowarp_core.pth` install uses `DESTINATION ..` to escape `wheel.install-dir` by one level so it still lands at site-packages root.
- Bump project version to 1.5.3.

## Motivation
Closes #420. Previously every wheel-bound `install()` had to manually interpolate `${PIP_PKG_DIR}` into its destination — a footgun for new install rules that forget the prefix. scikit-build-core has a first-class setting for this; using it removes the boilerplate and the trap.

## Test plan
- [x] `pip wheel installers/pip` builds successfully (`iowarp_core-1.5.3-cp312-cp312-linux_x86_64.whl`)
- [x] Wheel contents under `iowarp_core/` are byte-equivalent to pre-refactor layout (`bin/chimaera`, `lib/lib*.so`, `ext/wrp_cee.*.so`, `ext/wrp_cte_core_ext.*.so`, `data/chimaera_default.yaml`, `visualizer/...`)
- [x] `iowarp_core.pth` lands at site-packages root after install
- [x] `python -c "import iowarp_core; print(iowarp_core.get_version())"` prints `1.5.3` in a clean venv
- [x] Top-level `import wrp_cee` and `import wrp_cte_core_ext` work (confirms .pth → `_setup()` chain intact)
- [x] `chimaera --help` works
- [ ] CI build-and-test green
- [ ] CI cpplint / sanitizers green

## Breaking changes
None. Installed wheel layout under site-packages is identical to the previous behavior; `${PIP_PKG_DIR}` is no longer set in CMakeLists.txt, but it was an internal variable not consumed by anything outside the deleted block.