### PR TITLE
fix(windows-pip): make bundled binaries runnable + add Windows test job

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -476,6 +476,72 @@ jobs:
         echo "=== All tests passed ==="
 
   #------------------------------------------------------------
+  # Test Windows wheels natively (Linux Docker doesn't run on Windows
+  # runners). v1.9.0 shipped a Windows wheel where `chimaera --help`
+  # failed because chimaera.exe was missing from the wheel and the
+  # Python CLI wrapper assumed LD_LIBRARY_PATH semantics — exactly the
+  # class of thing this job is meant to catch. Same shape as the macOS
+  # native test: pip install into a clean venv, run import + CLI +
+  # benchmark smoke tests.
+  #------------------------------------------------------------
+  test-wheels-windows:
+    needs: build-wheels-windows
+    name: Test Windows wheels
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Download Windows wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: wheels-win_amd64
+        path: wheels/
+
+    - name: Test wheel in clean venv
+      shell: pwsh
+      run: |
+        python -m venv $env:TEMP\test-venv
+        & $env:TEMP\test-venv\Scripts\Activate.ps1
+
+        pip install --quiet --find-links wheels --no-cache-dir iowarp-core
+        if ($LASTEXITCODE -ne 0) { throw "pip install failed" }
+
+        Write-Host "=== Import test ==="
+        python -c "import iowarp_core; print('Version:', iowarp_core.get_version())"
+        if ($LASTEXITCODE -ne 0) { throw "import failed" }
+        python -c "import iowarp_core; print('Bin dir:', iowarp_core.get_bin_dir())"
+        if ($LASTEXITCODE -ne 0) { throw "get_bin_dir failed" }
+        python -c "import iowarp_core; print('CTE available:', iowarp_core.cte_available())"
+        if ($LASTEXITCODE -ne 0) { throw "cte_available failed" }
+
+        Write-Host "=== CLI test ==="
+        chimaera --help
+        # chimaera --help typically exits non-zero (printing usage),
+        # which is fine. Only fail on missing-binary / DLL-load errors,
+        # which surface as Windows error 0xC0000135 (-1073741515) or
+        # similar load-time codes. Treat any negative exit code as a
+        # crash; positive small codes are app-level "I printed usage".
+        if ($LASTEXITCODE -lt 0 -or $LASTEXITCODE -gt 100) {
+          throw "chimaera --help died with exit code $LASTEXITCODE (likely missing DLL or binary)"
+        }
+
+        Write-Host "=== Benchmark binaries: --help smoke test ==="
+        foreach ($bench in @('clio_cte_bench', 'clio_run_thrpt_bench')) {
+          Write-Host "--- $bench --help ---"
+          & $bench --help
+          if ($LASTEXITCODE -lt 0 -or $LASTEXITCODE -gt 100) {
+            throw "$bench --help died with exit code $LASTEXITCODE"
+          }
+        }
+
+        Write-Host "=== All Windows tests passed ==="
+
+  #------------------------------------------------------------
   # Publish to PyPI on version tags
   #------------------------------------------------------------
   publish-to-pypi:
@@ -487,6 +553,7 @@ jobs:
       - build-wheels-macos
       - test-wheels
       - test-wheels-macos
+      - test-wheels-windows
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     environment:
@@ -541,6 +608,7 @@ jobs:
       - build-wheels-macos
       - test-wheels
       - test-wheels-macos
