### PR TITLE
chore(config): standardize user-config paths on ~/.clio/clio.yaml

### DIFF
--- a/context-runtime/CMakeLists.txt
+++ b/context-runtime/CMakeLists.txt
@@ -201,11 +201,13 @@ install(DIRECTORY config/
   FILES_MATCHING PATTERN "*"
 )
 
-# Seed the user's default config — both ~/.clio/clio.yaml (preferred) and
-# ~/.chimaera/chimaera.yaml (legacy) so either location continues to work
-# in the wild. Runtime lookup order is documented in
-# ConfigManager::GetServerConfigPath; the new ~/.clio takes priority.
-# Existing files are never overwritten.
+# Seed the user's default config at ~/.clio/clio.yaml — the canonical
+# user-config location the runtime checks first
+# (ConfigManager::GetServerConfigPath). Existing files are never
+# overwritten. Legacy ~/.chimaera/chimaera.yaml is still HONORED at
+# read time as a fallback for users with pre-existing configs, but we
+# no longer seed it on install — that path is documented as legacy
+# in docs/deprecation-notes.md and will eventually be removed.
 install(CODE "
   # Determine real user's home directory (handles sudo install)
   set(_HOME \"\")
@@ -232,8 +234,7 @@ install(CODE "
 
   # Per-destination seeding helper: directory + filename + optional chown
   foreach(_entry
-      \"\${_HOME}/.clio|clio.yaml\"       # new canonical location
-      \"\${_HOME}/.chimaera|chimaera.yaml\")  # legacy location, kept seeded
+      \"\${_HOME}/.clio|clio.yaml\")  # canonical user-config location
     string(REPLACE \"|\" \";\" _parts \"\${_entry}\")
     list(GET _parts 0 _DEST)
     list(GET _parts 1 _NAME)

--- a/context-runtime/config/chimaera_default.yaml
+++ b/context-runtime/config/chimaera_default.yaml
@@ -6,10 +6,12 @@
 #   - Context Transfer Engine / CTE (context-transfer-engine)
 #   - Context Assimilation Engine / CAE (context-assimilation-engine)
 #
-# Config lookup order:
-#   1. CLIO_SERVER_CONF environment variable
-#   2. CLIO_SERVER_CONF environment variable
-#   3. ~/.chimaera/chimaera.yaml
+# Config lookup order (canonical first; legacy paths kept for back-compat):
+#   1. $CLIO_SERVER_CONF (or legacy $CHI_SERVER_CONF) environment variable
+#   2. ~/.clio/clio.yaml
+#   3. ~/.clio/chimaera.yaml
+#   4. ~/.chimaera/clio.yaml
+#   5. ~/.chimaera/chimaera.yaml         (legacy)
 #
 # Size values accept: B, KB, MB, GB, TB (case-insensitive)
 # =============================================================================

--- a/docker/clio_cte_bench/docker-compose.yml
+++ b/docker/clio_cte_bench/docker-compose.yml
@@ -32,11 +32,11 @@ services:
 
     # Mount shared CTE configuration
     volumes:
-      - ./cte_config.yaml:/etc/iowarp/chimaera.yaml:ro
+      - ./cte_config.yaml:/etc/iowarp/clio.yaml:ro
 
     # Config lookup: CLIO_SERVER_CONF is checked first by the runtime
     environment:
-      - CLIO_SERVER_CONF=/etc/iowarp/chimaera.yaml
+      - CLIO_SERVER_CONF=/etc/iowarp/clio.yaml
 
     # Expose ZeroMQ port for client connections
     ports:

--- a/docker/clio_cte_bench/docker-stack.yml
+++ b/docker/clio_cte_bench/docker-stack.yml
@@ -22,7 +22,7 @@ services:
     image: iowarp/deploy-cpu:latest
     command: >
       bash -c "
-        clio_run runtime start --config /etc/iowarp/chimaera.yaml &
+        clio_run runtime start --config /etc/iowarp/clio.yaml &
         sleep 3 &&
         clio_cte_bench Put 2 4 1m 20 &&
         clio_run runtime stop
@@ -33,16 +33,16 @@ services:
         condition: none
     environment:
       - NODE_ID=1
-      - CLIO_SERVER_CONF=/etc/iowarp/chimaera.yaml
+      - CLIO_SERVER_CONF=/etc/iowarp/clio.yaml
     configs:
       - source: cte_config
-        target: /etc/iowarp/chimaera.yaml
+        target: /etc/iowarp/clio.yaml
 
   node2:
     image: iowarp/deploy-cpu:latest
     command: >
       bash -c "
-        clio_run runtime start --config /etc/iowarp/chimaera.yaml &
+        clio_run runtime start --config /etc/iowarp/clio.yaml &
         sleep 3 &&
         clio_cte_bench Put 2 4 1m 20 &&
         clio_run runtime stop
@@ -53,10 +53,10 @@ services:
         condition: none
     environment:
       - NODE_ID=2
-      - CLIO_SERVER_CONF=/etc/iowarp/chimaera.yaml
+      - CLIO_SERVER_CONF=/etc/iowarp/clio.yaml
     configs:
       - source: cte_config
-        target: /etc/iowarp/chimaera.yaml
+        target: /etc/iowarp/clio.yaml
 
 configs:
   cte_config:

--- a/docker/deploy-cpu.Dockerfile
+++ b/docker/deploy-cpu.Dockerfile
@@ -59,10 +59,11 @@ RUN sudo chown -R $(whoami):$(whoami) /workspace && \
     cmake --preset build-cpu-release -DCLIO_CORE_ENABLE_CONDA=OFF ../ && \
     sudo make -j$(nproc) install
 
-# Seed default config at ~/.chimaera/chimaera.yaml (picked up automatically by runtime)
-RUN mkdir -p /home/iowarp/.chimaera && \
+# Seed default config at ~/.clio/clio.yaml (the canonical user-config
+# location the runtime checks first; see ConfigManager::GetServerConfigPath).
+RUN mkdir -p /home/iowarp/.clio && \
     cp /workspace/context-runtime/config/chimaera_default.yaml \
-       /home/iowarp/.chimaera/chimaera.yaml
+       /home/iowarp/.clio/clio.yaml
 
 #------------------------------------------------------------
 # Final Deploy Image
@@ -84,7 +85,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/share /usr/local/share
 
 # Copy default config for runtime auto-discovery
-COPY --from=builder --chown=iowarp:iowarp /home/iowarp/.chimaera /home/iowarp/.chimaera
+COPY --from=builder --chown=iowarp:iowarp /home/iowarp/.clio /home/iowarp/.clio
 
 # Copy Jarvis-CD and jarvis_clio_core from builder
 COPY --from=builder /workspace/external/jarvis-cd /opt/jarvis-cd

--- a/docker/quickstart/README.md
+++ b/docker/quickstart/README.md
@@ -25,7 +25,7 @@ docker compose down
 
 ## Configuration
 
-Edit `chimaera.yaml` to customize the runtime. Key settings:
+Edit `clio.yaml` to customize the runtime. Key settings:
 
 | Section | What it controls |
 |---------|-----------------|

--- a/docker/quickstart/clio.yaml
+++ b/docker/quickstart/clio.yaml
@@ -6,10 +6,12 @@
 #   - Context Transfer Engine / CTE (context-transfer-engine)
 #   - Context Assimilation Engine / CAE (context-assimilation-engine)
 #
-# Config lookup order:
-#   1. CLIO_SERVER_CONF environment variable
-#   2. CLIO_SERVER_CONF environment variable
-#   3. ~/.chimaera/chimaera.yaml
+# Config lookup order (canonical first, legacy paths kept for back-compat):
+#   1. $CLIO_SERVER_CONF (or legacy $CHI_SERVER_CONF) environment variable
+#   2. ~/.clio/clio.yaml
+#   3. ~/.clio/chimaera.yaml
+#   4. ~/.chimaera/clio.yaml
+#   5. ~/.chimaera/chimaera.yaml         (legacy)
 #
 # Size values accept: B, KB, MB, GB, TB (case-insensitive)
 # =============================================================================

--- a/docker/quickstart/docker-compose.yml
+++ b/docker/quickstart/docker-compose.yml
@@ -13,11 +13,11 @@ services:
     container_name: iowarp-quickstart
     hostname: iowarp
     volumes:
-      - ./chimaera.yaml:/etc/iowarp/chimaera.yaml:ro
+      - ./clio.yaml:/etc/iowarp/clio.yaml:ro
     environment:
-      - CLIO_SERVER_CONF=/etc/iowarp/chimaera.yaml
+      - CLIO_SERVER_CONF=/etc/iowarp/clio.yaml
     ports:
       - "9413:9413"
     mem_limit: 8g
-    command: ["chimaera", "runtime", "start"]
+    command: ["clio_run", "start"]
     restart: unless-stopped

--- a/installers/pip/iowarp_core/__init__.py
+++ b/installers/pip/iowarp_core/__init__.py
@@ -106,23 +106,22 @@ def _setup():
     if os.path.isdir(_EXT_DIR) and _EXT_DIR not in sys.path:
         sys.path.insert(0, _EXT_DIR)
 
-    # Seed the per-user default config from the bundled default if missing.
-    # Both ~/.clio/clio.yaml (preferred) AND ~/.chimaera/chimaera.yaml
-    # (legacy) are seeded so the runtime's lookup hits a file regardless of
-    # which layout the user has migrated to. The C++ runtime checks the new
-    # path first; see ConfigManager::GetServerConfigPath.
+    # Seed the per-user default config at ~/.clio/clio.yaml if missing.
+    # This is the canonical user-config path the C++ runtime checks
+    # first; see ConfigManager::GetServerConfigPath. Legacy
+    # ~/.chimaera/chimaera.yaml is still honored at read time as a
+    # fallback for users with pre-existing configs, but we no longer
+    # seed it on install.
     _bundled_default = os.path.join(_DATA_DIR, "chimaera_default.yaml")
     if os.path.exists(_bundled_default):
-        for _dir, _name in (("~/.clio", "clio.yaml"),
-                            ("~/.chimaera", "chimaera.yaml")):
-            _user_conf_dir = os.path.expanduser(_dir)
-            _user_conf = os.path.join(_user_conf_dir, _name)
-            if not os.path.exists(_user_conf):
-                try:
-                    os.makedirs(_user_conf_dir, exist_ok=True)
-                    shutil.copy2(_bundled_default, _user_conf)
-                except OSError:
-                    pass  # read-only home, containerised, etc.
+        _user_conf_dir = os.path.expanduser("~/.clio")
+        _user_conf = os.path.join(_user_conf_dir, "clio.yaml")
+        if not os.path.exists(_user_conf):
+            try:
+                os.makedirs(_user_conf_dir, exist_ok=True)
+                shutil.copy2(_bundled_default, _user_conf)
+            except OSError:
+                pass  # read-only home, containerised, etc.
 
 
 _setup()

--- a/jarvis_clio_core/jarvis_clio_core/clio_compress/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_compress/pkg.py
@@ -225,9 +225,10 @@ class ClioCompress(Service):
         # ``KEY=VAL`` env vars to the command string; bash only attaches
         # those to a *simple* command, so a wrapping ``for ... do ...
         # done`` retry loop strips the env (notably CLIO_SERVER_CONF) and
-        # the clio_run compose client falls back to ~/.chimaera, picking
-        # up unrelated compose entries that occupy our target pool ID.
-        # Keep this a single command so the env prefix reaches chimaera.
+        # the clio_run compose client falls back to ~/.clio/clio.yaml,
+        # picking up unrelated compose entries that occupy our target
+        # pool ID. Keep this a single command so the env prefix reaches
+        # clio_run.
         cmd = f'clio_run compose {self.compose_config_path}'
 
         Exec(cmd, PsshExecInfo(

--- a/jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte/pkg.py
@@ -209,8 +209,8 @@ class ClioCte(Service):
         # as ``KEY=VAL`` before the command, and bash only forwards them
         # to a *simple* command — wrapping in ``for ... do ... done``
         # would strip the env (notably CLIO_SERVER_CONF), causing the
-        # clio_run compose client to fall back to ~/.chimaera and load
-        # unrelated compose entries that occupy our target pool IDs.
+        # clio_run compose client to fall back to ~/.clio/clio.yaml and
+        # load unrelated compose entries that occupy our target pool IDs.
         # The original retry loop existed for an Aurora apptainer
         # ZMTP-greeting race at >=64 daemons; for the bare-metal /
         # single-node path here the simple form is enough.

--- a/jarvis_clio_core/jarvis_clio_core/clio_runtime/Dockerfile.deploy
+++ b/jarvis_clio_core/jarvis_clio_core/clio_runtime/Dockerfile.deploy
@@ -33,7 +33,7 @@ COPY --from=builder /usr/local/lib     /usr/local/lib
 COPY --from=builder /usr/local/bin     /usr/local/bin
 COPY --from=builder /usr/local/share   /usr/local/share
 COPY --from=builder /usr/local/include /usr/local/include
-COPY --from=builder /root/.chimaera    /root/.chimaera
+COPY --from=builder /root/.clio        /root/.clio
 
 # Set up library paths and update cache
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/lib/x86_64-linux-gnu

--- a/jarvis_clio_core/jarvis_clio_core/clio_runtime/build.sh
+++ b/jarvis_clio_core/jarvis_clio_core/clio_runtime/build.sh
@@ -135,7 +135,9 @@ cmake --build build -j"$(nproc)"
 cmake --install build
 ldconfig
 
-# --- Seed default chimaera config ------------------------------------------
-mkdir -p /root/.chimaera
+# --- Seed default clio config ----------------------------------------------
+# ~/.clio/clio.yaml is the canonical user-config location the runtime
+# checks first; Dockerfile.deploy COPYs this dir from the builder.
+mkdir -p /root/.clio
 cp /opt/iowarp/context-runtime/config/chimaera_default.yaml \
-   /root/.chimaera/chimaera.yaml
+   /root/.clio/clio.yaml


### PR DESCRIPTION
## What
Switch every Docker image, CI workflow, jarvis package, and installer in the parent repo that touched the user-side config from the legacy `~/.chimaera/chimaera.yaml` spelling to the canonical `~/.clio/clio.yaml`. The C++ runtime already prefers `~/.clio/clio.yaml` and keeps the older paths as a read-time fallback (see `ConfigManager::GetServerConfigPath`), so existing user installs with `~/.chimaera/chimaera.yaml` continue to work unchanged.

## Files changed (13)

| File | Change |
|---|---|
| `docker/deploy-cpu.Dockerfile` | Seed + COPY `/home/iowarp/.clio` instead of `.chimaera` |
| `docker/quickstart/{chimaera.yaml → clio.yaml}` | Rename (file) |
| `docker/quickstart/docker-compose.yml` | Volume + env-var point at `clio.yaml`; `command:` switched to `clio_run start` |
| `docker/quickstart/README.md` | Reference renamed file |
| `docker/clio_cte_bench/docker-compose.yml` | Mount target + CLIO_SERVER_CONF → `/etc/iowarp/clio.yaml` |
| `docker/clio_cte_bench/docker-stack.yml` | Same (6 occurrences) |
| `jarvis_clio_core/clio_runtime/build.sh` | Seed `/root/.clio/clio.yaml` (the deploy Dockerfile COPYs this) |
| `jarvis_clio_core/clio_runtime/Dockerfile.deploy` | `COPY /root/.clio` |
| `jarvis_clio_core/clio_cte/pkg.py` | Comment update only (referenced `~/.chimaera` fallback by name) |
| `jarvis_clio_core/clio_compress/pkg.py` | Comment update only |
| `installers/pip/iowarp_core/__init__.py` | Seed only `~/.clio/clio.yaml` on first import (was dual-seeding) |
| `context-runtime/CMakeLists.txt` | Install-time seeding writes only to `~/.clio/clio.yaml` |
| `context-runtime/config/chimaera_default.yaml` | Header comment now lists the actual lookup order |

## Out of scope (intentionally preserved)

- **Read-time fallback lookup chains** in `config_manager.cc`, `installers/pip/iowarp_core/_config.py`, and `context-visualizer/api/config.py`. These walk `~/.clio/clio.yaml`, `~/.clio/chimaera.yaml`, `~/.chimaera/clio.yaml`, `~/.chimaera/chimaera.yaml` in order so pre-existing user configs keep working. The legacy entries are documented as deprecated.
- **`docs/deprecation-notes.md`** and the legacy-path callouts in `docs/deployment/{configuration,monitoring}.md` + `README.md` — those explicitly describe the deprecation and need to keep mentioning the old paths.
- **Module / library / namespace names** (`chimaera_bdev`, `libchimaera_cxx`, `chimaera::*`, `<chimaera/chimaera.h>`). Those aren't config paths.
- **`docs/` submodule**: one remaining `export CLIO_SERVER_CONF=/etc/iowarp/chimaera.yaml` example in `docs/deployment/configuration.md` needs a follow-up PR against `iowarp/docs`. Not touched here so the submodule pointer stays at `913f7d7c`.

## Test plan
- [ ] Docker quickstart still starts: `docker compose -f docker/quickstart/docker-compose.yml up -d` mounts `./clio.yaml` and the runtime picks it up via `CLIO_SERVER_CONF=/etc/iowarp/clio.yaml`.
- [ ] `pip install` of the wheel from this branch creates `~/.clio/clio.yaml` and no longer creates `~/.chimaera/chimaera.yaml`.
- [ ] Users with a pre-existing `~/.chimaera/chimaera.yaml` still load it (no regression — handled by the runtime's read-time fallback chain).
- [ ] `sudo cmake --install build` seeds `~/.clio/clio.yaml` only (legacy path no longer auto-seeded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)