### PR TITLE
Ship context_visualizer as top-level package in the pip wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.5.4 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.5.6 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options
@@ -1350,15 +1350,11 @@ if(WRP_CORE_ENABLE_PYTHON)
       COMPONENT pip_package
       LIBRARY DESTINATION ext)
   endif()
-  # Context Visualizer -> iowarp_core/visualizer/
-  install(DIRECTORY context-visualizer/context_visualizer/
-    COMPONENT pip_package
-    DESTINATION visualizer
-    FILES_MATCHING
-      PATTERN "*.py"
-      PATTERN "*.html"
-      PATTERN "*.css"
-      PATTERN "*.js")
+  # Note: the context_visualizer Python package ships at the wheel root
+  # (top-level "context_visualizer/") via scikit-build-core's wheel.packages
+  # setting in pyproject.toml, not via CMake install.  That keeps the
+  # `python -m context_visualizer` and `context-visualizer` entry-point
+  # paths consistent with the package's own __main__.py.
 endif()
 
 # Default config -> iowarp_core/data/

--- a/installers/pip/pyproject.toml
+++ b/installers/pip/pyproject.toml
@@ -34,6 +34,7 @@ visualizer = [
 chimaera = "iowarp_core._cli:main"
 wrp_cte_bench = "iowarp_core._cli:cte_bench_main"
 wrp_run_thrpt_benchmark = "iowarp_core._cli:run_thrpt_main"
+context-visualizer = "context_visualizer.__main__:main"
 
 [project.urls]
 Homepage = "https://iowarp.ai"
@@ -44,7 +45,10 @@ Documentation = "https://docs.iowarp.ai"
 cmake.source-dir = "../.."
 cmake.build-type = "Release"
 install.components = ["pip_package"]
-wheel.packages = ["iowarp_core"]
+wheel.packages = [
+    "iowarp_core",
+    "../../context-visualizer/context_visualizer",
+]
 # Sets CMAKE_INSTALL_PREFIX = <wheel>/platlib/iowarp_core, so every install()
 # DESTINATION is package-relative ("lib", "bin", "ext", ...) instead of having
 # to manually prefix each one with iowarp_core/.  The single exception is the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ visualizer = [
 chimaera = "iowarp_core._cli:main"
 wrp_cte_bench = "iowarp_core._cli:cte_bench_main"
 wrp_run_thrpt_benchmark = "iowarp_core._cli:run_thrpt_main"
+context-visualizer = "context_visualizer.__main__:main"
 
 [project.urls]
 Homepage = "https://iowarp.ai"
@@ -44,7 +45,10 @@ Documentation = "https://docs.iowarp.ai"
 cmake.source-dir = "."
 cmake.build-type = "Release"
 install.components = ["pip_package"]
-wheel.packages = ["installers/pip/iowarp_core"]
+wheel.packages = [
+    "installers/pip/iowarp_core",
+    "context-visualizer/context_visualizer",
+]
 # Sets CMAKE_INSTALL_PREFIX = <wheel>/platlib/iowarp_core, so every install()
 # DESTINATION is package-relative ("lib", "bin", "ext", ...) instead of having
 # to manually prefix each one with iowarp_core/.  The single exception is the


### PR DESCRIPTION
## Summary
- Add \`context-visualizer/context_visualizer\` to \`wheel.packages\` in both pyproject.toml files; scikit-build-core now packs the directory at the wheel root as a top-level \`context_visualizer\` package.
- Drop the CMake \`install(DIRECTORY context-visualizer/context_visualizer/ ... DESTINATION visualizer)\` rule from the COMPONENT pip_package block to avoid shipping the visualizer twice.
- Add \`[project.scripts]\` entry \`context-visualizer = "context_visualizer.__main__:main"\` so it's a PATH command alongside \`chimaera\`, \`wrp_cte_bench\`, and \`wrp_run_thrpt_benchmark\`.
- Bump project version to 1.5.5.

## Motivation
Closes #426. After \`pip install iowarp-core==1.5.4\`, \`python -m context_visualizer\` failed with \`No module named context_visualizer\` — the files were at \`iowarp_core/visualizer/\`, but the visualizer's \`__main__.py\` is written to run as a top-level package.

## Test plan
- [x] \`pip wheel .\` produces \`iowarp_core-1.5.5-cp312-cp312-linux_x86_64.whl\`.
- [x] Wheel contains \`context_visualizer/\` at the top level and no longer contains \`iowarp_core/visualizer/\`.
- [x] In a fresh venv with \`[visualizer]\` extra: \`python -m context_visualizer --help\` and \`context-visualizer --help\` both succeed.
- [x] No regressions: \`chimaera --help\`, \`wrp_cte_bench --help\`, \`wrp_run_thrpt_benchmark --help\` all still work.
- [ ] CI build-and-test + sanitizers + cpplint green.
- [ ] CI build-pip workflow (build-wheels + test-wheels) green.

## Breaking changes
None for users invoking via \`python -m context_visualizer\` (this now works for the first time on pip installs).  If anything imports \`iowarp_core.visualizer\` directly, it will break — searched the tree, no in-repo consumers found.

## Notes
Bundling couples the visualizer's release cadence to iowarp-core.  The visualizer's own metadata (\`context-visualizer/pyproject.toml\`, \`name = "context-visualizer"\`, \`version = "0.1.0"\`) is untouched so a future split to a separate PyPI package remains an option.