### PR TITLE
fix(runtime): cr_ipc_transport_ipc UAF in SocketTransport bulk handoff

### DIFF
--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -2375,6 +2375,14 @@ void IpcManager::RecvZmqClientThread() {
       em.Wait(100);  // 100μs (precise with epoll_pwait2)
     }
   }
+  // `em` is about to be destroyed (stack-allocated). The transport
+  // stashed a raw pointer to it in RegisterEventManager — clear that
+  // before unwinding, otherwise ClientFinalize's later ~SocketTransport
+  // calls em_->RemoveEvent on freed memory (ASan: heap-use-after-free
+  // in EventManager::RemoveEvent → std::unordered_map::find).
+  if (zmq_transport_) {
+    zmq_transport_->UnregisterEventManager();
+  }
 }
 
 void IpcManager::HeartbeatThread() {

--- a/context-runtime/src/task_archive.cc
+++ b/context-runtime/src/task_archive.cc
@@ -106,6 +106,26 @@ void LoadTaskArchive::bulk(ctp::ipc::ShmPtr<> &ptr, size_t size, uint32_t flags)
           ptr = buf.shm_.template Cast<void>();
           recv[current_bulk_index_].data = buf;
           ++daemon_allocated_bulk_count_;
+        } else if (recv[current_bulk_index_].data.shm_.alloc_id_ ==
+                       ctp::ipc::AllocatorId(UINT32_MAX - 1,
+                                              UINT32_MAX - 1)) {
+          // SocketTransport (IPC/TCP-socket) recv: the buffer was
+          // std::malloc'd in SocketTransport::RecvBulks and tagged with
+          // the (UINT32_MAX-1, UINT32_MAX-1) sentinel. ClearRecvHandles
+          // will std::free it immediately after AllocLoadTask returns —
+          // pointing the task straight at recv[i].data leaves a dangling
+          // ptr that the worker later memcpy()s in e.g.
+          // bdev::Runtime::WriteToRam (ASan: heap-use-after-free). Mirror
+          // the ZMQ path: copy into a CTP buffer the task owns via
+          // TASK_DATA_OWNER, leaving recv[i].data alone so
+          // ClearRecvHandles still frees the malloc'd buffer.
+          ctp::ipc::FullPtr<char> buf = CLIO_IPC->AllocateBuffer(size);
+          char *src = recv[current_bulk_index_].data.ptr_;
+          if (buf.ptr_ && src) {
+            memcpy(buf.ptr_, src, size);
+          }
+          ptr = buf.shm_.template Cast<void>();
+          ++daemon_allocated_bulk_count_;
         } else {
           // Valid ShmPtr, no zmq handle: SHM transport (data already in
           // shared memory) — keep zero-copy.

--- a/context-transport-primitives/include/clio_ctp/lightbeam/lightbeam.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/lightbeam.h
@@ -217,6 +217,7 @@ class Transport {
 
   // Event registration API
   void RegisterEventManager(EventManager &em);
+  void UnregisterEventManager();
 
   // Liveness check
   bool IsServerAlive(const LbmContext& ctx = LbmContext()) const;

--- a/context-transport-primitives/include/clio_ctp/lightbeam/socket_transport.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/socket_transport.h
@@ -186,7 +186,17 @@ class SocketTransport : public Transport {
 
   void ClearRecvHandles(LbmMeta<>& meta) {
     for (auto& bulk : meta.recv) {
-      if (bulk.data.ptr_) {
+      // Only std::free buffers RecvBulks allocated itself (tagged with
+      // the (UINT32_MAX-1, UINT32_MAX-1) sentinel). LoadTaskArchive::bulk
+      // may have swapped in a CTP MallocAllocator FullPtr (whose user
+      // pointer is offset 16 bytes inside the real malloc region) for the
+      // BULK_EXPOSE / ZMQ-copy paths — passing that to std::free triggers
+      // glibc "free(): invalid pointer" (ASan: bad-free). Those CTP
+      // buffers are reclaimed by the task destructor via
+      // daemon_allocated_bulk_count_ / TASK_DATA_OWNER instead.
+      if (bulk.data.ptr_ &&
+          bulk.data.shm_.alloc_id_ ==
+              ctp::ipc::AllocatorId(UINT32_MAX - 1, UINT32_MAX - 1)) {
         std::free(bulk.data.ptr_);
         bulk.data.ptr_ = nullptr;
       }
@@ -239,6 +249,14 @@ class SocketTransport : public Transport {
         em.AddEvent(fd, kDefaultReadEvent, &fired_action_);
       }
     }
+  }
+
+  void UnregisterEventManager() {
+    // Detach without RemoveEvent — caller (e.g. RecvZmqClientThread) is
+    // about to destroy the EventManager itself; touching em_ here would
+    // be UAF. ~SocketTransport will see em_ == nullptr and skip the
+    // (now-stale) RemoveEvent calls.
+    em_ = nullptr;
   }
 
   template <typename MetaT>
@@ -443,7 +461,14 @@ class SocketTransport : public Transport {
 
       if (allocated) {
         meta.recv[i].data.ptr_ = buf;
-        meta.recv[i].data.shm_.alloc_id_ = ctp::ipc::AllocatorId::GetNull();
+        // Use a distinct sentinel (UINT32_MAX-1, UINT32_MAX-1) — not
+        // AllocatorId::GetNull() (UINT32_MAX, UINT32_MAX) — so
+        // LoadTaskArchive::bulk and ClearRecvHandles can distinguish a
+        // SocketTransport-owned raw std::malloc'd buffer from a CTP
+        // MallocAllocator buffer (whose backend id is also Null but whose
+        // ptr_ is offset 16 bytes inside the real malloc region).
+        meta.recv[i].data.shm_.alloc_id_ =
+            ctp::ipc::AllocatorId(UINT32_MAX - 1, UINT32_MAX - 1);
         meta.recv[i].data.shm_.off_ = reinterpret_cast<size_t>(buf);
       }
     }

--- a/context-transport-primitives/include/clio_ctp/lightbeam/transport_factory_impl.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/transport_factory_impl.h
@@ -186,6 +186,14 @@ inline void Transport::RegisterEventManager(EventManager &em) {
   }
 }
 
+inline void Transport::UnregisterEventManager() {
+  // Only SocketTransport currently tracks the EventManager pointer
+  // beyond a single Recv call. ZMQ/SHM/etc. are no-ops here.
+  if (type_ == TransportType::kSocket) {
+    static_cast<SocketTransport*>(this)->UnregisterEventManager();
+  }
+}
+
 inline bool Transport::IsServerAlive(const LbmContext& ctx) const {
   switch (type_) {
 #if CTP_ENABLE_ZMQ


### PR DESCRIPTION
cr_ipc_transport_ipc was failing while the SHM and TCP variants of the same suite passed. Root cause (ASan):

  READ of size 4096 in ctp::DeviceAwareMemcpy
    ← bdev::Runtime::WriteToRam
  freed by SocketTransport::ClearRecvHandles
    ← IpcCpu2CpuZmq::RuntimeRecv
  allocated by SocketTransport::RecvBulks (std::malloc)

SocketTransport::RecvBulks std::malloc's the BULK_XFER buffer and stashes the raw pointer in recv[i].data with
alloc_id == AllocatorId::GetNull(). LoadTaskArchive::bulk's existing branches treat that as the SHM zero-copy case (desc==null, !IsNull()) and point the task straight at recv[i].data. RuntimeRecv then calls ClearRecvHandles *before* the task runs, std::free'ing the buffer out from under the worker; the next bdev WriteToRam memcpy reads freed memory. Non-ASan glibc surfaced this as `double free or corruption (out)` on the next allocation.

The CTP MallocAllocator's null backend also reports GetNull() for its alloc_id, so a plain IsNull() check can't tell the two apart and the ZMQ-copy fix doesn't transfer. Disambiguate explicitly:

- clio_ctp/lightbeam/socket_transport.h RecvBulks: tag self-allocated buffers with the sentinel AllocatorId(UINT32_MAX-1, UINT32_MAX-1) instead of GetNull().
- src/task_archive.cc LoadTaskArchive::bulk: when the sentinel is set, memcpy into a CLIO_IPC->AllocateBuffer'd buffer the task owns via daemon_allocated_bulk_count_/TASK_DATA_OWNER, leaving recv[i].data pointing at the original malloc'd buffer.
- clio_ctp/lightbeam/socket_transport.h ClearRecvHandles: only std::free buffers carrying the sentinel; CTP MallocAllocator user pointers are offset 16 bytes inside the real malloc region and would crash std::free with glibc "free(): invalid pointer" (ASan: bad-free) otherwise.

Separately, ClientInit's RecvZmqClientThread stack-allocates an EventManager, hands a raw pointer to SocketTransport via RegisterEventManager, then returns — leaving zmq_transport_->em_ dangling. ClientFinalize later destroys zmq_transport_, ~SocketTransport calls em_->RemoveEvent, ASan flags heap-use-after-free in EventManager::RemoveEvent → unordered_map::find. Add Transport::UnregisterEventManager (dispatches to
SocketTransport::UnregisterEventManager which clears em_) and call it right before RecvZmqClientThread returns.

After the fix: 199/199 tests pass; cr_ipc_transport_ipc clears in 2.27s.