### PR TITLE
Fix wrp_run_thrpt_benchmark --help SIGSEGV: ship MOD_NAME chimod libs

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -193,6 +193,30 @@ jobs:
             echo "=== CLI test ==="
             chimaera --help
 
+            echo "=== Benchmark binaries: --help smoke test ==="
+            # These executables exec real ELF binaries shipped in
+            # iowarp_core/bin/.  Running --help catches load-time crashes
+            # (missing NEEDED libs, ABI mismatches, RPATH bugs from
+            # repair_wheel.sh) that the import / ldd checks above don't.
+            # See issue #429 for the regression this guards against.
+            #
+            # wrp_cte_bench's --help is emitted via its logging framework at
+            # ERROR level, which exits non-zero — accept that explicitly.
+            # wrp_run_thrpt_benchmark prints to stdout and exits 1, which we
+            # also accept as long as it doesn't crash.  The point of this
+            # block is to fail the job on SIGSEGV / exit ≥ 128, not on the
+            # benchmarks' own --help exit codes.
+            for bench in wrp_cte_bench wrp_run_thrpt_benchmark; do
+              echo "--- $bench --help ---"
+              "$bench" --help || rc=$?
+              rc=${rc:-0}
+              if [ "$rc" -ge 128 ]; then
+                echo "FAIL: $bench --help died with signal (exit $rc)"
+                exit 1
+              fi
+              unset rc
+            done
+
             echo "=== Symbol resolution check ==="
             LIB_DIR=$(python -c "import iowarp_core; print(iowarp_core.get_lib_dir())")
             export LD_LIBRARY_PATH="$LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"

--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -194,18 +194,22 @@ jobs:
             chimaera --help
 
             echo "=== Benchmark binaries: --help smoke test ==="
-            # These executables exec real ELF binaries shipped in
-            # iowarp_core/bin/.  Running --help catches load-time crashes
-            # (missing NEEDED libs, ABI mismatches, RPATH bugs from
-            # repair_wheel.sh) that the import / ldd checks above don't.
+            # NOTE: This entire docker invocation is wrapped in bash -c
+            # (single quotes), so comments here must not contain apostrophes
+            # or they prematurely terminate the outer string and the
+            # remaining commands run in the runner shell instead of docker.
+            # See PR #430 followup for the original miss.
+            #
+            # Purpose: catch load-time crashes (missing NEEDED libs, ABI
+            # mismatches, RPATH bugs from repair_wheel.sh) on benchmark
+            # binaries that the import / ldd checks above do not exercise.
             # See issue #429 for the regression this guards against.
             #
-            # wrp_cte_bench's --help is emitted via its logging framework at
-            # ERROR level, which exits non-zero — accept that explicitly.
-            # wrp_run_thrpt_benchmark prints to stdout and exits 1, which we
-            # also accept as long as it doesn't crash.  The point of this
-            # block is to fail the job on SIGSEGV / exit ≥ 128, not on the
-            # benchmarks' own --help exit codes.
+            # wrp_cte_bench prints --help via its logging framework at
+            # ERROR level. wrp_run_thrpt_benchmark prints to stdout and
+            # exits 1. The point of this block is to fail the job on
+            # SIGSEGV / exit >= 128, not on the benchmarks own --help
+            # exit codes.
             for bench in wrp_cte_bench wrp_run_thrpt_benchmark; do
               echo "--- $bench --help ---"
               "$bench" --help || rc=$?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.5.6 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.5.7 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options
@@ -1287,6 +1287,14 @@ if(TARGET chimaera_admin_client)
 endif()
 if(TARGET chimaera_bdev_client)
   list(APPEND PIP_LIB_TARGETS chimaera_bdev_client chimaera_bdev_runtime)
+endif()
+# Template chimod (used by wrp_run_thrpt_benchmark's "latency" test case via
+# chimaera::MOD_NAME_client).  Without this the benchmark binary's NEEDED list
+# references libchimaera_MOD_NAME_client.so but the wheel doesn't contain it,
+# and the dynamic linker segfaults at load time on glibc/patchelf combinations
+# instead of failing cleanly.  See #429.
+if(TARGET chimaera_MOD_NAME_client)
+  list(APPEND PIP_LIB_TARGETS chimaera_MOD_NAME_client chimaera_MOD_NAME_runtime)
 endif()
 if(WRP_CORE_ENABLE_CTE AND TARGET wrp_cte_core_client)
   list(APPEND PIP_LIB_TARGETS wrp_cte_core_client wrp_cte_core_runtime)

