### PR TITLE
Demote DumpNetStats HLOGs to kDebug

### DIFF
--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -137,7 +137,7 @@ static inline void DumpNetStatsIfDue(chi::u64 self_node_id, size_t num_peers) {
         s.rout_count == 0) {
       continue;
     }
-    HLOG(kInfo,
+    HLOG(kDebug,
          "[NetStats] self={} peer={} sin={}/{}MiB sout={}/{}MiB "
          "rin={}/{}MiB rout={}/{}MiB "
          "sin_lbm_ms={:.1f} sout_lbm_ms={:.1f} "
@@ -163,7 +163,7 @@ static inline void DumpNetStatsIfDue(chi::u64 self_node_id, size_t num_peers) {
     tot_rin_des += s.rin_des_ns;
     tot_rout_des += s.rout_des_ns;
   }
-  HLOG(kInfo,
+  HLOG(kDebug,
        "[NetStats] self={} TOTAL sin={}/{}MiB sout={}/{}MiB "
        "rin={}/{}MiB rout={}/{}MiB "
        "sin_lbm_ms={:.1f} sout_lbm_ms={:.1f} "


### PR DESCRIPTION
## Summary
- `context-runtime/modules/admin/src/admin_runtime.cc:140` and `:166`: `HLOG(kInfo, ...)` → `HLOG(kDebug, ...)`.

## Motivation
Closes #424.  `DumpNetStatsIfDue` fires once per second under `kNetStatsDumpIntervalSec = 1.0` and the two `[NetStats]` lines (per-peer + TOTAL) flood normal-verbosity logs.  Useful when profiling cross-node traffic but not at default verbosity.

## Test plan
- [x] `grep 'HLOG(kInfo' admin_runtime.cc` no longer hits lines 140/166
- [ ] CI build + tests green

## Breaking changes
None — strictly a verbosity reduction.