+      - test-wheels-windows
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.9.0 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.9.1 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options
@@ -1424,10 +1424,16 @@ if(TARGET clio_run)
     COMPONENT pip_package
     RUNTIME DESTINATION bin)
   install(CODE "
-    set(_pip_dst \"\${CMAKE_INSTALL_PREFIX}/bin/chimaera\")
-    if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/bin/clio_run\" AND NOT EXISTS \"\${_pip_dst}\")
+    if(WIN32)
+      set(_pip_src \"\${CMAKE_INSTALL_PREFIX}/bin/clio_run.exe\")
+      set(_pip_dst \"\${CMAKE_INSTALL_PREFIX}/bin/chimaera.exe\")
+    else()
+      set(_pip_src \"\${CMAKE_INSTALL_PREFIX}/bin/clio_run\")
+      set(_pip_dst \"\${CMAKE_INSTALL_PREFIX}/bin/chimaera\")
+    endif()
+    if(EXISTS \"\${_pip_src}\" AND NOT EXISTS \"\${_pip_dst}\")
       if(WIN32)
-        file(INSTALL \"\${CMAKE_INSTALL_PREFIX}/bin/clio_run\"
+        file(INSTALL \"\${_pip_src}\"
              DESTINATION \"\${CMAKE_INSTALL_PREFIX}/bin\" RENAME chimaera.exe)
       else()
         execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink clio_run \"\${_pip_dst}\")
@@ -1441,10 +1447,16 @@ if(TARGET clio_run)
     install(TARGETS clio_run
       RUNTIME DESTINATION "${PYTHON_SITE_PACKAGES}/iowarp_core/bin")
     install(CODE "
-      set(_py_dst \"${PYTHON_SITE_PACKAGES}/iowarp_core/bin/chimaera\")
-      if(EXISTS \"${PYTHON_SITE_PACKAGES}/iowarp_core/bin/clio_run\" AND NOT EXISTS \"\${_py_dst}\")
+      if(WIN32)
+        set(_py_src \"${PYTHON_SITE_PACKAGES}/iowarp_core/bin/clio_run.exe\")
+        set(_py_dst \"${PYTHON_SITE_PACKAGES}/iowarp_core/bin/chimaera.exe\")
+      else()
+        set(_py_src \"${PYTHON_SITE_PACKAGES}/iowarp_core/bin/clio_run\")
+        set(_py_dst \"${PYTHON_SITE_PACKAGES}/iowarp_core/bin/chimaera\")
+      endif()
+      if(EXISTS \"\${_py_src}\" AND NOT EXISTS \"\${_py_dst}\")
         if(WIN32)
-          file(INSTALL \"${PYTHON_SITE_PACKAGES}/iowarp_core/bin/clio_run\"
+          file(INSTALL \"\${_py_src}\"
                DESTINATION \"${PYTHON_SITE_PACKAGES}/iowarp_core/bin\" RENAME chimaera.exe)
         else()
           execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink clio_run \"\${_py_dst}\")

--- a/context-runtime/util/CMakeLists.txt
+++ b/context-runtime/util/CMakeLists.txt
@@ -43,10 +43,18 @@ install(TARGETS clio_run
 
 # Install `chimaera` as a symlink to `clio_run` (Windows: copy fallback).
 # Done at install time so it lands at ${CMAKE_INSTALL_PREFIX}/bin regardless
-# of CPACK/DESTDIR.
+# of CPACK/DESTDIR. The Windows source path needs the `.exe` suffix — the
+# bare-name check silently skipped on Windows wheels and shipped without
+# chimaera.exe, breaking `pip install iowarp-core` users' first-touch
+# experience.
 install(CODE "
-  set(_src \"\${CMAKE_INSTALL_PREFIX}/bin/clio_run\")
-  set(_dst \"\${CMAKE_INSTALL_PREFIX}/bin/chimaera\")
+  if(WIN32)
+    set(_src \"\${CMAKE_INSTALL_PREFIX}/bin/clio_run.exe\")
+    set(_dst \"\${CMAKE_INSTALL_PREFIX}/bin/chimaera.exe\")
+  else()
+    set(_src \"\${CMAKE_INSTALL_PREFIX}/bin/clio_run\")
+    set(_dst \"\${CMAKE_INSTALL_PREFIX}/bin/chimaera\")
+  endif()
   if(EXISTS \"\${_src}\")
     if(WIN32)
       file(INSTALL \"\${_src}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/bin\"

--- a/installers/pip/iowarp_core/__init__.py
+++ b/installers/pip/iowarp_core/__init__.py
@@ -33,39 +33,74 @@ _EXT_MODULES = {"clio_cee", "clio_cte_core_ext", "chimaera_runtime_ext"}
 
 
 def _setup():
-    """Configure library and extension paths at import time."""
-    # Add lib/ to LD_LIBRARY_PATH so dlopen finds IOWarp shared libs
-    if os.path.isdir(_LIB_DIR):
-        ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+    """Configure library and extension paths at import time.
+
+    Per-platform shape:
+      - Linux: prepend lib/ to LD_LIBRARY_PATH (for child procs), then
+        dlopen each lib in dependency order with RTLD_GLOBAL so nanobind
+        extension modules find transitive symbols. Python loads .so
+        extensions with RTLD_LOCAL by default, which hides transitive
+        deps and breaks clio_cee on Linux.
+      - macOS: skip the explicit preload — every dylib in the wheel
+        carries @loader_path/../lib rpaths set at link time, so dlopen()
+        resolves transitively without help. Still prepend
+        DYLD_LIBRARY_PATH for child procs (SIP may strip it for system
+        binaries; harmless for our spawned children).
+      - Windows: DLLs live alongside .pyd files in bin/ (CMake's Windows
+        convention). Python 3.8+ restricts LoadLibraryEx to the .pyd's
+        own dir + system32 by default — register bin/ and lib/ via
+        os.add_dll_directory so .pyd extensions find clio_*.dll deps.
+        Also prepend PATH for child procs spawned by the chimaera
+        wrapper.
+    """
+    if sys.platform == "win32":
+        # Register DLL search directories for in-process LoadLibrary
+        # (Python extension loads).
+        for _d in (_BIN_DIR, _LIB_DIR):
+            if os.path.isdir(_d):
+                try:
+                    os.add_dll_directory(_d)
+                except (OSError, AttributeError):
+                    pass  # add_dll_directory is Py3.8+ and Windows-only.
+        # Prepend bin/ + lib/ to PATH so child processes (the wrapped
+        # chimaera/clio_*_bench) inherit a search path that finds the
+        # same DLLs.
+        _paths = [d for d in (_BIN_DIR, _LIB_DIR) if os.path.isdir(d)]
+        if _paths:
+            existing = os.environ.get("PATH", "")
+            os.environ["PATH"] = os.pathsep.join(
+                _paths + ([existing] if existing else [])
+            )
+    elif os.path.isdir(_LIB_DIR):
+        # POSIX (Linux + macOS).
+        _env_var = "DYLD_LIBRARY_PATH" if sys.platform == "darwin" else "LD_LIBRARY_PATH"
+        ld_path = os.environ.get(_env_var, "")
         if _LIB_DIR not in ld_path:
-            os.environ["LD_LIBRARY_PATH"] = (
-                _LIB_DIR + ":" + ld_path if ld_path else _LIB_DIR
+            os.environ[_env_var] = (
+                _LIB_DIR + os.pathsep + ld_path if ld_path else _LIB_DIR
             )
 
-        # Pre-load ALL shared libraries in dependency order with RTLD_GLOBAL
-        # so symbols are globally visible to subsequently loaded extensions.
-        # LD_LIBRARY_PATH changes above only affect child processes, so we
-        # must explicitly load each library for the current process.
-        # Python loads extension modules with RTLD_LOCAL by default, which
-        # hides symbols from transitive dependencies and breaks nanobind
-        # modules like clio_cee that depend on multiple IOWarp libraries.
-        for _lib_name in [
-            "libclio_ctp_host.so",
-            "libchimaera_cxx.so",
-            "libclio_admin_client.so",
-            "libclio_admin_runtime.so",
-            "libchimaera_bdev_client.so",
-            "libchimaera_bdev_runtime.so",
-            "libclio_cte_core_client.so",
-            "libclio_cte_core_runtime.so",
-            "libclio_cte_cae_config.so",
-            "libclio_cae_core_client.so",
-            "libclio_cae_core_runtime.so",
-            "libclio_cee_api.so",
-        ]:
-            _lib_path = os.path.join(_LIB_DIR, _lib_name)
-            if os.path.exists(_lib_path):
-                ctypes.CDLL(_lib_path, mode=ctypes.RTLD_GLOBAL)
+        # Linux-only: explicit RTLD_GLOBAL preload so nanobind extensions
+        # see transitive symbols. macOS resolves these via @loader_path
+        # rpaths baked into each dylib at link time.
+        if sys.platform.startswith("linux"):
+            for _lib_name in [
+                "libclio_ctp_host.so",
+                "libchimaera_cxx.so",
+                "libclio_admin_client.so",
+                "libclio_admin_runtime.so",
+                "libchimaera_bdev_client.so",
+                "libchimaera_bdev_runtime.so",
+                "libclio_cte_core_client.so",
+                "libclio_cte_core_runtime.so",
+                "libclio_cte_cae_config.so",
+                "libclio_cae_core_client.so",
+                "libclio_cae_core_runtime.so",
+                "libclio_cee_api.so",
+            ]:
+                _lib_path = os.path.join(_LIB_DIR, _lib_name)
+                if os.path.exists(_lib_path):
+                    ctypes.CDLL(_lib_path, mode=ctypes.RTLD_GLOBAL)
 
     # Add ext/ to sys.path so extension modules can be found by import
     if os.path.isdir(_EXT_DIR) and _EXT_DIR not in sys.path:
@@ -125,11 +160,14 @@ def get_data_dir():
     return _DATA_DIR
 
 
+_EXT_SUFFIXES = (".so", ".pyd")  # POSIX (.so on Linux + macOS), Windows (.pyd)
+
+
 def cte_available():
     """Check if the Context Transfer Engine extension is available."""
     if os.path.isdir(_EXT_DIR):
         for f in os.listdir(_EXT_DIR):
-            if f.startswith("clio_cte_core_ext") and f.endswith(".so"):
+            if f.startswith("clio_cte_core_ext") and f.endswith(_EXT_SUFFIXES):
                 return True
     return False
 
@@ -138,6 +176,6 @@ def cee_available():
     """Check if the Context Exploration Engine extension is available."""
     if os.path.isdir(_EXT_DIR):
         for f in os.listdir(_EXT_DIR):
-            if f.startswith("clio_cee") and f.endswith(".so"):
+            if f.startswith("clio_cee") and f.endswith(_EXT_SUFFIXES):
                 return True
     return False

--- a/installers/pip/iowarp_core/_cli.py
+++ b/installers/pip/iowarp_core/_cli.py
@@ -1,58 +1,85 @@
 """CLI entry points for bundled IOWarp binaries.
 
-Locates a named binary bundled in the wheel (under ``iowarp_core/bin/``)
-and exec's it after ensuring IOWarp shared libraries are on the library
-search path.  Each ``[project.scripts]`` entry in pyproject.toml routes
-to a thin wrapper around ``_exec_iowarp_bin``.
+Locates a named binary under ``iowarp_core/bin/`` (auto-adding the
+``.exe`` suffix on Windows), wires up the platform's shared-library
+search path, and runs it. Each ``[project.scripts]`` entry in
+pyproject.toml routes to a thin wrapper around ``_exec_iowarp_bin``.
 """
 
 import importlib
 import os
+import subprocess
 import sys
 
 
-def _exec_iowarp_bin(name):
-    """Find ``iowarp_core/bin/<name>``, prepend ``lib/`` to LD_LIBRARY_PATH,
-    and replace the current process with it.
+def _locate_bin(name):
+    """Return (bin_path, bin_dir, lib_dir) for the named binary.
 
-    In scikit-build-core editable installs, ``__file__`` resolves to the
-    workspace source tree, but cmake-built artifacts (binaries, .so libs)
-    live in ``site-packages/iowarp_core/``.  Anchor to site-packages by
-    importing a cmake-built extension module — the editable finder always
-    serves those from site-packages — and walking from its .so location.
+    Tries the site-packages route via an installed cmake-built ext
+    module first (works around editable installs where ``__file__``
+    points at the source tree), then falls back to the directory of
+    this _cli.py file (normal wheel installs).
     """
-    bin_path = None
-    lib_dir = None
+    exe = name + (".exe" if sys.platform == "win32" else "")
+
     for _extmod in ("clio_cte_core_ext", "clio_cee"):
         try:
             _m = importlib.import_module(_extmod)
             _sp = os.path.dirname(os.path.abspath(_m.__file__))
-            _candidate = os.path.join(_sp, "iowarp_core", "bin", name)
+            _candidate = os.path.join(_sp, "iowarp_core", "bin", exe)
             if os.path.exists(_candidate):
-                bin_path = _candidate
-                lib_dir = os.path.join(_sp, "iowarp_core", "lib")
-                break
+                return (
+                    _candidate,
+                    os.path.dirname(_candidate),
+                    os.path.join(_sp, "iowarp_core", "lib"),
+                )
         except (ImportError, AttributeError):
             continue
 
-    if bin_path is None:
-        # Fallback for regular (non-editable) installs where _cli.py lives
-        # inside site-packages/iowarp_core/ itself.
-        package_dir = os.path.dirname(os.path.abspath(__file__))
-        bin_path = os.path.join(package_dir, "bin", name)
-        lib_dir = os.path.join(package_dir, "lib")
+    # Fallback: regular wheel install where _cli.py is inside
+    # site-packages/iowarp_core/ itself.
+    package_dir = os.path.dirname(os.path.abspath(__file__))
+    candidate = os.path.join(package_dir, "bin", exe)
+    return candidate, os.path.join(package_dir, "bin"), os.path.join(package_dir, "lib")
 
+
+def _exec_iowarp_bin(name):
+    """Find ``iowarp_core/bin/<name>[.exe]``, set the platform's
+    dynamic-loader search path, and run it.
+    """
+    bin_path, bin_dir, lib_dir = _locate_bin(name)
     if not os.path.exists(bin_path):
-        print(f"Error: {name} binary not found at {bin_path}", file=sys.stderr)
+        exe = name + (".exe" if sys.platform == "win32" else "")
+        print(f"Error: {exe} binary not found at {bin_path}", file=sys.stderr)
         sys.exit(1)
 
-    ld_path = os.environ.get("LD_LIBRARY_PATH", "")
-    if lib_dir not in ld_path:
-        os.environ["LD_LIBRARY_PATH"] = (
-            lib_dir + ":" + ld_path if ld_path else lib_dir
+    env = os.environ.copy()
+    if sys.platform == "win32":
+        # CMake places .dll files in bin/ next to .exe files on
+        # Windows, so the standard DLL search (which checks the
+        # .exe's own dir first) handles the common case. Prepending
+        # bin/ + lib/ to PATH is belt-and-braces for cases where the
+        # spawned binary itself spawns a child that isn't co-located
+        # with its DLLs.
+        env["PATH"] = (
+            bin_dir + os.pathsep + lib_dir + os.pathsep + env.get("PATH", "")
         )
+        # os.execve has odd Windows semantics: cmd.exe doesn't really
+        # see the replaced process, argv quoting goes through MSVCRT,
+        # and the parent prompt returns control immediately. Use
+        # subprocess.run and forward the exit code instead.
+        result = subprocess.run([bin_path] + sys.argv[1:], env=env)
+        sys.exit(result.returncode)
 
-    os.execve(bin_path, [bin_path] + sys.argv[1:], os.environ)
+    if sys.platform == "darwin":
+        env_var = "DYLD_LIBRARY_PATH"
+    else:
+        env_var = "LD_LIBRARY_PATH"
+    existing = env.get(env_var, "")
+    env[env_var] = (
+        lib_dir + os.pathsep + existing if existing else lib_dir
+    )
+    os.execve(bin_path, [bin_path] + sys.argv[1:], env)
 
 
 def main():


### PR DESCRIPTION
## Summary
- Fix `chimaera.exe` missing from Windows wheels (CMake install hooks checked for `clio_run` without `.exe` suffix)
- Make `_cli.py` Windows-aware: `.exe` suffix, `PATH` instead of `LD_LIBRARY_PATH`, `os.pathsep`, `subprocess.run` instead of `os.execve`
- Make `__init__.py` setup three-way: Windows uses `os.add_dll_directory`, macOS uses rpaths, Linux keeps the `RTLD_GLOBAL` preload loop
- Update `cte_available()`/`cee_available()` to accept `.pyd` alongside `.so`
- Add `test-wheels-windows` CI job (native venv smoke test) to catch this regression class — v1.9.0 shipped a broken Windows wheel because there was no Windows-side test gate
- Bump CMakeLists.txt to **1.9.1** (1.9.0 wheels are immutable on PyPI)

## Root cause of the v1.9.0 Windows breakage
1. `EXISTS .../bin/clio_run` check in two `install(CODE)` blocks silently no-op'd on Windows (file is `clio_run.exe`), so `chimaera.exe` was never created in the wheel.
2. Entry-point script `chimaera` → `_cli.py:_exec_iowarp_bin("chimaera")` then looked for a non-existent file.
3. Even with chimaera.exe present, `_cli.py` would have set `LD_LIBRARY_PATH` (a no-op on Windows) and called `os.execve` (broken argv semantics on Windows).
4. The `.pyd` extension modules in `iowarp_core/ext/` would not find their `clio_*.dll` deps in `iowarp_core/bin/` because Python 3.8+ on Windows restricts `LoadLibraryEx` to the .pyd's own dir + system32 by default — needs `os.add_dll_directory(bin_dir)`.

## Test plan
- [ ] CI: `Test Windows wheels` job passes on this branch
- [ ] After merge + tag `v1.9.1`: PyPI ships 16 wheels (4 Python × 4 platforms)
- [ ] After publish: `pip install iowarp-core==1.9.1` on Windows → `chimaera --help` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)