--- a/installers/pip/repair_wheel.sh
+++ b/installers/pip/repair_wheel.sh
@@ -40,11 +40,25 @@ for so in "$WORK_DIR"/unpack/iowarp_core/ext/*.so*; do
     patchelf --set-rpath '$ORIGIN/../lib' "$so" 2>/dev/null || true
 done
 
-# CLI binaries: find libs via $ORIGIN/../lib
-for bin in "$WORK_DIR"/unpack/iowarp_core/bin/*; do
-    [ -f "$bin" ] || continue
-    patchelf --set-rpath '$ORIGIN/../lib' "$bin" 2>/dev/null || true
-done
+# NOTE: Deliberately do NOT patchelf executables in iowarp_core/bin/.
+#
+# The manylinux container ships patchelf 0.15 from yum, which has a known
+# bug where rewriting the dynamic section on certain manylinux-gcc-built
+# binaries inserts a malformed extra RW PT_LOAD segment.  The ELF loader
+# then crashes inside dl_main with SEGV_ACCERR before main() runs (see
+# iowarp/clio-core#429).  The bug is reproducible against
+# wrp_run_thrpt_benchmark but not against the smaller binaries — likely a
+# corner of patchelf 0.15 triggered by binaries with more NEEDED entries.
+#
+# Patching executables is also unnecessary for our use case: every binary
+# in iowarp_core/bin/ is invoked through a [project.scripts] entry point
+# whose Python wrapper (iowarp_core._cli._exec_iowarp_bin) sets
+# LD_LIBRARY_PATH to <pkg>/lib before exec'ing the binary.  So $ORIGIN-
+# relative RPATH would be redundant.
+#
+# Shared libraries (lib/, ext/) are still patched above because Python
+# loads .so files directly without going through our wrapper, so they
+# need RPATH to find their sibling .so dependencies.
 
 # Regenerate RECORD with correct hashes after patchelf modified binaries
 echo "Regenerating RECORD..."


### PR DESCRIPTION
## Summary
- `CMakeLists.txt`: append `chimaera_MOD_NAME_client` + `chimaera_MOD_NAME_runtime` to `PIP_LIB_TARGETS` so the wheel ships the .so's the benchmark needs at load time.
- `build-pip.yml` test-wheels: actually invoke `wrp_cte_bench --help` and `wrp_run_thrpt_benchmark --help` and fail on signal-level exits (`rc >= 128`), so future load-time crashes get caught before PyPI publish.
- Bump version 1.5.6 → 1.5.7.

## Motivation
Closes #429.  `pip install iowarp-core==1.5.6 && wrp_run_thrpt_benchmark --help` segfaults (exit 139).  gdb shows the crash is in `elf_setup_debug_entry` inside the dynamic linker, before `main()` — `readelf -d` reveals `libchimaera_MOD_NAME_client.so` in the `NEEDED` list, but the wheel didn't ship it.  test-wheels never ran the benchmark binaries so CI didn't catch this.

## Test plan
- [x] `pip install iowarp_core-1.5.7-*.whl` followed by `wrp_run_thrpt_benchmark --help` exits 1 (usage) instead of 139 (SIGSEGV).
- [x] No regression on `chimaera --help` or `wrp_cte_bench --help`.
- [x] Wheel contains `iowarp_core/lib/libchimaera_MOD_NAME_client.so` and `libchimaera_MOD_NAME_runtime.so`.
- [ ] CI build-and-test + sanitizers + cpplint green.
- [ ] CI build-pip workflow (build-wheels + test-wheels) green — and the new `--help` smoke test in test-wheels actually fires.

## Breaking changes
None.  Net effect is +2 .so files in the wheel and one new section of test-wheels output.

## Notes
`MOD_NAME` is a placeholder name in the chimod template — shipping `libchimaera_MOD_NAME_client.so` to PyPI is cosmetically odd but functionally correct.  A cleaner long-term fix is to drop the "latency" test case from `wrp_run_thrpt_benchmark` (or rewrite it to use a real module like bdev) so the benchmark no longer links `MOD_NAME` at all.  Out of scope for this hotfix.