### PR TITLE
fix(ci-packaging): make build-packages.yml actually run on tag pushes

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -35,12 +35,17 @@ jobs:
         echo "Version check passed."
 
   #-----------------------------------------------------------------------
-  # Build .deb on Ubuntu (devcontainer has all build dependencies)
+  # Build .deb on Ubuntu
+  #
+  # Previously ran inside `iowarp/clio-core-devcontainer:latest`, which is
+  # not pulled into a public registry the GHA runner can access (Docker
+  # pull failed with "access denied" at v1.9.0). Run natively on
+  # ubuntu-latest and `apt-get install` deps inline — same shape the RPM
+  # job already uses for Fedora.
   #-----------------------------------------------------------------------
   build-deb:
     name: Build Debian package
     runs-on: ubuntu-latest
-    container: iowarp/clio-core-devcontainer:latest
     needs: [check-version]
     if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     steps:
@@ -49,6 +54,14 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          cmake ninja-build build-essential pkg-config \
+          libzmq3-dev libyaml-cpp-dev libcereal-dev libmsgpack-dev \
+          libsodium-dev
 
     - name: Configure with CMake
       run: |
@@ -74,6 +87,10 @@ jobs:
 
   #-----------------------------------------------------------------------
   # Build .rpm on Fedora (in a container)
+  #
+  # fedora:40 ships without git in the base image, so actions/checkout@v4
+  # falls back to the REST API which doesn't support submodules. Install
+  # git BEFORE the checkout step so it can use the native git path.
   #-----------------------------------------------------------------------
   build-rpm:
     name: Build RPM package
@@ -82,15 +99,20 @@ jobs:
     needs: [check-version]
     if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     steps:
+    - name: Install git (required for actions/checkout submodule mode)
+      run: dnf install -y git
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
 
-    - name: Install dependencies
+    - name: Install build dependencies
       run: |
-        dnf install -y cmake ninja-build gcc-c++ zeromq-devel yaml-cpp-devel cereal-devel msgpack-devel rpm-build
+        dnf install -y cmake ninja-build gcc-c++ pkgconf-pkg-config \
+          zeromq-devel yaml-cpp-devel cereal-devel msgpack-devel \
+          libsodium-devel rpm-build
 
     - name: Configure with CMake
       run: |
@@ -116,14 +138,16 @@ jobs:
         path: build-rpm/*.rpm
 
   #-----------------------------------------------------------------------
-  # Build AppImage on Ubuntu (devcontainer has all build dependencies)
+  # Build AppImage on Ubuntu
   # appimagetool is downloaded at build time; APPIMAGE_EXTRACT_AND_RUN=1
   # lets it run without a FUSE mount (no --privileged needed).
+  #
+  # Same devcontainer-image fix as build-deb: run natively on
+  # ubuntu-latest with deps installed inline.
   #-----------------------------------------------------------------------
   build-appimage:
     name: Build AppImage
     runs-on: ubuntu-latest
-    container: iowarp/clio-core-devcontainer:latest
     needs: [check-version]
     if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     steps:
@@ -132,6 +156,14 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          cmake ninja-build build-essential pkg-config wget file \
+          libzmq3-dev libyaml-cpp-dev libcereal-dev libmsgpack-dev \
+          libsodium-dev
 
     - name: Configure with CMake
       run: |
@@ -155,6 +187,12 @@ jobs:
 
   #-----------------------------------------------------------------------
   # Publish all artifacts to GitHub Release on tag
+  #
+  # softprops/action-gh-release appends to an existing release when one
+  # exists (created by build-pip.yml's github-release job), or creates a
+  # new one if not. fail_on_unmatched_files=true so a missing artifact
+  # is surfaced as a job failure instead of silently shipping a partial
+  # release.
   #-----------------------------------------------------------------------
   publish-release:
     name: Publish to GitHub Release
@@ -185,9 +223,10 @@ jobs:
     - name: List packages
       run: ls -lh packages/
 
-    - name: Create GitHub Release
+    - name: Attach packages to GitHub Release
       uses: softprops/action-gh-release@v1
       with:
         files: packages/*
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Closes #444.

## Summary
v1.9.0 shipped wheels only — no .deb / .rpm / .AppImage — because the packaging workflow silently broke. Three independent failures, all fixed here:

1. **DEB + AppImage** dropped the `iowarp/clio-core-devcontainer:latest` container (image isn't in a public registry, pull returned 'access denied') and now run natively on `ubuntu-latest` with deps installed inline.
2. **RPM** installs `git` in the fedora:40 container before `actions/checkout@v4` runs, so submodule recursion uses the native git path instead of the REST API fallback (which doesn't support submodules).
3. **publish-release** now passes `fail_on_unmatched_files: true` so a missing artifact loudly fails the job instead of silently shipping a partial release.

## Test plan
- [ ] PR CI: the new branch-push run triggers DEB + RPM + AppImage builds (the `if: startsWith(github.ref, 'refs/tags/v')` gate on `publish-release` will skip the upload, but the build jobs will run on `workflow_dispatch` and via the manual trigger — or they'll run as part of the on-push behavior via the implicit branch coverage in `on:`). **Note**: the current `on:` block only triggers on tags + workflow_dispatch — PR pushes do NOT trigger this workflow. Maintainer should run via `gh workflow run "Build and Publish Binary Packages" --ref fix/444-build-packages-workflow` to validate, OR rely on the v1.9.1 tag as the final integration test.
- [ ] After merge: tag v1.9.1 and verify the GitHub Release has 16 wheels + 1 .deb + 1 .rpm + 1 .AppImage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)