### PR TITLE
Ship wrp_cte_bench and wrp_run_thrpt_benchmark in the pip wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.5.3 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.5.4 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options
@@ -1317,6 +1317,25 @@ if(TARGET chimaera)
     install(TARGETS chimaera
       RUNTIME DESTINATION "${PYTHON_SITE_PACKAGES}/iowarp_core/bin")
   endif()
+endif()
+
+# Benchmark binaries -> iowarp_core/bin/
+# Per-subdir install(TARGETS) calls in */benchmark/CMakeLists.txt land in
+# the default component, which scikit-build-core filters out of the wheel.
+# Re-install the user-facing benchmarks here under COMPONENT pip_package
+# so they ship in the wheel.  if(TARGET ...) guards skip benchmarks that
+# weren't built (e.g. MPI/Redis-only ones disabled in pip configurations).
+if(WRP_CORE_ENABLE_BENCHMARKS)
+  set(PIP_BENCH_TARGETS
+    wrp_cte_bench
+    wrp_run_thrpt_benchmark)
+  foreach(_bench ${PIP_BENCH_TARGETS})
+    if(TARGET ${_bench})
+      install(TARGETS ${_bench}
+        COMPONENT pip_package
+        RUNTIME DESTINATION bin)
+    endif()
+  endforeach()
 endif()
 
 # Python extensions -> iowarp_core/ext/

--- a/installers/pip/iowarp_core/_cli.py
+++ b/installers/pip/iowarp_core/_cli.py
@@ -1,30 +1,33 @@
-"""CLI entry point for the chimaera command.
+"""CLI entry points for bundled IOWarp binaries.
 
