### PR TITLE
fix(windows-pip): bundle vcpkg DLLs into the wheel via delvewheel

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -150,6 +150,19 @@ jobs:
           CLIO_CORE_ENABLE_BENCHMARKS=OFF
         CIBW_BUILD_FRONTEND: "build"
         CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
+        # Without this, cibuildwheel skips wheel repair on Windows entirely
+        # and the wheel ships with dangling imports to vcpkg DLLs (yaml-cpp,
+        # libzmq, libsodium, msgpack). delvewheel walks the wheel's PE
+        # import table, copies missing DLLs into iowarp_core.libs/, and
+        # rewrites loads via os.add_dll_directory at import time.
+        # --add-path points it at vcpkg's installed DLL dir so it can
+        # find the runtime libs corresponding to the .lib files cmake
+        # linked against. --no-mangle keeps the original DLL filenames
+        # so dependent loads (chimaera.exe → yaml-cpp.dll) still resolve.
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+          delvewheel repair -w {dest_dir} -v {wheel}
+          --add-path C:/vcpkg/installed/x64-windows/bin
+          --no-mangle-all
       run: cibuildwheel --output-dir installers/pip/wheelhouse
 
     - name: Upload Windows wheels

--- a/installers/pip/iowarp_core/_cli.py
+++ b/installers/pip/iowarp_core/_cli.py
@@ -55,14 +55,25 @@ def _exec_iowarp_bin(name):
 
     env = os.environ.copy()
     if sys.platform == "win32":
-        # CMake places .dll files in bin/ next to .exe files on
-        # Windows, so the standard DLL search (which checks the
-        # .exe's own dir first) handles the common case. Prepending
-        # bin/ + lib/ to PATH is belt-and-braces for cases where the
-        # spawned binary itself spawns a child that isn't co-located
-        # with its DLLs.
-        env["PATH"] = (
-            bin_dir + os.pathsep + lib_dir + os.pathsep + env.get("PATH", "")
+        # CMake places .dll files in bin/ next to .exe files on Windows,
+        # so the standard DLL search (which checks the .exe's own dir
+        # first) handles the IOWarp-owned DLLs. Third-party vcpkg DLLs
+        # (yaml-cpp, libzmq, libsodium, msgpack) get bundled by
+        # delvewheel into a sibling `iowarp_core.libs/` directory at
+        # site-packages root — find it and prepend to PATH so the
+        # spawned chimaera.exe / *_bench.exe can resolve those imports
+        # too. (Python imports of .pyd modules use the os.add_dll_directory
+        # registration that delvewheel installs into __init__.py, which
+        # doesn't propagate to subprocess children.)
+        search_dirs = [bin_dir, lib_dir]
+        pkg_dir = os.path.dirname(bin_dir)  # site-packages/iowarp_core
+        sp_root = os.path.dirname(pkg_dir)  # site-packages
+        delvewheel_libs = os.path.join(sp_root, "iowarp_core.libs")
+        if os.path.isdir(delvewheel_libs):
+            search_dirs.append(delvewheel_libs)
+        existing = env.get("PATH", "")
+        env["PATH"] = os.pathsep.join(
+            search_dirs + [existing] if existing else search_dirs
         )
         # os.execve has odd Windows semantics: cmd.exe doesn't really
         # see the replaced process, argv quoting goes through MSVCRT,


### PR DESCRIPTION
Closes #446.

## Summary
The v1.9.1-pre Windows wheel was shipping with dangling imports — `clio_run_cxx.dll` references `yaml-cpp.dll` and `libzmq-mt-4_3_5.dll`, neither bundled, so `chimaera.exe` failed to load on first launch. The new `Test Windows wheels` job catches this as exit -1 / no output ([run 26356683592](https://github.com/iowarp/clio-core/actions/runs/26356683592)).

## Fix
Two parts:

1. **cibuildwheel repair step.** Add `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS` running `delvewheel repair --add-path C:/vcpkg/installed/x64-windows/bin --no-mangle-all`. delvewheel walks PE imports, copies missing DLLs into `iowarp_core.libs/`, and patches our `__init__.py` to register the dir via `os.add_dll_directory` for in-process loads (Python `.pyd` extensions).
2. **subprocess PATH.** `_cli.py` Windows path now also prepends `iowarp_core.libs/` to the spawned child's PATH — `os.add_dll_directory` only affects the parent Python's LoadLibraryEx, and `chimaera.exe` is a fresh subprocess that needs its own DLL search.

`--no-mangle-all` keeps original DLL filenames since delvewheel doesn't rewrite `.exe` import tables (only `.pyd` and `.dll`); mangled names would leave `chimaera.exe` looking for the unmangled originals.

## Test plan
- [ ] PR CI: `Test Windows wheels` passes — `chimaera --help` returns 0 with usage output, benchmarks survive `--help` smoke.
- [ ] After merge: tag v1.9.1 → `pip install iowarp-core==1.9.1` on Windows + `chimaera --help` works.

## Relationship to #445
Independent. Both PRs target the v1.9.1 release. Merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)