-Locates the chimaera binary bundled in the wheel and exec's it,
-ensuring IOWarp shared libraries are on the library search path.
+Locates a named binary bundled in the wheel (under ``iowarp_core/bin/``)
+and exec's it after ensuring IOWarp shared libraries are on the library
+search path.  Each ``[project.scripts]`` entry in pyproject.toml routes
+to a thin wrapper around ``_exec_iowarp_bin``.
 """
 
+import importlib
 import os
 import sys
 
 
-def main():
-    """Execute the chimaera binary."""
-    # In scikit-build-core editable installs, __file__ resolves to the
-    # workspace source tree, but cmake-built artifacts (binary, .so libs)
-    # live in site-packages/iowarp_core/.  Anchor to site-packages by
-    # using the __file__ of a cmake-built extension module (.so), which the
-    # editable finder always serves from site-packages (known_wheel_files).
+def _exec_iowarp_bin(name):
+    """Find ``iowarp_core/bin/<name>``, prepend ``lib/`` to LD_LIBRARY_PATH,
+    and replace the current process with it.
+
+    In scikit-build-core editable installs, ``__file__`` resolves to the
+    workspace source tree, but cmake-built artifacts (binaries, .so libs)
+    live in ``site-packages/iowarp_core/``.  Anchor to site-packages by
+    importing a cmake-built extension module — the editable finder always
+    serves those from site-packages — and walking from its .so location.
+    """
     bin_path = None
     lib_dir = None
     for _extmod in ("wrp_cte_core_ext", "wrp_cee"):
         try:
-            import importlib as _il
-            _m = _il.import_module(_extmod)
-            # .so lives at site-packages/<name>.so (top-level module).
-            # iowarp_core/bin/chimaera is a sibling of that .so file.
+            _m = importlib.import_module(_extmod)
             _sp = os.path.dirname(os.path.abspath(_m.__file__))
-            _candidate = os.path.join(_sp, "iowarp_core", "bin", "chimaera")
+            _candidate = os.path.join(_sp, "iowarp_core", "bin", name)
             if os.path.exists(_candidate):
                 bin_path = _candidate
                 lib_dir = os.path.join(_sp, "iowarp_core", "lib")
@@ -33,25 +36,38 @@ def main():
             continue
 
     if bin_path is None:
-        # Fallback: __file__-based path works for regular (non-editable) installs
-        # where _cli.py itself lives inside site-packages/iowarp_core/.
+        # Fallback for regular (non-editable) installs where _cli.py lives
+        # inside site-packages/iowarp_core/ itself.
         package_dir = os.path.dirname(os.path.abspath(__file__))
-        bin_path = os.path.join(package_dir, "bin", "chimaera")
+        bin_path = os.path.join(package_dir, "bin", name)
         lib_dir = os.path.join(package_dir, "lib")
 
     if not os.path.exists(bin_path):
-        print("Error: chimaera binary not found at", bin_path, file=sys.stderr)
+        print(f"Error: {name} binary not found at {bin_path}", file=sys.stderr)
         sys.exit(1)
 
-    # Ensure IOWarp libs are on the library path
     ld_path = os.environ.get("LD_LIBRARY_PATH", "")
     if lib_dir not in ld_path:
         os.environ["LD_LIBRARY_PATH"] = (
             lib_dir + ":" + ld_path if ld_path else lib_dir
         )
 
-    # Replace this process with the chimaera binary
     os.execve(bin_path, [bin_path] + sys.argv[1:], os.environ)
+
+
+def main():
+    """Entry point for the ``chimaera`` console script."""
+    _exec_iowarp_bin("chimaera")
+
+
+def cte_bench_main():
+    """Entry point for the ``wrp_cte_bench`` console script."""
+    _exec_iowarp_bin("wrp_cte_bench")
+
+
+def run_thrpt_main():
+    """Entry point for the ``wrp_run_thrpt_benchmark`` console script."""
+    _exec_iowarp_bin("wrp_run_thrpt_benchmark")
 
 
 if __name__ == "__main__":

--- a/installers/pip/pyproject.toml
+++ b/installers/pip/pyproject.toml
@@ -32,6 +32,8 @@ visualizer = [
 
 [project.scripts]
 chimaera = "iowarp_core._cli:main"
+wrp_cte_bench = "iowarp_core._cli:cte_bench_main"
+wrp_run_thrpt_benchmark = "iowarp_core._cli:run_thrpt_main"
 
 [project.urls]
 Homepage = "https://iowarp.ai"
@@ -60,7 +62,7 @@ WRP_CORE_ENABLE_CAE = "ON"
 WRP_CORE_ENABLE_CEE = "ON"
 WRP_CORE_ENABLE_PYTHON = "ON"
 WRP_CORE_ENABLE_TESTS = "OFF"
-WRP_CORE_ENABLE_BENCHMARKS = "OFF"
+WRP_CORE_ENABLE_BENCHMARKS = "ON"
 WRP_CORE_ENABLE_RPATH = "OFF"
 WRP_CORE_ENABLE_ZMQ = "ON"
 WRP_CORE_ENABLE_CEREAL = "ON"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ visualizer = [
 
 [project.scripts]
 chimaera = "iowarp_core._cli:main"
+wrp_cte_bench = "iowarp_core._cli:cte_bench_main"
+wrp_run_thrpt_benchmark = "iowarp_core._cli:run_thrpt_main"
 
 [project.urls]
 Homepage = "https://iowarp.ai"
@@ -61,7 +63,7 @@ WRP_CORE_ENABLE_CAE = "ON"
 WRP_CORE_ENABLE_CEE = "ON"
 WRP_CORE_ENABLE_PYTHON = "ON"
 WRP_CORE_ENABLE_TESTS = "OFF"
-WRP_CORE_ENABLE_BENCHMARKS = "OFF"
+WRP_CORE_ENABLE_BENCHMARKS = "ON"
 WRP_CORE_ENABLE_RPATH = "OFF"
 WRP_CORE_ENABLE_ZMQ = "ON"
 WRP_CORE_ENABLE_CEREAL = "ON"


### PR DESCRIPTION
## Summary
- Set `WRP_CORE_ENABLE_BENCHMARKS = "ON"` in both pyproject.toml files (top-level + `installers/pip/`).
- New install block in `CMakeLists.txt` re-installs `wrp_cte_bench` and `wrp_run_thrpt_benchmark` under `COMPONENT pip_package` so they ship in the wheel.
- `_cli.py` refactored: extracted `_exec_iowarp_bin(name)` helper; added `cte_bench_main` and `run_thrpt_main` entry points.
- `[project.scripts]` in both pyproject.toml files now exposes `wrp_cte_bench` and `wrp_run_thrpt_benchmark` as PATH-visible commands, same wrapper trick as `chimaera`.
- Bump version to 1.5.4.

## Motivation
Closes #422. v1.5.3 didn't ship any benchmark binaries — `wrp_cte_bench` after `pip install iowarp-core` returned "command not found".

## Test plan
- [x] `pip wheel .` produces `iowarp_core-1.5.4-cp312-cp312-linux_x86_64.whl`
- [x] Wheel contains `iowarp_core/bin/wrp_cte_bench` and `iowarp_core/bin/wrp_run_thrpt_benchmark` (and still `chimaera`)
- [x] Fresh-venv install: `wrp_cte_bench --help`, `wrp_run_thrpt_benchmark --help`, and `chimaera --help` all run successfully
- [ ] CI: build-and-test, sanitizers, cpplint green
- [ ] CI: build-pip → build-wheels + test-wheels green

## Breaking changes
None. New entries on PATH, no removed surface.

## Notes
- `allocator_benchmark` and `zmq_ipc_latency_benchmark` are deliberately excluded from this PR but can be added later by appending them to `PIP_BENCH_TARGETS`.
- MPI/Redis-only benchmarks (`wrp_xnode_bdev_bench`, `wrp_cte_score_bench`, `wrp_redis_bench`) remain unbuilt in pip configurations and are auto-skipped by the `if(TARGET ...)` guard.