### PR TITLE
docs: add INSTALL.md and drop 'chimaera' brand from README + docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,255 @@
+# Installing CLIO Core from Source
+
+This guide is for building **CLIO Core from source on a bare-metal Linux
+host**. It enumerates every system dependency, when each is required,
+and the `apt` / `dnf` package names that satisfy them.
+
+> **If you do not need to extend the C++ side or enable hardware-specific
+> features, install a pre-built binary instead — no system packages are
+> required.**
+>
+> | Channel  | Command                                  | Includes                                                                 |
+> | -------- | ---------------------------------------- | ------------------------------------------------------------------------ |
+> | pip      | `pip install iowarp-core`                | CLIO runtime, CTE, CAE, CEE; `clio_run` / `clio_cte_bench` CLIs; Python `clio_cee` |
+> | conda    | `bash install.sh release` (uses Miniconda) | Same as pip; pulls deps from conda-forge instead of statically linking |
+> | release  | [GitHub Releases](https://github.com/iowarp/clio-core/releases) | `.deb`, `.rpm`, `.AppImage` per tag (currently v1.9.1+) |
+>
+> Source builds are necessary only when you want CUDA / ROCm / SYCL,
+> MPI, HDF5 / ADIOS2 / FUSE adapters, sanitizer builds, or custom
+> ChiMods written against the C++ headers.
+
+---
+
+## 1. Always-required system prerequisites
+
+These are needed for *every* source build, regardless of which optional
+features you enable.
+
+| Need              | Why                                                 | apt (Ubuntu 22.04+)                                            | dnf (Fedora 40+ / RHEL 9+)                                   |
+| ----------------- | --------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------ |
+| C++20 compiler    | GCC ≥ 11 or Clang ≥ 14                              | `build-essential` (GCC 13 on 24.04)                            | `gcc-c++` (GCC 14 on Fedora 40)                              |
+| CMake ≥ 3.20      | Build system                                        | `cmake`                                                        | `cmake`                                                      |
+| Ninja or Make     | Build driver (Ninja recommended)                    | `ninja-build`                                                  | `ninja-build`                                                |
+| pkg-config        | Some deps published via pkg-config                  | `pkg-config`                                                   | `pkgconf-pkg-config`                                         |
+| Git + submodules  | Source + vendored deps                              | `git`                                                          | `git`                                                        |
+| Python ≥ 3.10     | Build scripts, Python bindings (if enabled)        | `python3 python3-pip python3-venv`                             | `python3 python3-pip`                                        |
+| yaml-cpp ≥ 0.7    | Config-file parser                                  | `libyaml-cpp-dev`                                              | `yaml-cpp-devel`                                             |
+| Cereal            | C++ serialization (header-only)                     | `libcereal-dev`                                                | `cereal-devel`                                               |
+| msgpack-c ≥ 5     | Wire serialization                                  | `libmsgpack-dev`                                               | `msgpack-devel`                                              |
+| libsodium         | Crypto primitives used by ZeroMQ                    | `libsodium-dev`                                                | `libsodium-devel`                                            |
+| ZeroMQ ≥ 4.3      | RPC transport (default; can be disabled)            | `libzmq3-dev`                                                  | `zeromq-devel`                                               |
+
+### Quick install — apt (Debian / Ubuntu)
+
+```bash
+sudo apt update
+sudo apt install -y --no-install-recommends \
+  build-essential cmake ninja-build pkg-config git \
+  python3 python3-pip python3-venv \
+  libyaml-cpp-dev libcereal-dev libmsgpack-dev libsodium-dev libzmq3-dev
+```
+
+### Quick install — dnf (Fedora / RHEL / Rocky)
+
+```bash
+sudo dnf install -y \
+  gcc-c++ cmake ninja-build pkgconf-pkg-config git \
+  python3 python3-pip \
+  yaml-cpp-devel cereal-devel msgpack-devel libsodium-devel zeromq-devel
+```
+
+---
+
+## 2. Optional features and their dependencies
+
+Each feature is opt-in via a CMake `-D<FLAG>=ON` switch. Enabling a flag
+without its dependency available will fail at configure time with a
+`find_package` error pointing at the missing component.
+
+### Networking + RPC
+
+| Feature                       | CMake flag                       | apt                                | dnf                                | Notes                                                                |
+| ----------------------------- | -------------------------------- | ---------------------------------- | ---------------------------------- | -------------------------------------------------------------------- |
+| MPI (multi-node deployment)   | `CLIO_CORE_ENABLE_MPI=ON`        | `libopenmpi-dev openmpi-bin`       | `openmpi-devel`                    | Or MPICH (`libmpich-dev` / `mpich-devel`); auto-detected.            |
+| libfabric (OFI transport)     | `CLIO_CORE_ENABLE_LIBFABRIC=ON`  | `libfabric-dev`                    | `libfabric-devel`                  | Alternative to ZeroMQ on RDMA-capable fabrics.                       |
+| Thallium (Mochi RPC)          | `CLIO_CORE_ENABLE_THALLIUM=ON`   | *via Spack / conda-forge*          | *via Spack / conda-forge*          | Not packaged in distro repos; install via Spack or build from source.|
+| io\_uring                     | `CLIO_CORE_ENABLE_IO_URING=ON`   | `liburing-dev`                     | `liburing-devel`                   | Linux 5.1+ only. Auto-fallback to libaio / pread+pwrite if disabled. |
+
+### Compression (`CLIO_CTE_ENABLE_COMPRESS=ON`)
+
+Pulls in every codec at once. Trim the list by editing
+`context-transfer-engine/CMakeLists.txt` if you only need a subset.
+
+| apt                                                                                                    | dnf                                                                                                |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `libzstd-dev liblz4-dev zlib1g-dev liblzma-dev libbrotli-dev libblosc2-dev`                            | `libzstd-devel lz4-devel zlib-devel xz-devel libbrotli-devel blosc2-devel`                         |
+
+LibPressio is also linked in if found (build from source — not in
+distro repos).
+
+### Encryption
+
+| Feature                   | CMake flag                      | apt           | dnf                |
+| ------------------------- | ------------------------------- | ------------- | ------------------ |
+| OpenSSL (libcrypto)       | `CLIO_CORE_ENABLE_ENCRYPT=ON`   | `libssl-dev`  | `openssl-devel`    |
+
+### CTE Adapters
+
+| Adapter                      | CMake flag                              | apt                                  | dnf                                | Notes                                                  |
+| ---------------------------- | --------------------------------------- | ------------------------------------ | ---------------------------------- | ------------------------------------------------------ |
+| POSIX file I/O               | `CLIO_CTE_ENABLE_POSIX_ADAPTER=ON`*     | *(always available)*                 | *(always available)*               | **Default ON.** No extra deps.                         |
+| STDIO (fopen / fread / fwrite) | `CLIO_CTE_ENABLE_STDIO_ADAPTER=ON`    | *(always available)*                 | *(always available)*               | No extra deps.                                         |
+| MPI-IO                       | `CLIO_CTE_ENABLE_MPIIO_ADAPTER=ON`      | `libopenmpi-dev`                     | `openmpi-devel`                    | Requires `CLIO_CORE_ENABLE_MPI=ON`.                    |
+| HDF5 VFD                     | `CLIO_CTE_ENABLE_VFD=ON`                | `libhdf5-dev`                        | `hdf5-devel`                       | Adds CLIO as a custom VFD to HDF5 client apps.         |
+| HDF5 VOL (≥ HDF5 2.0)        | `CLIO_CTE_ENABLE_HDF5_VOL=ON`           | *(HDF5 2.0 not in apt yet — source)* | *(HDF5 2.0 not in dnf yet — source)* | Higher-level than VFD; full virtual object layer.    |
+| ADIOS2                       | `CLIO_CTE_ENABLE_ADIOS2_ADAPTER=ON`     | *via Spack / source*                 | *via Spack / source*               | Pulls in `ADIOS2::adios2` CMake target.                |
+| FUSE3 (filesystem mount)     | `CLIO_CTE_ENABLE_FUSE_ADAPTER=ON`       | `libfuse3-dev fuse3`                 | `fuse3-devel fuse3`                | Mount CTE storage as a POSIX FS via FUSE.              |
+| NVIDIA GDS (GPU Direct Storage) | `CLIO_CTE_ENABLE_NVIDIA_GDS_ADAPTER=ON` | *NVIDIA CUDA Toolkit*               | *NVIDIA CUDA Toolkit*              | Requires `CLIO_CORE_ENABLE_CUDA=ON` and a CUDA install. |
+
+### GPU acceleration
+
+| Feature                | CMake flag                           | Notes                                                                                                  |
+| ---------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| NVIDIA CUDA            | `CLIO_CORE_ENABLE_CUDA=ON`           | NVIDIA HPC SDK or CUDA Toolkit 11.8+ installed (`nvcc` on PATH). Tested with sm_70+.                   |
+| GPU runtime (CDP)      | `CLIO_CORE_ENABLE_GPU_RUNTIME=ON`    | Requires CUDA. Enables Dynamic Parallelism for kernel-side task launch.                                |
+| AMD ROCm               | `CLIO_CORE_ENABLE_ROCM=ON`           | ROCm 5.5+ (`hipcc` on PATH; `find_package(HIP)` succeeds).                                              |
+| Intel SYCL (oneAPI)    | `CLIO_CORE_ENABLE_SYCL=ON`           | oneAPI DPC++ (`icpx -fsycl`) installed. Targets Intel GPUs + SYCL-2020 CPU targets.                    |
+| NVSHMEM                | `CLIO_CORE_ENABLE_NVSHMEM=ON`        | NVSHMEM library installed (NVIDIA HPC SDK or standalone). GPU-to-GPU direct messaging.                  |
+| NIXL (NVIDIA xfer)     | `CLIO_CORE_ENABLE_NIXL=ON`           | NVIDIA Inference Transfer Library. Source-only.                                                         |
+
+### Python bindings + bench tools
+
+| Feature                | CMake flag                           | Notes                                                              |
+| ---------------------- | ------------------------------------ | ------------------------------------------------------------------ |
+| Python bindings        | `CLIO_CORE_ENABLE_PYTHON=ON`         | Builds `clio_cee` and `clio_cte_core_ext` Python modules. Requires Python 3.10+ headers (`python3-dev` / `python3-devel`). |
+| OpenMP                 | `CLIO_CORE_ENABLE_OPENMP=ON`         | Some benchmark loops use OpenMP. Compiler-provided (no system pkg). |
+| Redis bench            | `CLIO_CORE_ENABLE_REDIS=ON`          | Builds the head-to-head Redis comparison benchmark. `libhiredis-dev` / `hiredis-devel`. |
+| LLM hooks (llama.cpp)  | `CLIO_CORE_ENABLE_LLAMA=ON`          | Integrates the bundled `external/llama.cpp` submodule.             |
+| Globus transfer (CAE)  | `CAE_ENABLE_GLOBUS=ON`               | Globus toolkit installed and on PATH.                              |
+
+### Testing + diagnostics
+
+| Feature                  | CMake flag                       | Notes                                                                  |
+| ------------------------ | -------------------------------- | ---------------------------------------------------------------------- |
+| Unit + integration tests | `CLIO_CORE_ENABLE_TESTS=ON`      | Pulls in Catch2 via FetchContent (no system dep).                       |
+| AddressSanitizer + LSan  | `CLIO_CORE_ENABLE_ASAN=ON`       | Compiler-provided (`-fsanitize=address`).                                |
+| UBSan                    | `CLIO_CORE_ENABLE_UBSAN=ON`      | Compiler-provided.                                                       |
+| MSan                     | `CLIO_CORE_ENABLE_MSAN=ON`       | Clang only; requires MSan-instrumented libc++.                          |
+| Coverage (gcov / llvm-cov)| `CLIO_CORE_ENABLE_COVERAGE=ON`  | `lcov` (apt) / `lcov` (dnf) for HTML reports.                            |
+| Doxygen                  | `CLIO_CORE_ENABLE_DOXYGEN=ON`    | `doxygen perl` (apt) / `doxygen perl` (dnf).                             |
+
+---
+
+## 3. Building from source
+
+```bash
+git clone --recurse-submodules https://github.com/iowarp/clio-core.git
+cd clio-core
+
+# Pick a preset (CMakePresets.json lists all of them):
+#   release           — default, no GPU
+#   cuda-release      — CUDA enabled
+#   rocm-debug        — ROCm + debug symbols
+#   sycl-debug        — SYCL + debug
+#   release-adapter   — release + ADIOS2 + HDF5 VOL + FUSE3
+#   release-fuse      — release + just FUSE3
+#   asan / ubsan / msan / sanitize — sanitizer builds
+cmake --preset release
+cmake --build build/release -j$(nproc)
+sudo cmake --install build/release
+```
+
+The install seeds a default runtime config at `~/.clio/clio.yaml` and
+exports CMake config files under `lib/cmake/iowarp-core/` so downstream
+projects can `find_package(iowarp-core)`.
+
+If you already cloned without submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+---
+
+## 4. Feature checklist
+
+Tick what you need; copy the matching `-D` flags into your `cmake`
+invocation (or add them to a custom preset under
+`installers/conda/variants/` if you use the Conda flow).
+
+```
+Core components (all ON by default)
+─────────────────────────────────
+[x] CLIO_CORE_ENABLE_RUNTIME=ON       Runtime + scheduler
+[x] CLIO_CORE_ENABLE_CTE=ON           Context Transfer Engine
+[x] CLIO_CORE_ENABLE_CAE=ON           Context Assimilation Engine
+[x] CLIO_CORE_ENABLE_CEE=ON           Context Exploration Engine
+
+Transports (ZMQ ON by default)
+─────────────────────────────────
+[x] CLIO_CORE_ENABLE_ZMQ=ON           ZeroMQ
+[ ] CLIO_CORE_ENABLE_MPI=ON           MPI (multi-node)
+[ ] CLIO_CORE_ENABLE_LIBFABRIC=ON     libfabric (OFI)
+[ ] CLIO_CORE_ENABLE_THALLIUM=ON      Thallium / Mochi
+[ ] CLIO_CORE_ENABLE_IO_URING=ON      io_uring async I/O (Linux 5.1+)
+
+GPU / accelerators
+─────────────────────────────────
+[ ] CLIO_CORE_ENABLE_CUDA=ON          NVIDIA CUDA
+[ ] CLIO_CORE_ENABLE_GPU_RUNTIME=ON   CUDA Dynamic Parallelism
+[ ] CLIO_CORE_ENABLE_ROCM=ON          AMD ROCm / HIP
+[ ] CLIO_CORE_ENABLE_SYCL=ON          Intel oneAPI SYCL
+[ ] CLIO_CORE_ENABLE_NVSHMEM=ON       NVSHMEM GPU-to-GPU
+[ ] CLIO_CORE_ENABLE_NIXL=ON          NVIDIA NIXL
+
+CTE adapters (POSIX ON by default)
+─────────────────────────────────
+[x] CLIO_CTE_ENABLE_POSIX_ADAPTER=ON
+[ ] CLIO_CTE_ENABLE_STDIO_ADAPTER=ON
+[ ] CLIO_CTE_ENABLE_MPIIO_ADAPTER=ON  needs MPI
+[ ] CLIO_CTE_ENABLE_VFD=ON            HDF5 VFD
+[ ] CLIO_CTE_ENABLE_HDF5_VOL=ON       HDF5 VOL (HDF5 2.0+)
+[ ] CLIO_CTE_ENABLE_ADIOS2_ADAPTER=ON
+[ ] CLIO_CTE_ENABLE_FUSE_ADAPTER=ON   FUSE3 mount
+[ ] CLIO_CTE_ENABLE_NVIDIA_GDS_ADAPTER=ON  needs CUDA
+
+Compression + crypto (all OFF by default)
+─────────────────────────────────────────
+[ ] CLIO_CTE_ENABLE_COMPRESS=ON       zstd + lz4 + zlib + xz + brotli + blosc2
+[ ] CLIO_CORE_ENABLE_ENCRYPT=ON       OpenSSL libcrypto
+
+Misc
+─────────────────────────────────
+[ ] CLIO_CORE_ENABLE_PYTHON=ON        Python bindings (clio_cee + clio_cte_core_ext)
+[ ] CLIO_CORE_ENABLE_OPENMP=ON
+[ ] CLIO_CORE_ENABLE_REDIS=ON         Redis comparison benchmark (hiredis)
+[ ] CLIO_CORE_ENABLE_LLAMA=ON         llama.cpp LLM hooks
+[ ] CAE_ENABLE_GLOBUS=ON              Globus transfers in CAE
+
+Build profiles (mutually exclusive)
+─────────────────────────────────
+[ ] CMAKE_BUILD_TYPE=Release          default
+[ ] CMAKE_BUILD_TYPE=Debug
+[ ] CLIO_CORE_ENABLE_ASAN=ON
+[ ] CLIO_CORE_ENABLE_UBSAN=ON
+[ ] CLIO_CORE_ENABLE_MSAN=ON          Clang only
+[ ] CLIO_CORE_ENABLE_COVERAGE=ON
+```
+
+---
+
+## 5. Verifying the install
+
+```bash
+clio_run --help                          # should print CLIO Runtime usage
+clio_run start                           # foreground runtime; Ctrl-C to stop
+ctest --test-dir build/release           # if you built with CLIO_CORE_ENABLE_TESTS=ON
+```
+
+If `clio_run` is on `PATH`, the install succeeded. If the runtime exits
+immediately with a config error, check `~/.clio/clio.yaml` (seeded
+automatically at install time).
+
+For container-based deployment, see
+[`docker/quickstart/`](docker/quickstart/) for a single-node
+docker-compose recipe.

--- a/README.md
+++ b/README.md
@@ -22,18 +22,21 @@
 
 ## Overview
 
-**CLIO Core** is a unified framework that integrates multiple high-performance components for context management, data transfer, and scientific computing. Built with a modular architecture, CLIO Core enables developers to create efficient data processing pipelines for HPC, storage systems, and near-data computing applications.
+**CLIO Core** is a unified framework that integrates multiple high-performance
+components for context management, data transfer, and scientific computing.
+CLIO Core enables developers to build efficient data processing pipelines for
+HPC, storage systems, and near-data computing applications.
 
-CLIO Core provides:
-- **High-Performance Context Management**: Efficient handling of computational contexts and data transformations
-- **Heterogeneous-Aware I/O**: Multi-tiered, dynamic buffering for accelerated data access
-- **Modular Runtime System**: Extensible architecture with dynamically loadable processing modules
-- **Advanced Data Structures**: Shared memory compatible containers with GPU support (CUDA, ROCm)
-- **Distributed Computing**: Seamless scaling from single node to cluster deployments
+It provides:
+
+- **High-performance context management** for computational contexts and data
+  transformations.
+- **Heterogeneous-aware I/O** with multi-tiered, dynamic buffering.
+- **A modular runtime** with dynamically loadable processing modules.
+- **Shared-memory data structures** that work across host, CUDA, and ROCm.
+- **Distributed-by-construction** scaling from single node to clusters.
 
 ## Architecture
-
-CLIO Core follows a layered architecture integrating five core components:
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -52,8 +55,7 @@ CLIO Core follows a layered architecture integrating five core components:
         └─────────────────────┼─────────────────────┘
                               │
                     ┌─────────────────┐
-                    │  CLIO           │
-                    │  Runtime        │
+                    │  CLIO Runtime   │
                     │  (Module System)│
                     └─────────────────┘
                               │
@@ -68,20 +70,19 @@ CLIO Core follows a layered architecture integrating five core components:
 
 ### Pip (recommended)
 
-The pip wheel is the easiest way to get CLIO Core. It ships a
-**portable, self-contained build** with all dependencies statically
-linked. No system installs are required beyond glibc and Python 3.10+.
+The pip wheel ships a **portable, self-contained build** with all
+dependencies statically linked. No system installs are required beyond
+glibc and Python 3.10+.
 
 ```bash
 pip install iowarp-core
 ```
 
-The wheel includes the CLIO runtime, the `clio_run` CLI, the CTE,
-CAE, and CEE engines, and the `clio_cee` Python bindings. A default
-configuration is seeded at `~/.clio/clio.yaml` on first import.
+The wheel includes the CLIO runtime, the `clio_run` CLI, the CTE, CAE, and
+CEE engines, and the `clio_cee` Python bindings. A default configuration is
+seeded at `~/.clio/clio.yaml` on first import.
 
-Newer extensions and advanced/accelerated features are not in the
-portable wheel — switch to a source build below if you need any of:
+Switch to a source build below if you need any of:
 
 - NVIDIA GPU (CUDA) or AMD GPU (ROCm) acceleration
 - MPI for distributed multi-node deployment
@@ -99,424 +100,147 @@ cd clio-core
 bash install.sh release
 ```
 
-`release` corresponds to a variant stored under
-`installers/conda/variants/`. Other variants (`cuda`, `rocm`, `mpi`,
-`full`, `release-fuse`, `debug`, ...) enable the corresponding features.
-Feel free to add a new variant for your specific machine there.
+`release` corresponds to a variant under `installers/conda/variants/`. Other
+variants (`cuda`, `rocm`, `mpi`, `full`, `release-fuse`, `debug`, ...) enable
+the corresponding features.
 
-If you already cloned without submodules, initialize them with:
-
-```bash
-git submodule update --init --recursive
-```
-
-For a full **bare-metal source build** (without Conda) with the
-per-feature apt/dnf dependency list and a checklist of every
-`CLIO_*_ENABLE_*` flag, see [INSTALL.md](INSTALL.md).
-
-Other source-install methods (Docker, Spack) are documented in
+For a full **bare-metal source build** (without Conda) with the per-feature
+apt / dnf dependency list and the complete `CLIO_*_ENABLE_*` flag checklist,
+see [INSTALL.md](INSTALL.md). Other methods (Docker, Spack) are documented in
 [docs/getting-started/installation](docs/docs/getting-started/installation.mdx).
 
 ## Components
 
-CLIO Core consists of five integrated components, each with its own specialized functionality:
-
-### 1. Context Transport Primitives
-**Location:** [`context-transport-primitives/`](context-transport-primitives/)
-
-High-performance shared memory library containing data structures and synchronization primitives compatible with shared memory, CUDA, and ROCm.
-
-**Key Features:**
-- Shared memory compatible data structures (vector, list, unordered_map, queues)
-- GPU-aware allocators (CUDA, ROCm)
-- Thread synchronization primitives
-- Networking layer with ZMQ transport
-- Compression and encryption utilities
-
-**[Read more →](context-transport-primitives/README.md)**
-
-### 2. Context Runtime
-**Location:** [`context-runtime/`](context-runtime/)
-
-High-performance modular runtime for scientific computing and storage systems with coroutine-based task execution.
-
-**Key Features:**
-- Ultra-high performance task execution (< 10μs latency)
-- Modular Module system for dynamic extensibility
-- Coroutine-aware synchronization (CoMutex, CoRwLock)
-- Distributed architecture with shared memory IPC
-- Built-in storage backends (RAM, file-based, custom block devices)
-
-**[Read more →](context-runtime/README.md)**
-
-### 3. Context Transfer Engine
-**Location:** [`context-transfer-engine/`](context-transfer-engine/)
-
-Heterogeneous-aware, multi-tiered, dynamic I/O buffering system designed to accelerate I/O for HPC and data-intensive workloads.
-
-**Key Features:**
-- Programmable buffering across memory/storage tiers
-- Multiple I/O pathway adapters
-- Integration with HPC runtimes and workflows
-- Improved throughput, latency, and predictability
-
-**[Read more →](context-transfer-engine/README.md)**
-
-### 4. Context Assimilation Engine
-**Location:** [`context-assimilation-engine/`](context-assimilation-engine/)
-
-High-performance data ingestion and processing engine for heterogeneous storage systems and scientific workflows.
-
-**Key Features:**
-- OMNI format for YAML-based job orchestration
-- MPI-based parallel data processing
-- Binary format handlers (Parquet, CSV, custom formats)
-- Repository and storage backend abstraction
-- Integrity verification with hash validation
-
-**[Read more →](context-assimilation-engine/README.md)**
-
-### 5. Context Exploration Engine
-**Location:** [`context-exploration-engine/`](context-exploration-engine/)
-
-Interactive tools and interfaces for exploring scientific data contents and metadata.
-
-**Key Features:**
-- Model Context Protocol (MCP) for HDF5 data
-- HDF Compass viewer (wxPython-4 based)
-- Interactive data exploration interfaces
-- Metadata browsing capabilities
-
-**[Read more →](context-exploration-engine/README.md)**
+| Component | Location | Purpose |
+|---|---|---|
+| **Context Transport Primitives** | [`context-transport-primitives/`](context-transport-primitives/) | Shared-memory containers, allocators, sync primitives, networking (ZMQ / libfabric / Thallium). GPU-aware (CUDA, ROCm). |
+| **CLIO Runtime** | [`context-runtime/`](context-runtime/) | Coroutine-based modular runtime (< 10 µs task latency). Hosts ChiMods and provides admin + bdev modules. |
+| **Context Transfer Engine** | [`context-transfer-engine/`](context-transfer-engine/) | Multi-tiered, heterogeneous-aware I/O buffering. Tag + blob storage with adapters for POSIX, HDF5 (VFD/VOL), ADIOS2, MPI-IO, FUSE3, GDS. |
+| **Context Assimilation Engine** | [`context-assimilation-engine/`](context-assimilation-engine/) | OMNI-YAML-driven data ingestion (binary, HDF5, Globus) into CTE. |
+| **Context Exploration Engine** | [`context-exploration-engine/`](context-exploration-engine/) | High-level C++ and Python (`clio_cee`) API for bundling, querying, and retrieving data. Includes an MCP server for AI agents. |
 
 ## Quickstart
 
-### Starting the Runtime
+### Start the runtime
 
-Installation seeds a default configuration at `~/.clio/clio.yaml`, so
-the runtime works out of the box:
+Installation seeds a default configuration at `~/.clio/clio.yaml`, so the
+runtime works out of the box:
 
 ```bash
-# Foreground
-clio_run start
-
-# Background
-clio_run start &
+clio_run start          # foreground
+clio_run start &        # background
 ```
 
-To override the configuration, point `CLIO_X` at your YAML file:
+To override the configuration, point `CLIO_X` at your own YAML file:
 
 ```bash
 export CLIO_X=/path/to/my_config.yaml
 clio_run start
 ```
 
-(The legacy nested form `clio_run runtime start` still works for back-compat.)
-
-### Context Exploration Engine Python Example
-
-Here we show an example of how to use the context exploration engine to
-bundle and retrieve data.
+### Python: bundle, query, retrieve
 
 ```python
 import clio_cee as cee
 
-# Create ContextInterface (handles runtime initialization internally)
 ctx_interface = cee.ContextInterface()
 
-# Assimilate a file into IOWarp storage
+# Assimilate a file into IOWarp storage.
 ctx = cee.AssimilationCtx(
-    src="file::/path/to/data.bin",      # Source: local file
-    dst="iowarp::my_dataset",            # Destination: IOWarp tag
-    format="binary"                      # Format: binary, hdf5, etc.
+    src="file::/path/to/data.bin",
+    dst="iowarp::my_dataset",
+    format="binary",
 )
-result = ctx_interface.context_bundle([ctx])
-print(f"Assimilation result: {result}")
+ctx_interface.context_bundle([ctx])
 
-# Query for blobs matching a pattern
-blobs = ctx_interface.context_query(
-    "my_dataset",    # Tag name
-    ".*",            # Blob name regex (match all)
-    0                # Flags
-)
-print(f"Found blobs: {blobs}")
+# Query for blob names matching a regex.
+blobs = ctx_interface.context_query("my_dataset", ".*", 0)
 
-# Retrieve blob data
-packed_data = ctx_interface.context_retrieve(
-    "my_dataset",    # Tag name
-    ".*",            # Blob name regex
-    0                # Flags
-)
-print(f"Retrieved {len(packed_data)} bytes")
+# Retrieve blob payloads.
+data = ctx_interface.context_retrieve("my_dataset", ".*", 0)
 
-# Cleanup when done
+# Clean up.
 ctx_interface.context_destroy(["my_dataset"])
 ```
 
-### Context Transfer Engine C++ Example
+### C++ (CTE, direct)
 
-Here is an example of the context transfer engine's C++ API.
-
-```cpp
-#include <clio_cte/core/core_client.h>
-#include <clio_runtime/ipc_manager.h>
-#include <cstring>
-
-int main() {
-  // 1. Initialize the CTE client.  This auto-connects to the runtime
-  //    started by `clio_run start` and creates the CTE pool on the first
-  //    call (no separate CLIO_INIT / runtime-mode setup needed in the
-  //    consumer process).  Storage targets are configured declaratively
-  //    via the runtime's compose YAML — no RegisterTarget call needed
-  //    here either.
-  if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) return 1;
-  auto *cte = CLIO_CTE_CLIENT;
-
-  // 2. Get-or-create a named container for blobs.  The async APIs
-  //    return a chi::Future immediately; Wait() blocks for completion.
-  auto tag_future = cte->AsyncGetOrCreateTag("my_tag");
-  tag_future.Wait();
-  auto tag_id = tag_future->tag_id_;
-
-  // 3. Stage blob data into a CTE-managed shm buffer and submit the
-  //    PutBlob asynchronously.  Submit-then-Wait is the canonical
-  //    pattern; multiple AsyncPutBlob calls can be in flight before
-  //    the first Wait() to pipeline I/O.  The async signatures take a
-  //    type-erased `ShmPtr<>` so we wrap `put_buf.shm_` (a typed
-  //    `ShmPtr<char>`) in the void-typed view.
-  constexpr size_t kSize = 4096;
-  auto put_buf = CLIO_IPC->AllocateBuffer(kSize);
-  std::memset(put_buf.ptr_, 'A', kSize);
-  ctp::ipc::ShmPtr<> put_data(put_buf.shm_);
-  auto put_future = cte->AsyncPutBlob(tag_id, "my_blob",
-                                       /*offset=*/0, kSize,
-                                       put_data);
-  put_future.Wait();
-  CLIO_IPC->FreeBuffer(put_buf);
-
-  // 4. Pre-allocate the receive buffer in shm, fire an async GetBlob,
-  //    then Wait — the buffer holds the blob data on return.
-  auto get_buf = CLIO_IPC->AllocateBuffer(kSize);
-  ctp::ipc::ShmPtr<> get_data(get_buf.shm_);
-  auto get_future = cte->AsyncGetBlob(tag_id, "my_blob",
-                                       /*offset=*/0, kSize,
-                                       /*flags=*/0,
-                                       get_data);
-  get_future.Wait();
-  // get_buf.ptr_ now holds the retrieved bytes.
-  CLIO_IPC->FreeBuffer(get_buf);
-
-  // 5. Clean up.
-  cte->AsyncDelTag(tag_id).Wait();
-  return 0;
-}
-```
-
-**Build and Link:**
-```cmake
-# Unified package includes everything - ClioCtp, CLIO Runtime, and all ChiMods.
-# `clio-core` is the canonical package name; the legacy `iowarp-core` spelling
-# still works for backward-compat.
-find_package(clio-core REQUIRED)
-
-target_link_libraries(my_app
-  clio::cte::core_client    # CTE client (for the example above)
-  clio::run::admin_client   # Admin module (always available)
-  clio::run::bdev_client    # Block-device module (always available)
-)
-```
-
-**What `find_package(clio-core)` provides:**
-
-*Core Components:*
-- All `ctp::*` modular targets (cxx, configure, serialize, interceptor, lightbeam, thread_all, mpi, compress, encrypt)
-- `clio::run::cxx` (core runtime library)
-- Module build utilities
-
-*Core ChiMods (Always Available):*
-- `clio::run::admin_client`, `clio::run::admin_runtime`
-- `clio::run::bdev_client`, `clio::run::bdev_runtime`
-
-*Optional ChiMods (if enabled at build time):*
-- `clio::cte::core_client`, `clio::cte::core_runtime` (Context Transfer Engine)
-- `clio::cae::core_client`, `clio::cae::core_runtime` (Context Assimilation Engine)
-
-The pre-`::` waypoint spellings (`clio_run::*`, `clio_cte::*`, `clio_cae::*`) remain available as backward-compat ALIAS targets; the historical install-time aliases are catalogued in [Deprecation Notes](https://iowarp.readthedocs.io/en/latest/deprecation-notes/).
+For direct CTE put/get from C++, see the canonical example and operation
+reference in the [Context Transfer Engine
+README](context-transfer-engine/README.md#c-client-api).
 
 ## Testing
 
-CLIO Core includes comprehensive test suites for each component:
-
 ```bash
-# Run all unit tests
-cd build
-ctest -VV
-
-# Run specific component tests
-ctest -R context_transport  # Transport primitives tests
-ctest -R cr                 # CLIO Runtime tests
-ctest -R cte                # Context Transfer Engine tests
-ctest -R cae                # Context Assimilation Engine tests
-ctest -R cee                # Context Exploration Engine tests
+cd build/release
+ctest -VV                    # all unit tests
+ctest -R context_transport   # CTP tests
+ctest -R runtime             # runtime tests
+ctest -R cte                 # CTE tests
+ctest -R omni                # CAE tests
+ctest -R context             # CEE tests
 ```
 
 ## Benchmarking
 
-CLIO Core includes performance benchmarks for measuring runtime and I/O throughput.
+CLIO Core ships two main benchmarks; pass `--help` to either for the full
+parameter list.
 
-### Runtime Throughput Benchmark (clio_run_thrpt_bench)
+- **`clio_run_thrpt_bench`** — runtime task throughput and latency
+  (`bdev_io`, `bdev_allocation`, `bdev_task_alloc`, `latency` test cases).
+- **`clio_cte_bench`** — CTE Put / Get / PutGet throughput across threads,
+  async depth, I/O size, and key-space cardinality.
 
-Measures task throughput and latency for the Clio runtime.
-
-```bash
-clio_run_thrpt_bench [options]
-```
-
-**Parameters:**
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--test-case <case>` | bdev_io | Test case to run |
-| `--threads <N>` | 4 | Number of client worker threads |
-| `--duration <seconds>` | 10.0 | Duration to run benchmark |
-| `--max-file-size <size>` | 1g | Maximum file size (supports k, m, g suffixes) |
-| `--io-size <size>` | 4k | I/O size per operation |
-| `--lane-policy <P>` | (from config) | Lane policy: map_by_pid_tid, round_robin, random |
-| `--output-dir <dir>` | /tmp/clio_benchmark | Output directory for files |
-| `--verbose, -v` | false | Enable verbose output |
-
-**Test Cases:**
-- `bdev_io` - Full I/O throughput (Allocate → Write → Free)
-- `bdev_allocation` - Allocation-only throughput
-- `bdev_task_alloc` - Task allocation/deletion overhead
-- `latency` - Round-trip task latency
-
-**Examples:**
+Example:
 
 ```bash
-# Full I/O benchmark with 8 threads for 30 seconds
 clio_run_thrpt_bench --test-case bdev_io --threads 8 --duration 30
-
-# Latency benchmark with verbose output
-clio_run_thrpt_bench --test-case latency --threads 4 --verbose
-
-# Large I/O with 1MB blocks
-clio_run_thrpt_bench --test-case bdev_io --io-size 1m --threads 16
+clio_cte_bench       --op PutGet --threads 8 --depth 16 --io-size 1m --io-count 200
 ```
-
-### CTE Benchmark (clio_cte_bench)
-
-Measures Context Transfer Engine Put/Get performance.
-
-```bash
-clio_cte_bench [options]
-```
-
-**Parameters:**
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `--op <Put\|Get\|PutGet>` | Put | Operation to benchmark (alias: `--test-case`) |
-| `--threads <N>` | 1 | Number of worker threads |
-| `--depth <N>` | 1 | Async requests in flight per thread |
-| `--io-size <size>` | 1m | Bytes per op (supports k, m, g suffixes) |
-| `--io-count <N>` | 1000 | Ops per thread (ignored when `--time-limit` is set) |
-| `--max-total-blobs <N>` | 0 (unbounded) | Total distinct keys across all threads (split evenly) |
-| `--time-limit <seconds>` | 0 (off) | Run for N seconds instead of `--io-count` ops |
-| `--help, -h` | | Show usage and exit |
-
-A legacy positional form is also accepted:
-```bash
-clio_cte_bench <test_case> <threads> <depth> <io_size> <io_count>
-```
-
-**Examples:**
-
-```bash
-# Put benchmark: 4 threads, 8 async depth, 1MB I/O, 200 ops/thread
-clio_cte_bench --op Put --threads 4 --depth 8 --io-size 1m --io-count 200
-
-# Get benchmark with a 30-second time limit and 4KB I/O
-clio_cte_bench --op Get --threads 2 --depth 4 --io-size 4k --time-limit 30
-
-# Combined Put/Get over a bounded keyspace of 1024 total blobs
-clio_cte_bench --op PutGet --threads 8 --depth 16 --io-size 16m \
-               --io-count 50 --max-total-blobs 1024
-```
-
-**Output Metrics:**
-- Total execution time (ms)
-- Per-thread bandwidth: min, max, avg (MB/s)
-- Aggregate bandwidth across all threads
 
 ## Documentation
 
-Comprehensive documentation is available for each component:
-
-- **[AGENTS.md](AGENTS.md)**: Unified development guide and coding standards
-- **[Context Transport Primitives](context-transport-primitives/README.md)**: Shared memory data structures
-- **[Context Runtime](context-runtime/README.md)**: Modular runtime system and Module development
-  - [MODULE_DEVELOPMENT_GUIDE.md](context-transport-primitives/docs/MODULE_DEVELOPMENT_GUIDE.md): Complete Module development guide
-- **[Context Transfer Engine](context-transfer-engine/README.md)**: I/O buffering and acceleration
-  - [CTE API Documentation](context-transfer-engine/docs/cte/cte.md): Complete API reference
-- **[Context Assimilation Engine](context-assimilation-engine/README.md)**: Data ingestion and processing
-- **[Context Exploration Engine](context-exploration-engine/README.md)**: Interactive data exploration
+- **[AGENTS.md](AGENTS.md)** — unified development guide and coding standards.
+- **[INSTALL.md](INSTALL.md)** — bare-metal source-build instructions.
+- **[Context Transport Primitives](context-transport-primitives/README.md)**
+- **[CLIO Runtime](context-runtime/README.md)**
+- **[Context Transfer Engine](context-transfer-engine/README.md)** — canonical
+  C++ CTE API reference.
+- **[Context Assimilation Engine](context-assimilation-engine/README.md)**
+- **[Context Exploration Engine](context-exploration-engine/README.md)**
+- **Full documentation site:** <https://grc.iit.edu/docs/category/iowarp>
 
 ## Use Cases
 
-**Scientific Computing:**
-- High-performance data processing pipelines
-- Near-data computing for large datasets
-- Custom storage engine development
-- Computational workflows with context management
+**Scientific computing:** data processing pipelines, near-data computing,
+custom storage engines, workflows with context management.
 
-**Storage Systems:**
-- Distributed file system backends
-- Object storage implementations
-- Multi-tiered cache and storage solutions
-- High-throughput I/O buffering
+**Storage systems:** distributed file system backends, object storage,
+multi-tiered caches, high-throughput I/O buffering.
 
-**HPC and Data-Intensive Workloads:**
-- Accelerated I/O for scientific applications
-- Data ingestion and transformation pipelines
-- Heterogeneous computing with GPU support
-- Real-time streaming analytics
+**HPC and data-intensive workloads:** accelerated I/O, ingestion and
+transformation pipelines, heterogeneous computing with GPU support, real-time
+streaming analytics.
 
 ## Performance Characteristics
 
-CLIO Core is designed for high-performance computing scenarios:
-
-- **Task Latency**: < 10 microseconds for local task execution (Context Runtime)
-- **Memory Bandwidth**: Up to 50 GB/s with RAM-based storage backends
-- **Scalability**: Single node to multi-node cluster deployments
-- **Concurrency**: Thousands of concurrent coroutine-based tasks
-- **I/O Performance**: Native async I/O with multi-tiered buffering
+- **Task latency:** < 10 µs for local task execution.
+- **Memory bandwidth:** up to 50 GB/s with the RAM bdev backend.
+- **Scalability:** single node to multi-node clusters.
+- **Concurrency:** thousands of concurrent coroutine-based tasks.
 
 ## Contributing
 
-We welcome contributions to the CLIO Core project!
-
-### Development Workflow
-
-1. **Fork** the repository
-2. **Create** a feature branch: `git checkout -b feature/amazing-feature`
-3. **Follow** the coding standards in [AGENTS.md](AGENTS.md)
-4. **Test** your changes: `ctest --test-dir build`
-5. **Submit** a pull request
-
-### Coding Standards
-
-- Follow **Google C++ Style Guide**
-- Use semantic naming for IDs and priorities
-- Always create docstrings for new functions (Doxygen compatible)
-- Add comprehensive unit tests for new functionality
-- Never use mock/stub code unless explicitly required - implement real, working code
-
-See [AGENTS.md](AGENTS.md) for complete coding standards and workflow guidelines.
+1. Fork the repository.
+2. Create a feature branch: `git checkout -b feature/amazing-feature`.
+3. Follow the standards in [AGENTS.md](AGENTS.md).
+4. `ctest --test-dir build/release` before opening a PR.
+5. Submit a pull request against `iowarp/clio-core`.
 
 ## License
 
-CLIO Core is licensed under the **BSD 3-Clause License**. See [LICENSE](LICENSE) file for complete license text.
+CLIO Core is licensed under the **BSD 3-Clause License**. See
+[LICENSE](LICENSE) for the full text.
 
 **Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology**
 
@@ -524,15 +248,11 @@ CLIO Core is licensed under the **BSD 3-Clause License**. See [LICENSE](LICENSE)
 
 ## Acknowledgements
 
-CLIO Core is developed at the [GRC lab](https://grc.iit.edu/) at Illinois Institute of Technology as part of the IOWarp project. This work is supported by the National Science Foundation (NSF) and aims to advance next-generation scientific computing infrastructure.
+CLIO Core is developed at the [GRC lab](https://grc.iit.edu/) at Illinois
+Institute of Technology as part of the IOWarp project, supported by the
+National Science Foundation (NSF) to advance next-generation scientific
+computing infrastructure.
 
-**For more information:**
-- IOWarp Project: https://grc.iit.edu/research/projects/iowarp
-- IOWarp Organization: https://github.com/iowarp
-- Documentation Hub: https://grc.iit.edu/docs/category/iowarp
-
----
-
-<p align="center">
-  Built with ❤️ by the GRC Lab at Illinois Institute of Technology
-</p>
+- IOWarp project: <https://grc.iit.edu/research/projects/iowarp>
+- IOWarp organization: <https://github.com/iowarp>
+- Documentation hub: <https://grc.iit.edu/docs/category/iowarp>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ CLIO Core follows a layered architecture integrating five core components:
         └─────────────────────┼─────────────────────┘
                               │
                     ┌─────────────────┐
-                    │  Chimaera       │
+                    │  CLIO           │
                     │  Runtime        │
                     │  (Module System)│
                     └─────────────────┘
@@ -76,9 +76,9 @@ linked. No system installs are required beyond glibc and Python 3.10+.
 pip install iowarp-core
 ```
 
-The wheel includes the Clio runtime, the `clio_run` CLI, the CTE,
+The wheel includes the CLIO runtime, the `clio_run` CLI, the CTE,
 CAE, and CEE engines, and the `clio_cee` Python bindings. A default
-configuration is seeded at `~/.clio/clio.yaml` (legacy: `~/.chimaera/chimaera.yaml`) on first import.
+configuration is seeded at `~/.clio/clio.yaml` on first import.
 
 Newer extensions and advanced/accelerated features are not in the
 portable wheel — switch to a source build below if you need any of:
@@ -109,6 +109,10 @@ If you already cloned without submodules, initialize them with:
 ```bash
 git submodule update --init --recursive
 ```
+
+For a full **bare-metal source build** (without Conda) with the
+per-feature apt/dnf dependency list and a checklist of every
+`CLIO_*_ENABLE_*` flag, see [INSTALL.md](INSTALL.md).
 
 Other source-install methods (Docker, Spack) are documented in
 [docs/getting-started/installation](docs/docs/getting-started/installation.mdx).
@@ -189,7 +193,7 @@ Interactive tools and interfaces for exploring scientific data contents and meta
 
 ### Starting the Runtime
 
-Installation seeds a default configuration at `~/.clio/clio.yaml` (legacy: `~/.chimaera/chimaera.yaml`), so
+Installation seeds a default configuration at `~/.clio/clio.yaml`, so
 the runtime works out of the box:
 
 ```bash
@@ -337,7 +341,7 @@ target_link_libraries(my_app
 - `clio::cte::core_client`, `clio::cte::core_runtime` (Context Transfer Engine)
 - `clio::cae::core_client`, `clio::cae::core_runtime` (Context Assimilation Engine)
 
-The pre-`::` waypoint spellings (`clio_run::*`, `clio_cte::*`, `clio_cae::*`) and the historical install-time names (`chimaera::*`, `wrp_cte::*`, `wrp_cae::*`) remain available as backward-compat ALIAS targets.
+The pre-`::` waypoint spellings (`clio_run::*`, `clio_cte::*`, `clio_cae::*`) remain available as backward-compat ALIAS targets; the historical install-time aliases are catalogued in [Deprecation Notes](https://iowarp.readthedocs.io/en/latest/deprecation-notes/).
 
 ## Testing
 
@@ -350,7 +354,7 @@ ctest -VV
 
 # Run specific component tests
 ctest -R context_transport  # Transport primitives tests
-ctest -R chimaera           # Runtime tests
+ctest -R runtime            # CLIO Runtime tests
 ctest -R cte                # Context transfer engine tests
 ctest -R omni               # Context assimilation engine tests
 ```

--- a/README.md
+++ b/README.md
@@ -354,9 +354,10 @@ ctest -VV
 
 # Run specific component tests
 ctest -R context_transport  # Transport primitives tests
-ctest -R runtime            # CLIO Runtime tests
-ctest -R cte                # Context transfer engine tests
-ctest -R omni               # Context assimilation engine tests
+ctest -R cr                 # CLIO Runtime tests
+ctest -R cte                # Context Transfer Engine tests
+ctest -R cae                # Context Assimilation Engine tests
+ctest -R cee                # Context Exploration Engine tests
 ```
 
 ## Benchmarking

--- a/context-assimilation-engine/README.md
+++ b/context-assimilation-engine/README.md
@@ -1,15 +1,17 @@
 # Context Assimilation Engine (CAE)
 
-A Chimaera module (Module) for high-performance data ingestion into the IOWarp
-ecosystem. CAE assimilates data from external sources — local binary files,
-HDF5 datasets, and Globus endpoints — into the Context Transfer Engine (CTE)
-for distributed storage and retrieval.
+A CLIO ChiMod for high-performance data ingestion into the IOWarp ecosystem.
+CAE assimilates data from external sources — local binary files, HDF5
+datasets, and Globus endpoints — into the [Context Transfer
+Engine](../context-transfer-engine) (CTE) for distributed storage and
+retrieval.
 
 ## Overview
 
-CAE runs as a pool inside the Clio runtime alongside CTE. Clients submit
-OMNI YAML files to describe data transfers; CAE parses them and dispatches
-assimilation tasks to the appropriate backend (binary, HDF5, or Globus).
+CAE runs as a pool inside the [CLIO runtime](../context-runtime) alongside
+CTE. Clients submit OMNI YAML files to describe data transfers; CAE parses
+them and dispatches assimilation tasks to the appropriate backend (binary,
+HDF5, or Globus).
 
 ```
 External Source          CAE Module              CTE Module
@@ -20,32 +22,37 @@ External Source          CAE Module              CTE Module
 
 ## Building
 
-CAE is built as part of the IOWarp Core monorepo:
+CAE is built as part of CLIO Core; it is enabled by default
+(`CLIO_CORE_ENABLE_CAE=ON`):
 
 ```bash
-git clone https://github.com/iowarp/clio-core.git
+git clone --recurse-submodules https://github.com/iowarp/clio-core.git
 cd clio-core
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j$(nproc)
+cmake --preset release
+cmake --build build/release -j$(nproc)
 ```
 
-To enable HDF5 support:
+HDF5 ingestion is opt-in (the CMake flag also turns on CTE's HDF5 adapters):
+
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Release -DWRP_CORE_ENABLE_HDF5=ON ..
+cmake --preset release -DCLIO_CORE_ENABLE_HDF5=ON
 ```
+
+Globus ingestion is opt-in via `-DCAE_ENABLE_GLOBUS=ON` and requires the
+Globus toolkit on `PATH`.
 
 ## Running
 
-### 1. Start the Clio runtime with CTE and CAE
+### 1. Start the CLIO runtime with CTE and CAE composed
 
 ```bash
 export CLIO_X=/path/to/clio_config.yaml
-clio_run runtime start
+clio_run start
 ```
 
-An example configuration deploying both CTE and CAE is provided in
-`config/clio_config_example.yaml`:
+The example configuration at
+[`config/clio_config_example.yaml`](config/clio_config_example.yaml)
+deploys both CTE and CAE via the runtime's declarative `compose` section:
 
 ```yaml
 compose:
@@ -83,6 +90,7 @@ transfers:
 ```
 
 **HDF5 with dataset filtering:**
+
 ```yaml
 transfers:
   - src: file::/data/experiment.h5
@@ -96,6 +104,7 @@ transfers:
 ```
 
 **Key fields:**
+
 | Field | Description |
 |---|---|
 | `src` | Source URL (`file::`, `globus::`) |
@@ -105,35 +114,49 @@ transfers:
 | `src_token` / `dst_token` | Auth tokens; environment variables are expanded |
 | `dataset_filter` | HDF5 dataset include/exclude glob patterns |
 
+## Linking from C++
+
+CAE is exported through the unified `clio-core` CMake package:
+
+```cmake
+find_package(clio-core CONFIG REQUIRED)
+
+target_link_libraries(my_app
+  clio::cae::core_client
+  clio::cte::core_client
+)
+```
+
+For the higher-level Python/C++ ingestion façade that drives CAE under the
+hood, see the [Context Exploration Engine](../context-exploration-engine).
+
 ## Project Structure
 
 ```
-config/      - Example runtime configuration files
-core/        - Module implementation
-  include/   - Public headers (tasks, assimilation context, factory)
-  src/        - Runtime and client implementation
-  util/       - clio_cae command-line tool
-data/        - Sample datasets for testing (HDF5, CSV, Parquet)
+config/      Example runtime configuration files
+core/        ChiMod implementation
+  include/   Public headers (tasks, assimilation context, factory)
+  src/       Runtime and client implementation
+  util/      clio_cae command-line tool
+data/        Sample datasets for testing (HDF5, CSV, Parquet)
 test/
-  unit/      - Unit tests (binary, HDF5, range, error handling)
-  integration/globus_matsci/ - Globus integration test
+  unit/                       Unit tests (binary, HDF5, range, error handling)
+  integration/globus_matsci/  Globus integration test
 ```
 
 ## Pool ID Reference
 
-| Component | Pool ID | Module Name    |
-|-----------|---------|----------------|
-| Admin     | 1.0     | chimaera_admin |
-| CTE Core  | 512.0   | clio_cte_core   |
-| CAE Core  | 400.0   | clio_cae_core   |
+| Component | Pool ID | mod_name        |
+|-----------|---------|-----------------|
+| Admin     | 1.0     | (auto-created)  |
+| CTE Core  | 512.0   | `clio_cte_core` |
+| CAE Core  | 400.0   | `clio_cae_core` |
 
 ## License
 
-This project is licensed under the BSD-3-Clause License - see the [LICENSE](LICENSE) file for details.
-
-**Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology**
+BSD-3-Clause. See [LICENSE](../LICENSE).
 
 ## Links
 
-- **IOWarp Organization**: [https://github.com/iowarp](https://github.com/iowarp)
-- **Issues**: [https://github.com/iowarp/clio-core/issues](https://github.com/iowarp/clio-core/issues)
+- **IOWarp Organization:** [https://github.com/iowarp](https://github.com/iowarp)
+- **Issues:** [https://github.com/iowarp/clio-core/issues](https://github.com/iowarp/clio-core/issues)

--- a/context-assimilation-engine/test/unit/CMakeLists.txt
+++ b/context-assimilation-engine/test/unit/CMakeLists.txt
@@ -168,33 +168,33 @@ target_link_libraries(test_cae_comprehensive
 install(TARGETS test_cae_comprehensive DESTINATION bin)
 
 # Register individual test cases with CTest
-add_test(NAME CAE_ClientInit COMMAND test_cae_comprehensive "[cae][core][init]")
-add_test(NAME CAE_AssimilationCtx_Default COMMAND test_cae_comprehensive "[cae][ctx]")
-add_test(NAME CAE_AssimilationCtx_Full COMMAND test_cae_comprehensive "[cae][ctx]")
-add_test(NAME CAE_AssimilationCtx_Patterns COMMAND test_cae_comprehensive "[cae][ctx]")
-add_test(NAME CAE_ParseOmni_Binary COMMAND test_cae_comprehensive "[cae][parseomni][binary]")
-add_test(NAME CAE_ParseOmni_BinaryRange COMMAND test_cae_comprehensive "[cae][parseomni][binary][range]")
-add_test(NAME CAE_ParseOmni_Multi COMMAND test_cae_comprehensive "[cae][parseomni][multi]")
-add_test(NAME CAE_ParseOmni_Empty COMMAND test_cae_comprehensive "[cae][parseomni][error]")
-add_test(NAME CAE_ProcessHdf5_Basic COMMAND test_cae_comprehensive "[cae][hdf5]")
-add_test(NAME CAE_ProcessHdf5_NonExistent COMMAND test_cae_comprehensive "[cae][hdf5][error]")
-add_test(NAME CAE_ProcessHdf5_EmptyPath COMMAND test_cae_comprehensive "[cae][hdf5][error]")
-add_test(NAME CAE_Serialization COMMAND test_cae_comprehensive "[cae][ctx][serialization]")
-add_test(NAME CAE_VerifyBinaryData COMMAND test_cae_comprehensive "[cae][integration][binary]")
-add_test(NAME CAE_FileURL COMMAND test_cae_comprehensive "[cae][url]")
-add_test(NAME CAE_IOWarpURL COMMAND test_cae_comprehensive "[cae][url]")
-add_test(NAME CAE_BinaryFormat COMMAND test_cae_comprehensive "[cae][format]")
-add_test(NAME CAE_HDF5Format COMMAND test_cae_comprehensive "[cae][format]")
-add_test(NAME CAE_UnknownFormat COMMAND test_cae_comprehensive "[cae][format]")
+add_test(NAME cae_clientinit COMMAND test_cae_comprehensive "[cae][core][init]")
+add_test(NAME cae_assimilationctx_default COMMAND test_cae_comprehensive "[cae][ctx]")
+add_test(NAME cae_assimilationctx_full COMMAND test_cae_comprehensive "[cae][ctx]")
+add_test(NAME cae_assimilationctx_patterns COMMAND test_cae_comprehensive "[cae][ctx]")
+add_test(NAME cae_parseomni_binary COMMAND test_cae_comprehensive "[cae][parseomni][binary]")
+add_test(NAME cae_parseomni_binaryrange COMMAND test_cae_comprehensive "[cae][parseomni][binary][range]")
+add_test(NAME cae_parseomni_multi COMMAND test_cae_comprehensive "[cae][parseomni][multi]")
+add_test(NAME cae_parseomni_empty COMMAND test_cae_comprehensive "[cae][parseomni][error]")
+add_test(NAME cae_processhdf5_basic COMMAND test_cae_comprehensive "[cae][hdf5]")
+add_test(NAME cae_processhdf5_nonexistent COMMAND test_cae_comprehensive "[cae][hdf5][error]")
+add_test(NAME cae_processhdf5_emptypath COMMAND test_cae_comprehensive "[cae][hdf5][error]")
+add_test(NAME cae_serialization COMMAND test_cae_comprehensive "[cae][ctx][serialization]")
+add_test(NAME cae_verifybinarydata COMMAND test_cae_comprehensive "[cae][integration][binary]")
+add_test(NAME cae_fileurl COMMAND test_cae_comprehensive "[cae][url]")
+add_test(NAME cae_iowarpurl COMMAND test_cae_comprehensive "[cae][url]")
+add_test(NAME cae_binaryformat COMMAND test_cae_comprehensive "[cae][format]")
+add_test(NAME cae_hdf5format COMMAND test_cae_comprehensive "[cae][format]")
+add_test(NAME cae_unknownformat COMMAND test_cae_comprehensive "[cae][format]")
 
 # Set test properties
 set_tests_properties(
-  CAE_ClientInit CAE_AssimilationCtx_Default CAE_AssimilationCtx_Full
-  CAE_AssimilationCtx_Patterns CAE_ParseOmni_Binary CAE_ParseOmni_BinaryRange
-  CAE_ParseOmni_Multi CAE_ParseOmni_Empty CAE_ProcessHdf5_Basic
-  CAE_ProcessHdf5_NonExistent CAE_ProcessHdf5_EmptyPath CAE_Serialization
-  CAE_VerifyBinaryData CAE_FileURL CAE_IOWarpURL CAE_BinaryFormat
-  CAE_HDF5Format CAE_UnknownFormat
+  cae_clientinit cae_assimilationctx_default cae_assimilationctx_full
+  cae_assimilationctx_patterns cae_parseomni_binary cae_parseomni_binaryrange
+  cae_parseomni_multi cae_parseomni_empty cae_processhdf5_basic
+  cae_processhdf5_nonexistent cae_processhdf5_emptypath cae_serialization
+  cae_verifybinarydata cae_fileurl cae_iowarpurl cae_binaryformat
+  cae_hdf5format cae_unknownformat
   PROPERTIES
     TIMEOUT 120
     LABELS "coverage;comprehensive;msan_skip"
@@ -285,14 +285,14 @@ install(TARGETS test_export_data DESTINATION bin)
 # Register as two CTest targets: task struct tests and runtime integration tests.
 # Each target runs all its test cases in a single process (one runtime startup),
 # avoiding port 9413 TIME_WAIT conflicts that arise from repeated restarts.
-add_test(NAME CAE_ExportData_Task
+add_test(NAME cae_exportdata_task
   COMMAND test_export_data "[cae][export][task]")
-add_test(NAME CAE_ExportData_Runtime
+add_test(NAME cae_exportdata_runtime
   COMMAND test_export_data "[cae][export][runtime]")
 
 set_tests_properties(
-  CAE_ExportData_Task
-  CAE_ExportData_Runtime
+  cae_exportdata_task
+  cae_exportdata_runtime
   PROPERTIES
     TIMEOUT 300
     LABELS "coverage;export;msan_skip"

--- a/context-exploration-engine/README.md
+++ b/context-exploration-engine/README.md
@@ -1,175 +1,146 @@
 # Context Exploration Engine (CEE)
 
-High-level C++ and Python API for exploring, querying, and managing IOWarp scientific data contexts.
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-yellow.svg)](../LICENSE)
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-yellow.svg)](LICENSE)
+The high-level C++ and Python API for exploring, querying, and managing
+IOWarp scientific data contexts. CEE is the user-facing facade that drives
+the [Context Transfer Engine](../context-transfer-engine) (CTE) and [Context
+Assimilation Engine](../context-assimilation-engine) (CAE) under the hood.
 
-## Overview
+## What it provides
 
-The Context Exploration Engine provides a unified interface for:
-- **Bundling**: Assimilating data files into the IOWarp storage system
-- **Querying**: Discovering and retrieving stored data by tag and blob patterns
-- **Managing**: Creating, destroying, and organizing data contexts
-
-CEE integrates with the Context Transfer Engine (CTE) and Context Assimilation Engine (CAE) to provide seamless data management capabilities.
+- **Bundling** — assimilate one or more data files into the IOWarp storage
+  system through CAE.
+- **Querying** — discover stored data by tag/blob regex.
+- **Retrieval** — pull blob payloads back out of CTE.
+- **Lifecycle** — create and destroy named contexts.
 
 ## Components
 
-### ContextInterface API
-High-level C++ API for context management operations:
-- `ContextBundle()` - Bundle and assimilate files into CTE storage
-- `ContextQuery()` - Query for data using regex patterns
-- `ContextDestroy()` - Remove contexts by name
-- `ContextRetrieve()` - Retrieve data and metadata (planned)
-- `ContextSplice()` - Split/splice contexts (planned)
-
-### Python Bindings
-Python interface to ContextInterface with snake_case methods:
-- `context_bundle()` - Bundle data files
-- `context_query()` - Query stored data
-- `context_destroy()` - Remove contexts
-
-### Legacy Components
-- **mcp-hdf-demo**: HDF5 Model Context Protocol server and client demo
-- **hdf-compass**: wxPython-4 based HDF Compass viewer
+- **`ContextInterface`** — the canonical C++ API
+  ([`api/include/clio_cee/api/context_interface.h`](api/include/clio_cee/api/context_interface.h)),
+  in the `iowarp::` namespace.
+- **`clio_cee` Python module** — wraps `ContextInterface` with `snake_case`
+  methods and a Pythonic `AssimilationCtx` dataclass.
+- **`iowarp-cei-mcp`** — an MCP server exposing CEE operations for AI agents
+  (see [`iowarp-cei-mcp/README.md`](iowarp-cei-mcp/README.md)).
 
 ## Building
 
-CEE is built as part of the IOWarp Core unified build system:
+CEE is enabled by default in CLIO Core (`CLIO_CORE_ENABLE_CEE=ON`):
 
 ```bash
-# Configure with debug preset
-cmake --preset=debug -DWRP_CORE_ENABLE_CEE=ON
-
-# Build CEE API and tests
-cmake --build build --target clio_cee_api -j$(nproc)
-cmake --build build --target test_context_bundle -j$(nproc)
+git clone --recurse-submodules https://github.com/iowarp/clio-core.git
+cd clio-core
+cmake --preset release
+cmake --build build/release -j$(nproc)
 ```
 
-## Testing
+To build a debug variant with CEE explicitly:
 
-### Unit Tests
-
-CEE includes comprehensive unit tests demonstrating the complete workflow:
-
-**Bundle-and-Retrieve Test** ([api/test/test_context_bundle.cc](api/test/test_context_bundle.cc)):
-- Generates 1MB test file with patterned data
-- Registers RAM storage target with CTE
-- Creates CAE pool dynamically
-- Bundles file using ContextBundle API
-- Queries to verify data storage
-- Cleans up test context
-
-**Query Test** ([api/test/test_context_query.cc](api/test/test_context_query.cc)):
-- Tests basic query operations
-- Validates regex pattern matching
-
-**Destroy Test** ([api/test/test_context_destroy.cc](api/test/test_context_destroy.cc)):
-- Tests context deletion
-- Validates error handling
-
-### Running Tests
-
-Tests support two modes:
-
-**1. With External Runtime:**
 ```bash
-# Start runtime in separate terminal
-cd build && ./bin/clio_run runtime start
-
-# Run tests
-./bin/test_context_bundle
-./bin/test_context_query
-./bin/test_context_destroy
+cmake --preset debug -DCLIO_CORE_ENABLE_CEE=ON
+cmake --build build/debug -j$(nproc)
 ```
 
-**2. With Embedded Runtime:**
-```bash
-# Tests initialize runtime automatically
-INIT_CHIMAERA=1 ./bin/test_context_bundle
-INIT_CHIMAERA=1 ./bin/test_context_query
-INIT_CHIMAERA=1 ./bin/test_context_destroy
-```
-
-### Test Configuration
-
-Tests use [api/test/clio_config.yaml](api/test/clio_config.yaml) for runtime configuration:
-- 4 worker threads (sched + slow)
-- 2GB main segment, 1GB client/runtime segments
-- RAM-based storage (4GB capacity)
-- Single-node configuration for unit testing
-
-## Usage Example
-
-### C++ API
+## C++ Usage
 
 ```cpp
 #include <clio_cee/api/context_interface.h>
 #include <clio_cae/core/factory/assimilation_ctx.h>
 
-// Initialize
-iowarp::ContextInterface ctx_interface;
+int main() {
+  // ContextInterface handles runtime initialization internally.
+  iowarp::ContextInterface ctx_interface;
 
-// Bundle a file
-std::vector<clio_cae::core::AssimilationCtx> bundle;
-clio_cae::core::AssimilationCtx ctx;
-ctx.src = "file::/path/to/data.bin";
-ctx.dst = "iowarp::my_dataset";
-ctx.format = "binary";
-bundle.push_back(ctx);
+  // 1. Bundle a file into IOWarp storage.
+  std::vector<clio::cae::core::AssimilationCtx> bundle;
+  clio::cae::core::AssimilationCtx ctx;
+  ctx.src    = "file::/path/to/data.bin";
+  ctx.dst    = "iowarp::my_dataset";
+  ctx.format = "binary";
+  bundle.push_back(ctx);
+  int rc = ctx_interface.ContextBundle(bundle);
 
-int result = ctx_interface.ContextBundle(bundle);
+  // 2. Query for matching blobs.
+  auto blobs = ctx_interface.ContextQuery(
+      "my_dataset",   // tag regex
+      ".*");          // blob regex
 
-// Query for data
-std::vector<std::string> blobs = ctx_interface.ContextQuery(
-    "my_dataset",  // Tag pattern
-    ".*");         // Blob pattern (all blobs)
-
-// Cleanup
-std::vector<std::string> contexts = {"my_dataset"};
-ctx_interface.ContextDestroy(contexts);
+  // 3. Clean up.
+  ctx_interface.ContextDestroy({"my_dataset"});
+  return 0;
+}
 ```
 
-### Python API
+Link with the unified CMake package:
+
+```cmake
+find_package(clio-core CONFIG REQUIRED)
+target_link_libraries(my_app
+  clio::cee::api
+  clio::cae::core_client
+  clio::cte::core_client
+)
+```
+
+## Python Usage
 
 ```python
-from clio_cee import ContextInterface, AssimilationCtx
+import clio_cee as cee
 
-# Initialize
-ctx = ContextInterface()
+# Construct (initializes the runtime internally on first use).
+ctx_interface = cee.ContextInterface()
 
-# Bundle a file
-bundle = [AssimilationCtx(
+# Bundle a file.
+ctx = cee.AssimilationCtx(
     src="file::/path/to/data.bin",
     dst="iowarp::my_dataset",
-    format="binary"
-)]
-result = ctx.context_bundle(bundle)
+    format="binary",
+)
+ctx_interface.context_bundle([ctx])
 
-# Query for data
-blobs = ctx.context_query("my_dataset", ".*")
+# Query for blob names matching a regex.
+blobs = ctx_interface.context_query("my_dataset", ".*", 0)
 
-# Cleanup
-ctx.context_destroy(["my_dataset"])
+# Retrieve blob payloads.
+data = ctx_interface.context_retrieve("my_dataset", ".*", 0)
+
+# Clean up.
+ctx_interface.context_destroy(["my_dataset"])
 ```
 
-## Quick Start (Legacy)
+## Testing
 
-### MCP HDF5 Demo
 ```bash
-cd mcp-hdf-demo
-pip install -r requirements.txt
-# Start the MCP server and client
+ctest --test-dir build/release -R context
 ```
 
-### HDF Compass
+The tests under [`api/test/`](api/test/) demonstrate the full
+bundle / query / retrieve / destroy workflow against an embedded runtime.
+They use [`api/test/clio_config.yaml`](api/test/clio_config.yaml), which
+provisions a 4-worker single-node runtime with a 4 GB RAM-backed CTE target.
+
+Tests can run in two modes:
+
 ```bash
-cd hdf-compass
-# Follow installation instructions in hdf-compass/README.md
+# Against an externally-started runtime:
+clio_run start &
+./build/release/bin/test_context_bundle
+
+# With an embedded runtime (auto-spawned by the test):
+INIT_CHIMAERA=1 ./build/release/bin/test_context_bundle
+```
+
+## Project structure
+
+```
+api/             C++ ContextInterface, Python bindings, tests, demos
+iowarp-cei-mcp/  MCP server exposing CEE operations
+hdf-compass/     Legacy wxPython HDF Compass viewer (pre-CEE)
+mcp-hdf-demo/    Legacy HDF5 MCP demo
 ```
 
 ## License
 
-BSD-3-Clause License - see [LICENSE](LICENSE) file for details.
-
-**Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology**
+BSD-3-Clause. See [LICENSE](../LICENSE).

--- a/context-exploration-engine/api/CMakeLists.txt
+++ b/context-exploration-engine/api/CMakeLists.txt
@@ -14,7 +14,10 @@ add_library(clio_cee_api SHARED
   src/context_interface.cc
 )
 
-add_library(clio_cee::api ALIAS clio_cee_api)
+# Canonical alias matches the project's clio::<engine>:: scheme. The
+# install(EXPORT ...) block below pins the exported name to `api` so
+# downstream consumers see `clio::cee::api` after find_package().
+add_library(clio::cee::api ALIAS clio_cee_api)
 
 target_include_directories(clio_cee_api
   PUBLIC
@@ -35,6 +38,9 @@ set_target_properties(clio_cee_api PROPERTIES
   SOVERSION 1
   CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
+  # Drives the install-time exported name: combined with NAMESPACE clio::cee::
+  # in install(EXPORT ...) it yields `clio::cee::api`.
+  EXPORT_NAME api
   # Auto-export non-static symbols on Windows so the test binaries can
   # link against clio_cee_api.lib without each public function needing
   # an explicit __declspec(dllexport). Mirrors the same property on
@@ -126,7 +132,7 @@ write_basic_package_version_file(
 
 install(EXPORT clio_cee_api_targets
   FILE clio_cee_api_targets.cmake
-  NAMESPACE clio_cee::
+  NAMESPACE clio::cee::
   DESTINATION lib/cmake/clio_cee_api
 )
 

--- a/context-exploration-engine/api/test/CMakeLists.txt
+++ b/context-exploration-engine/api/test/CMakeLists.txt
@@ -53,28 +53,28 @@ target_link_libraries(test_context_comprehensive
 install(TARGETS test_context_comprehensive DESTINATION bin/tests)
 
 # Register individual test cases with CTest
-add_test(NAME CEE_Init COMMAND test_context_comprehensive "[cee][init]")
-add_test(NAME CEE_Retrieve_Basic COMMAND test_context_comprehensive "[cee][retrieve][basic]")
-add_test(NAME CEE_Retrieve_Empty COMMAND test_context_comprehensive "[cee][retrieve][empty]")
-add_test(NAME CEE_Retrieve_SmallBuffer COMMAND test_context_comprehensive "[cee][retrieve][buffer]")
-add_test(NAME CEE_Retrieve_CustomBatch COMMAND test_context_comprehensive "[cee][retrieve][batch]")
-add_test(NAME CEE_Retrieve_MaxResults COMMAND test_context_comprehensive "[cee][retrieve][limit]")
-add_test(NAME CEE_Bundle_Multi COMMAND test_context_comprehensive "[cee][bundle][multi]")
-add_test(NAME CEE_Bundle_Range COMMAND test_context_comprehensive "[cee][bundle][range]")
-add_test(NAME CEE_Bundle_Invalid COMMAND test_context_comprehensive "[cee][bundle][error]")
-add_test(NAME CEE_Query_Regex COMMAND test_context_comprehensive "[cee][query][regex]")
-add_test(NAME CEE_Query_Limit COMMAND test_context_comprehensive "[cee][query][limit]")
-add_test(NAME CEE_Destroy_Multi COMMAND test_context_comprehensive "[cee][destroy][multi]")
-add_test(NAME CEE_Destroy_Partial COMMAND test_context_comprehensive "[cee][destroy][partial]")
-add_test(NAME CEE_Splice_Stub COMMAND test_context_comprehensive "[cee][splice][stub]")
-add_test(NAME CEE_Integration COMMAND test_context_comprehensive "[cee][integration]")
+add_test(NAME cee_init COMMAND test_context_comprehensive "[cee][init]")
+add_test(NAME cee_retrieve_basic COMMAND test_context_comprehensive "[cee][retrieve][basic]")
+add_test(NAME cee_retrieve_empty COMMAND test_context_comprehensive "[cee][retrieve][empty]")
+add_test(NAME cee_retrieve_smallbuffer COMMAND test_context_comprehensive "[cee][retrieve][buffer]")
+add_test(NAME cee_retrieve_custombatch COMMAND test_context_comprehensive "[cee][retrieve][batch]")
+add_test(NAME cee_retrieve_maxresults COMMAND test_context_comprehensive "[cee][retrieve][limit]")
+add_test(NAME cee_bundle_multi COMMAND test_context_comprehensive "[cee][bundle][multi]")
+add_test(NAME cee_bundle_range COMMAND test_context_comprehensive "[cee][bundle][range]")
+add_test(NAME cee_bundle_invalid COMMAND test_context_comprehensive "[cee][bundle][error]")
+add_test(NAME cee_query_regex COMMAND test_context_comprehensive "[cee][query][regex]")
+add_test(NAME cee_query_limit COMMAND test_context_comprehensive "[cee][query][limit]")
+add_test(NAME cee_destroy_multi COMMAND test_context_comprehensive "[cee][destroy][multi]")
+add_test(NAME cee_destroy_partial COMMAND test_context_comprehensive "[cee][destroy][partial]")
+add_test(NAME cee_splice_stub COMMAND test_context_comprehensive "[cee][splice][stub]")
+add_test(NAME cee_integration COMMAND test_context_comprehensive "[cee][integration]")
 
 # Set test properties for comprehensive tests
 set_tests_properties(
-  CEE_Init CEE_Retrieve_Basic CEE_Retrieve_Empty CEE_Retrieve_SmallBuffer
-  CEE_Retrieve_CustomBatch CEE_Retrieve_MaxResults CEE_Bundle_Multi
-  CEE_Bundle_Range CEE_Bundle_Invalid CEE_Query_Regex CEE_Query_Limit
-  CEE_Destroy_Multi CEE_Destroy_Partial CEE_Splice_Stub CEE_Integration
+  cee_init cee_retrieve_basic cee_retrieve_empty cee_retrieve_smallbuffer
+  cee_retrieve_custombatch cee_retrieve_maxresults cee_bundle_multi
+  cee_bundle_range cee_bundle_invalid cee_query_regex cee_query_limit
+  cee_destroy_multi cee_destroy_partial cee_splice_stub cee_integration
   PROPERTIES
     TIMEOUT 180
     LABELS "cee;comprehensive;coverage;msan_skip"
@@ -95,13 +95,13 @@ if(TARGET clio_cee)
 
   # Add Python test to CTest
   add_test(
-    NAME test_context_interface_python
+    NAME cee_python_interface
     COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/test_context_interface.py
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
   # Set test properties
-  set_tests_properties(test_context_interface_python PROPERTIES
+  set_tests_properties(cee_python_interface PROPERTIES
     LABELS "cee;api;python;interface"
     TIMEOUT 600  # 10 minute timeout for Python tests
   )
@@ -121,13 +121,13 @@ if(TARGET clio_cee)
 
   # Add enhanced Python test to CTest
   add_test(
-    NAME test_context_interface_enhanced_python
+    NAME cee_python_interface_enhanced
     COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/test_context_interface_enhanced.py
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
   # Set test properties
-  set_tests_properties(test_context_interface_enhanced_python PROPERTIES
+  set_tests_properties(cee_python_interface_enhanced PROPERTIES
     LABELS "cee;api;python;enhanced;coverage"
     TIMEOUT 600  # 10 minute timeout for Python tests
   )
@@ -147,12 +147,12 @@ if(TARGET clio_cee)
 
   # Add retrieve roundtrip test to CTest
   add_test(
-    NAME test_context_retrieve_roundtrip_python
+    NAME cee_python_retrieve_roundtrip
     COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/test_context_retrieve_roundtrip.py
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
-  set_tests_properties(test_context_retrieve_roundtrip_python PROPERTIES
+  set_tests_properties(cee_python_retrieve_roundtrip PROPERTIES
     LABELS "cee;api;python;retrieve;regression;manual"
     TIMEOUT 120
     DISABLED TRUE  # Requires externally running IOWarp runtime

--- a/context-exploration-engine/clio_repo.yaml
+++ b/context-exploration-engine/clio_repo.yaml
@@ -1,0 +1,8 @@
+# Context Exploration Engine (CEE) Repository Configuration
+namespace: clio::cee
+version: 1.0.0
+description: "Context Exploration Engine - high-level API for bundling, querying, and retrieving IOWarp data contexts"
+
+# CEE is not a ChiMod repository (no ChiMods inside); it exposes a higher-level
+# C++ library (`clio::cee::api`) and a Python module (`clio_cee`).
+modules: []

--- a/context-runtime/README.md
+++ b/context-runtime/README.md
@@ -1,4 +1,4 @@
-# Chimaera Runtime
+# CLIO Runtime
 
 <p align="center">
   <strong>High-Performance Modular Runtime for Scientific Computing and Storage Systems</strong>
@@ -6,38 +6,32 @@
   <br />
   <a href="#getting-started">Getting Started</a> ·
   <a href="#external-integration">External Integration</a> ·
-  <a href="#chimod-development">Module Development</a> ·
-  <a href="#documentation">Documentation</a> ·
+  <a href="#module-development">Module Development</a> ·
   <a href="#contributing">Contributing</a>
 </p>
 
 ---
 
-**Chimaera** is a high-performance, distributed task execution runtime designed for scientific computing, storage systems, and near-data processing applications. Built with a modular architecture, Chimaera enables developers to create custom processing modules (ChiMods) that can be dynamically loaded and executed with minimal overhead.
+The **CLIO Runtime** is the distributed, coroutine-based task-execution
+runtime that backs CLIO Core. It hosts dynamically-loaded modules (ChiMods),
+provides shared-memory IPC via the [Context Transport
+Primitives](../context-transport-primitives) (CTP), and powers higher-level
+engines like CTE, CAE, and CEE. The on-disk binary is `clio_run`.
 
-## What is Chimaera?
+## What it provides
 
-Chimaera provides:
-- **High-Performance Task Execution**: Coroutine-based task scheduling with microsecond-level latencies
-- **Modular Architecture**: Extensible Module system for custom functionality
-- **Advanced Synchronization**: CoMutex and CoRwLock for coroutine-aware synchronization
-- **Distributed Computing**: Seamless scaling from single node to cluster deployments
-- **Storage Integration**: Built-in support for block devices, file systems, and custom storage backends
-- **Memory Management**: Shared memory IPC with ClioCtp for optimal performance
-
-## Key Features
-
-- 🚀 **Ultra-High Performance**: Coroutine-based execution with shared memory IPC for microsecond-level task latencies
-- 🧩 **Modular Module System**: Dynamically loadable modules for custom functionality without core modifications
-- 🔄 **Advanced Task Management**: Asynchronous and fire-and-forget task execution patterns
-- 🔐 **Coroutine-Aware Synchronization**: CoMutex and CoRwLock primitives for deadlock-free coordination
-- 💾 **Flexible Storage Backends**: Built-in support for RAM, file-based, and custom block device operations
-- 🌐 **Distributed Architecture**: Seamless scaling from development to production clusters
-- 🔧 **Developer-Friendly**: Comprehensive APIs, extensive documentation, and external project integration
+- **Microsecond-level task latency** via coroutine scheduling on top of CTP
+  shared-memory queues.
+- **Pluggable ChiMods** — drop a `.so` and a `clio_mod.yaml` in a repository
+  directory and the runtime loads it on startup.
+- **Coroutine-aware synchronization** — `CoMutex`, `CoRwLock` for deadlock-free
+  coordination across tasks.
+- **Distributed by construction** — pools span hosts via the `lightbeam`
+  transport (ZMQ, libfabric, or Thallium).
+- **Built-in storage modules** — `admin` for pool management, `bdev` for RAM /
+  file-based block devices.
 
 ## Architecture
-
-Chimaera follows a modular semi-microkernel design:
 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
@@ -49,7 +43,7 @@ Chimaera follows a modular semi-microkernel design:
          └───────────────────────┼───────────────────────┘
                                  │
                     ┌─────────────────┐
-                    │ Chimaera Runtime │
+                    │  CLIO Runtime   │
                     │                 │
                     │  Core Services: │
                     │  • IPC Manager  │
@@ -66,50 +60,44 @@ Chimaera follows a modular semi-microkernel design:
     └───────────────┘   └───────────────┘   └───────────────┘
 ```
 
-**Core Components:**
-- **Runtime Process**: Central coordinator managing resources and ChiMods
-- **ChiMods**: Dynamically loaded modules providing specialized functionality
-- **Client Libraries**: Lightweight interfaces for application integration
-- **Shared Memory IPC**: High-performance inter-process communication via ClioCtp
-
 ## Getting Started
 
 ### Prerequisites
 
-Chimaera requires the following dependencies:
+- C++20 compiler (GCC ≥ 11 or Clang ≥ 14)
+- CMake ≥ 3.20
+- Linux
 
-**System Requirements:**
-- C++17 compatible compiler (GCC >= 9, Clang >= 10)
-- CMake >= 3.10
-- Linux (Ubuntu 20.04+, CentOS 8+, or similar)
+See [INSTALL.md](../INSTALL.md) for the full per-feature dependency list.
 
-Our docker container has all dependencies installed for you.
-```bash
-docker pull iowarp/iowarp-build:latest
-```
+### Build
 
-### Installation
-
-#### 1. Clone and Build
+The runtime is built as part of CLIO Core:
 
 ```bash
-# Clone the repository
-git clone https://github.com/iowarp/iowarp-runtime.git
-cd iowarp-runtime
-
-# Configure release with CMake preset
+git clone --recurse-submodules https://github.com/iowarp/clio-core.git
+cd clio-core
 cmake --preset release
-
-# Build all components
-cmake --build build --parallel $(nproc)
-
-# Install to system or custom prefix
-cmake --install build --prefix /usr/local
+cmake --build build/release -j$(nproc)
+sudo cmake --install build/release
 ```
 
-#### 2. Quick Start Example
+### Start the runtime
 
-Create a simple application using the bdev Module:
+```bash
+clio_run start          # foreground
+clio_run start &        # background
+```
+
+A default configuration is seeded at `~/.clio/clio.yaml` on install. To
+override it, point `CLIO_X` at your own YAML file:
+
+```bash
+export CLIO_X=/path/to/my_config.yaml
+clio_run start
+```
+
+### Minimal client example
 
 ```cpp
 #include <clio_runtime/clio_runtime.h>
@@ -117,234 +105,158 @@ Create a simple application using the bdev Module:
 #include <clio_runtime/admin/admin_client.h>
 
 int main() {
-  // Initialize Chimaera (client mode with embedded runtime)
-  chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
+  // Initialize CLIO Runtime in client mode with an embedded runtime.
+  clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
 
-  // Create admin client (always required)
-  clio::run::admin::Client admin_client(chi::PoolId(7000, 0));
-  admin_client.Create(chi::PoolQuery::Local());
-  
-  // Create bdev client for high-speed RAM storage
-  clio::run::bdev::Client bdev_client(chi::PoolId(8000, 0));
-  bdev_client.Create(chi::PoolQuery::Local(), 
-                    clio::run::bdev::BdevType::kRam, "", 1024*1024*1024); // 1GB RAM
-  
-  // Allocate and use a block
-  auto block = bdev_client.Allocate(4096);  // 4KB block
+  // Always-required admin client (pool management).
+  clio::run::admin::Client admin_client(clio::run::PoolId(7000, 0));
+  admin_client.Create(clio::run::PoolQuery::Local());
+
+  // RAM-backed block device.
+  clio::run::bdev::Client bdev(clio::run::PoolId(8000, 0));
+  bdev.Create(clio::run::PoolQuery::Local(),
+              clio::run::bdev::BdevType::kRam, "",
+              1024ull * 1024 * 1024);   // 1 GB
+
+  auto block = bdev.Allocate(4096);
   std::vector<ctp::u8> data(4096, 0xAB);
-  bdev_client.Write(block, data);
-  auto read_data = bdev_client.Read(block);
-  bdev_client.Free(block);
-  
+  bdev.Write(block, data);
+  auto read_data = bdev.Read(block);
+  bdev.Free(block);
+
   return 0;
 }
 ```
 
 ## External Integration
 
-Chimaera is designed to be easily integrated into external projects through its CMake export system.
+CLIO Core ships a single unified CMake package, `clio-core`, that exposes the
+runtime and all enabled ChiMods. Link the modular targets directly:
 
-### For External C++ Projects
-
-**CMakeLists.txt Example:**
 ```cmake
-cmake_minimum_required(VERSION 3.10)
-project(MyChimaeraApp)
+cmake_minimum_required(VERSION 3.20)
+project(MyClioApp)
 
-# Find Chimaera packages
-find_package(chimaera-core REQUIRED)
-find_package(chimaera-admin REQUIRED)
-find_package(chimaera-bdev REQUIRED)  # Optional: for block device operations
+find_package(clio-core CONFIG REQUIRED)
 
-# Create your application
 add_executable(my_app src/main.cpp)
-
-# Link against Chimaera libraries
 target_link_libraries(my_app
-  clio::run::cxx              # Core Clio runtime
-  clio::run::admin_client     # Admin module (always required)
-  clio::run::bdev_client      # Block device operations
-  ${CMAKE_THREAD_LIBS_INIT}  # Threading support
+  clio::run::cxx              # core runtime library
+  clio::run::admin_client     # admin module (always available)
+  clio::run::bdev_client      # block-device module (always available)
 )
 ```
 
-**Build Configuration:**
-```bash
-# Set CMAKE_PREFIX_PATH to include Chimaera installation
-export CMAKE_PREFIX_PATH="/usr/local:/path/to/chimaera/install"
+If CLIO Core is installed in a non-standard prefix, point CMake at it via
+`CMAKE_PREFIX_PATH`:
 
-mkdir build && cd build
-cmake ..
-make
+```bash
+export CMAKE_PREFIX_PATH=/path/to/clio-core/install
 ```
 
 ### Available ChiMods
 
-| Module | Purpose | CMake Package | Description |
-|--------|---------|---------------|--------------|
-| **admin** | Core Management | `chimaera-admin` | Pool creation and system administration (always required) |
-| **bdev** | Block I/O | `chimaera-bdev` | High-performance block device operations with RAM/file backends |
-| **MOD_NAME** | Template | `chimaera-MOD_NAME` | Example Module template for custom development |
+| Module | Purpose | Client target | Runtime target |
+|--------|---------|---------------|----------------|
+| **admin** | Pool creation and system administration (always available) | `clio::run::admin_client` | `clio::run::admin_runtime` |
+| **bdev** | Block-device operations (RAM / file backends, always available) | `clio::run::bdev_client` | `clio::run::bdev_runtime` |
+| **CTE core** | Context Transfer Engine (if `CLIO_CORE_ENABLE_CTE=ON`) | `clio::cte::core_client` | `clio::cte::core_runtime` |
+| **CAE core** | Context Assimilation Engine (if `CLIO_CORE_ENABLE_CAE=ON`) | `clio::cae::core_client` | `clio::cae::core_runtime` |
 
-### Runtime vs Client Mode
+### Runtime modes
 
-Chimaera applications can run in two modes:
+`clio::run::CLIO_INIT` takes a `RuntimeMode` and an `embedded_runtime` boolean:
 
-**Client Mode with Embedded Runtime** (Most Common):
 ```cpp
-// Initialize as client with embedded runtime - starts runtime and connects client
-chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
-```
+// Most common: client with an embedded runtime (auto-starts on first init).
+clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, true);
 
-**Client-Only Mode** (Advanced - requires external runtime):
-```cpp
-// Initialize as client only - connects to existing external runtime
-chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, false);
-```
+// Client-only — connects to a runtime already started by `clio_run start`.
+clio::run::CLIO_INIT(clio::run::RuntimeMode::kClient, false);
 
-**Runtime/Server Mode** (Advanced - embedded applications):
-```cpp
-// Initialize as runtime/server - starts runtime only (no client)
-chi::CHIMAERA_INIT(chi::ChimaeraMode::kServer, false);
+// Server / runtime-only — for embedding the runtime inside another daemon.
+clio::run::CLIO_INIT(clio::run::RuntimeMode::kServer, false);
 ```
 
 ## Module Development
 
-The true power of Chimaera lies in developing custom ChiMods. Each Module is a self-contained module providing specialized functionality.
+Each ChiMod is a self-contained shared library exposing a client interface, a
+runtime container, and a set of tasks.
 
-### Module Structure
+### Layout
 
 ```
 modules/my_module/
-├── clio_mod.yaml           # Module metadata
-├── CMakeLists.txt              # Build configuration
-├── doc/                        # Documentation
-│   ├── my_module.md           # API reference
-│   └── integration.md         # Integration guide
-├── include/chimaera/my_module/ # Headers
-│   ├── my_module_client.h     # Client interface
-│   ├── my_module_runtime.h    # Runtime implementation
-│   └── my_module_tasks.h      # Task definitions
-└── src/                        # Implementation
-    ├── my_module_client.cc    # Client code
-    └── my_module_runtime.cc   # Runtime code
+├── clio_mod.yaml                   # module metadata
+├── CMakeLists.txt
+├── doc/
+│   ├── my_module.md                # API reference
+│   └── integration.md
+├── include/clio_runtime/my_module/ # public headers
+│   ├── my_module_client.h
+│   ├── my_module_runtime.h
+│   └── my_module_tasks.h
+└── src/
+    ├── my_module_client.cc
+    └── my_module_runtime.cc
 ```
 
-### Key Development Concepts
+### Sketch
 
-**1. Task-Based Architecture:**
 ```cpp
-// Define custom tasks
-struct MyCustomTask : public chi::Task {
-  chi::u64 input_data_;
-  chi::u64 result_;        // Output parameter
-  chi::u32 result_code_;   // Error code
+// Task definition
+struct MyCustomTask : public clio::run::Task {
+  uint64_t input_data_;
+  uint64_t result_;
+  uint32_t result_code_;
 };
-```
 
-**2. Client Interface:**
-```cpp
-class Client : public chi::ContainerClient {
-public:
-  // Synchronous operations
-  chi::u64 ProcessData(const ctp::ipc::MemContext& mctx, chi::u64 data);
-  
-  // Asynchronous operations
-  ctp::ipc::FullPtr<MyCustomTask> AsyncProcessData(const ctp::ipc::MemContext& mctx, chi::u64 data);
+// Client
+class Client : public clio::run::ContainerClient {
+ public:
+  uint64_t ProcessData(const ctp::ipc::MemContext& mctx, uint64_t data);
+  ctp::ipc::FullPtr<MyCustomTask>
+      AsyncProcessData(const ctp::ipc::MemContext& mctx, uint64_t data);
 };
-```
 
-**3. Runtime Implementation:**
-```cpp
-class Runtime : public chi::Container {
-public:
-  void ProcessData(ctp::ipc::FullPtr<MyCustomTask> task, chi::RunContext& ctx) {
-    // Implement your logic here
+// Runtime
+class Runtime : public clio::run::Container {
+ public:
+  void ProcessData(ctp::ipc::FullPtr<MyCustomTask> task,
+                   clio::run::RunContext& ctx) {
     task->result_ = process_algorithm(task->input_data_);
-    task->result_code_ = 0;  // Success
+    task->result_code_ = 0;
   }
 };
 ```
 
-## Documentation
+The `MOD_NAME/` directory under [`modules/`](modules/) is a complete starter
+template you can copy and rename.
 
-Comprehensive documentation is available in the `docs/` directory:
-
-- **[MODULE_DEVELOPMENT_GUIDE.md](docs/MODULE_DEVELOPMENT_GUIDE.md)**: Complete guide for developing ChiMods
-- **[Module Documentation](modules/)**: Individual Module API references:
-  - [Admin Module](modules/admin/doc/admin.md): Core system management
-  - [Bdev Module](modules/bdev/doc/bdev.md): Block device operations
-  - [MOD_NAME Template](modules/MOD_NAME/doc/MOD_NAME.md): Development template
-
-### Testing
-
-Chimaera includes comprehensive test suites:
+## Testing
 
 ```bash
-# Run all unit tests
-ctest --test-dir build
-
-# Run specific test suites
-./build/bin/chimaera_bdev_chimod_tests      # Block device tests
-./build/bin/chimaera_comutex_tests          # Synchronization tests
-./build/bin/chimaera_task_archive_tests     # Serialization tests
+ctest --test-dir build/release            # all runtime tests
+ctest --test-dir build/release -R bdev    # block-device module tests
+ctest --test-dir build/release -R comutex # synchronization tests
 ```
+
+## Performance characteristics
+
+- **Task latency:** < 10 µs for local execution.
+- **Memory bandwidth:** up to 50 GB/s with the RAM bdev backend.
+- **Scalability:** single node to multi-node clusters via `lightbeam`.
+- **Concurrency:** thousands of concurrent coroutine-based tasks.
 
 ## Contributing
 
-We welcome contributions to the Chimaera project!
-
-### Development Workflow
-
-1. **Fork** the repository
-2. **Create** a feature branch: `git checkout -b feature/amazing-feature`
-3. **Follow** the coding standards in [CLAUDE.md](CLAUDE.md)
-4. **Test** your changes: `ctest --test-dir build`
-5. **Submit** a pull request
-
-### Coding Standards
-
-- Follow Google C++ Style Guide
-- Use semantic naming for queue IDs and priorities
-- Never use null pool queries - always use `chi::PoolQuery::Local()`
-- Implement proper monitor methods with `route_lane_` assignment
-- Add comprehensive unit tests for new functionality
-
-## Performance Characteristics
-
-Chimaera is designed for high-performance computing scenarios:
-
-- **Task Latency**: < 10 microseconds for local task execution
-- **Memory Bandwidth**: Up to 50 GB/s with RAM-based bdev backend
-- **Scalability**: Single node to multi-node cluster deployments
-- **Concurrency**: Thousands of concurrent coroutine-based tasks
-- **I/O Performance**: Native async I/O with libaio integration
-
-## Use Cases
-
-**Scientific Computing:**
-- High-performance data processing pipelines
-- Near-data computing for large datasets
-- Custom storage engine development
-
-**Storage Systems:**
-- Distributed file system backends
-- Object storage implementations
-- Cache and tiered storage solutions
-
-**Real-Time Applications:**
-- Low-latency data processing
-- Streaming analytics
-- Edge computing deployments
+1. Fork the repo and create a feature branch.
+2. Follow the standards in [AGENTS.md](../AGENTS.md).
+3. `ctest --test-dir build/release` before opening a PR.
+4. Submit a PR against `iowarp/clio-core`.
 
 ## License
 
-Chimaera is licensed under the **BSD 3-Clause License**. See source files for complete license text.
-
----
-
-## Acknowledgements
-
-Chimaera is developed at the [GRC lab](https://grc.iit.edu/) at Illinois Institute of Technology as part of the IOWarp project. This work is supported by the National Science Foundation (NSF) and aims to advance next-generation scientific computing infrastructure.
-
-For more information about IOWarp: https://grc.iit.edu/research/projects/iowarp
+BSD-3-Clause. Developed at the [GRC lab](https://grc.iit.edu/) at Illinois
+Institute of Technology as part of the [IOWarp
+project](https://grc.iit.edu/research/projects/iowarp).

--- a/context-transfer-engine/README.md
+++ b/context-transfer-engine/README.md
@@ -1,60 +1,165 @@
-# The Content Transfer Engine: Clio
-
-The CTE is a heterogeneous-aware, multi-tiered, dynamic, and distributed I/O buffering system designed to accelerate I/O for HPC and data-intensive workloads.
-
+# Context Transfer Engine (CTE)
 
 [![Project Site](https://img.shields.io/badge/Project-Site-blue)](https://grc.iit.edu/research/projects/iowarp)
 [![Documentation](https://img.shields.io/badge/Docs-Hub-green)](https://grc.iit.edu/docs/category/iowarp)
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-yellow.svg)](LICENSE)
-![Build](https://github.com/HDFGroup/iowarp/workflows/GitHub%20Actions/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/HDFGroup/iowarp/badge.svg?branch=master)](https://coveralls.io/github/HDFGroup/iowarp?branch=master)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-yellow.svg)](../LICENSE)
+
+The Context Transfer Engine is a heterogeneous-aware, multi-tiered, dynamic,
+distributed I/O buffering layer designed to accelerate I/O for HPC and
+data-intensive workloads. CTE runs as a pool inside the [CLIO
+runtime](../context-runtime) and is the primary blob/tag storage substrate for
+the higher-level engines ([CAE](../context-assimilation-engine),
+[CEE](../context-exploration-engine)).
 
 ## Overview
 
-iowarp provides a programmable buffering layer across memory/storage tiers and supports multiple I/O pathways via adapters. It integrates with HPC runtimes and workflows to improve throughput, latency, and predictability.
+CTE provides:
 
+- **Programmable buffering** across memory and storage tiers.
+- **Multiple I/O pathways** via adapters (POSIX, STDIO, MPI-IO, HDF5 VFD/VOL,
+  ADIOS2, FUSE3, NVIDIA GDS).
+- **Tag + Blob storage model** — `Tag`s name a container; `Blob`s store the
+  data, addressable by `(tag_id, blob_name, offset, size)`.
+- **Async-first API** returning a `Future`, so multiple operations can be
+  pipelined before the first `Wait()`.
 
-## Build instructions
+## Building
 
-### Dependencies
+CTE is built as part of CLIO Core; it is enabled by default
+(`CLIO_CORE_ENABLE_CTE=ON`):
 
-Our docker container has all dependencies installed for you.
 ```bash
-docker pull iowarp/iowarp-build:latest
+git clone --recurse-submodules https://github.com/iowarp/clio-core.git
+cd clio-core
+cmake --preset release
+cmake --build build/release -j$(nproc)
 ```
 
-### Build with CMake
+See [INSTALL.md](../INSTALL.md) for adapter-specific dependencies (HDF5,
+ADIOS2, FUSE3, GDS, etc.) and the matching `CLIO_CTE_ENABLE_*` flags.
 
-```bash
-mkdir -p build
-cd build
-cmake .. \
-    -DCMAKE_BUILD_TYPE=Release 
-make -j8
-make install
+## C++ Client API
+
+The CTE client lives under `<clio_cte/core/...>` and is initialized through a
+single helper. The runtime must already be running (`clio_run start`) — the
+client auto-connects on first use and creates the CTE pool on demand. Storage
+targets are configured declaratively in the runtime's `compose` YAML, so no
+`RegisterTarget` call is required from the client.
+
+```cpp
+#include <clio_cte/core/core_client.h>
+#include <clio_runtime/ipc_manager.h>
+#include <cstring>
+
+int main() {
+  // 1. Initialize the CTE client. Auto-connects to the runtime started by
+  //    `clio_run start` and creates the CTE pool on the first call.
+  if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) return 1;
+  auto *cte = CLIO_CTE_CLIENT;
+
+  // 2. Get-or-create a named container for blobs. The async APIs return a
+  //    Future immediately; Wait() blocks for completion.
+  auto tag_future = cte->AsyncGetOrCreateTag("my_tag");
+  tag_future.Wait();
+  auto tag_id = tag_future->tag_id_;
+
+  // 3. Stage blob data into a CTE-managed shm buffer and submit the PutBlob
+  //    asynchronously. Submit-then-Wait is the canonical pattern; multiple
+  //    AsyncPutBlob calls can be in flight before the first Wait() to
+  //    pipeline I/O. The async signatures take a type-erased ShmPtr<>, so
+  //    we wrap put_buf.shm_ (typed ShmPtr<char>) in the void-typed view.
+  constexpr size_t kSize = 4096;
+  auto put_buf = CLIO_IPC->AllocateBuffer(kSize);
+  std::memset(put_buf.ptr_, 'A', kSize);
+  ctp::ipc::ShmPtr<> put_data(put_buf.shm_);
+  auto put_future = cte->AsyncPutBlob(tag_id, "my_blob",
+                                       /*offset=*/0, kSize,
+                                       put_data);
+  put_future.Wait();
+  CLIO_IPC->FreeBuffer(put_buf);
+
+  // 4. Pre-allocate the receive buffer in shm, fire an async GetBlob, then
+  //    Wait — the buffer holds the blob data on return.
+  auto get_buf = CLIO_IPC->AllocateBuffer(kSize);
+  ctp::ipc::ShmPtr<> get_data(get_buf.shm_);
+  auto get_future = cte->AsyncGetBlob(tag_id, "my_blob",
+                                       /*offset=*/0, kSize,
+                                       /*flags=*/0,
+                                       get_data);
+  get_future.Wait();
+  // get_buf.ptr_ now holds the retrieved bytes.
+  CLIO_IPC->FreeBuffer(get_buf);
+
+  // 5. Clean up.
+  cte->AsyncDelTag(tag_id).Wait();
+  return 0;
+}
 ```
 
-Tip: run `ccmake ..` (or `cmake-gui`) to browse available CMake options.
+### Build and link
+
+CTE is exported through the unified `clio-core` CMake package:
+
+```cmake
+find_package(clio-core CONFIG REQUIRED)
+
+add_executable(my_app src/main.cpp)
+target_link_libraries(my_app
+  clio::cte::core_client      # CTE client (for the example above)
+  clio::run::admin_client     # admin module (always available)
+  clio::run::bdev_client      # block-device module (always available)
+)
+```
+
+### Operation reference
+
+The client header [`core/include/clio_cte/core/core_client.h`](core/include/clio_cte/core/core_client.h)
+is the authoritative API. The main operations:
+
+| Operation | Async API | Notes |
+|---|---|---|
+| Tag lifecycle | `AsyncGetOrCreateTag`, `AsyncDelTag` | Tags are the container abstraction. |
+| Blob I/O | `AsyncPutBlob`, `AsyncGetBlob` | Take a `ctp::ipc::ShmPtr<>` payload allocated via `CLIO_IPC->AllocateBuffer`. |
+| Blob metadata | `AsyncGetBlobScore`, `AsyncGetBlobSize`, `AsyncGetBlobInfo` | Score drives tier placement. |
+| Tag enumeration | `AsyncGetContainedBlobIds`, `AsyncTagExists` | Enumerate blobs within a tag. |
+
+Each async call returns a `Future<Task>` — call `.Wait()` to block, or keep
+the future around to pipeline subsequent calls.
+
+## Python and Higher-Level APIs
+
+- **Python** — the [CEE](../context-exploration-engine) module
+  (`import clio_cee`) wraps the CTE put/get/query workflow with a higher-level
+  `ContextInterface`.
+- **OMNI ingestion** — for declarative ingestion from external sources
+  (binary files, HDF5, Globus), use the [Context Assimilation
+  Engine](../context-assimilation-engine) which lowers OMNI YAML jobs into
+  CTE tag/blob writes.
 
 ## Testing
 
-- CTest unit tests (after building):
-
 ```bash
-cd build
-ctest -VV
+cd build/release
+ctest -R cte           # unit + integration tests for CTE
 ```
 
-## Development
+A distributed multi-node smoke test lives in
+[`test/integration/distributed/`](test/integration/distributed/).
 
-- Linting: we follow the Google C++ Style Guide.
-    - Run `make lint` (wraps `ci/lint.sh` which uses `cpplint`).
-    - Install `cpplint` via `pip install cpplint` if needed.
+## Project structure
 
-## Contributing
-
-We follow the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html). Submit PRs with clear descriptions and tests when possible. The CI will validate style and builds.
+```
+core/        CTE client + runtime container
+adapter/     I/O pathway adapters (POSIX, STDIO, MPI-IO, VFD, VOL, ADIOS2, FUSE, GDS)
+compressor/  Compression backends (zstd, lz4, zlib, xz, brotli, blosc2)
+config/      Example runtime YAML deploying CTE
+benchmark/   clio_cte_bench and related throughput/latency benchmarks
+llm-hooks/   Hooks for the bundled llama.cpp integration
+uvm/         Unified-virtual-memory experiments
+wrapper/     Python and language bindings
+test/        Unit + integration tests
+```
 
 ## License
 
-This project is licensed under the BSD-3-Clause License - see the [LICENSE](LICENSE) file for details.
+BSD-3-Clause. See [LICENSE](../LICENSE).

--- a/context-transport-primitives/README.md
+++ b/context-transport-primitives/README.md
@@ -1,119 +1,125 @@
+# Context Transport Primitives (CTP)
 
-# Clio Shared Memory (CTE)
-
-[![IoWarp](https://img.shields.io/badge/IoWarp-GitHub-blue.svg)](http://github.com/iowarp)
+[![IoWarp](https://img.shields.io/badge/IoWarp-GitHub-blue.svg)](https://github.com/iowarp)
 [![GRC](https://img.shields.io/badge/GRC-Website-blue.svg)](https://grc.iit.edu/)
 [![C++](https://img.shields.io/badge/C++-17-blue.svg)](https://isocpp.org/)
 [![CUDA](https://img.shields.io/badge/CUDA-Compatible-green.svg)](https://developer.nvidia.com/cuda-zone)
 [![ROCm](https://img.shields.io/badge/ROCm-Compatible-red.svg)](https://rocmdocs.amd.com/)
 
-A high-performance shared memory library containing data structures and synchronization primitives compatible with shared memory, CUDA, and ROCm.
+The foundational shared-memory layer for CLIO Core: data structures, allocators,
+synchronization primitives, and a networking layer (ZeroMQ / libfabric /
+Thallium) that are interoperable across host memory, CUDA, and ROCm.
 
-## Dependencies
+CTP underpins the inter-process communication used by the [CLIO
+runtime](../context-runtime), the [Context Transfer
+Engine](../context-transfer-engine), the [Context Assimilation
+Engine](../context-assimilation-engine), and the [Context Exploration
+Engine](../context-exploration-engine).
 
-### System Requirements
-- CMake >= 3.10
-- C++17 compatible compiler
-- Optional: CUDA toolkit (for GPU support)
-- Optional: ROCm (for AMD GPU support)
-- Optional: MPI, ZeroMQ, Thallium (for distributed computing)
+## What's inside
 
-Our docker container has all dependencies installed for you.
+- **IPC-safe containers** — `vector`, `list`, `unordered_map`, MPSC/SPSC ring
+  queues, all usable across process boundaries via shared memory.
+- **Allocators** — malloc, stack, heap, and GPU-aware allocators.
+- **Synchronization** — locks, atomics, and thread-model abstractions safe to
+  share between host and device.
+- **Networking** — the `lightbeam` transport stack (ZMQ, libfabric, Thallium).
+- **Compression + encryption utilities** — pluggable codecs and crypto
+  primitives.
+- **Introspection** — system topology / NUMA queries used by the runtime
+  scheduler.
+
+## Building
+
+CTP is built as part of CLIO Core; you do not build it standalone:
+
 ```bash
-docker pull iowarp/iowarp-build:latest
+git clone --recurse-submodules https://github.com/iowarp/clio-core.git
+cd clio-core
+cmake --preset release
+cmake --build build/release -j$(nproc)
 ```
 
-## Building Manually
+GPU support is opt-in via the root CMake flags:
 
-```bash
-git clone https://github.com/grc-iit/context-transport-primitives.git
-cd context-transport-primitives
-mkdir build
-cd build
-cmake ../ -DHSHM_ENABLE_CUDA=OFF -DHSHM_ENABLE_ROCM=OFF
-make -j8
-```
+| Flag | Effect |
+|---|---|
+| `CLIO_CORE_ENABLE_CUDA=ON` | Build the CUDA variant of CTP (`ctp::cudacxx`). |
+| `CLIO_CORE_ENABLE_ROCM=ON` | Build the ROCm variant of CTP (`ctp::rocmcxx_gpu`). |
 
-## CMake Integration
+See [INSTALL.md](../INSTALL.md) for the full per-feature dependency list.
 
-ClioCtp provides modular CMake targets for flexible dependency management. Link only what you need.
+## Linking against CTP
 
-### Core Library (CPU-Only)
-```cmake
-find_package(ClioCtp CONFIG REQUIRED)
-target_link_libraries(your_target ctp::cxx)
-```
-
-### Modular Dependency Targets
-
-ClioCtp provides fine-grained modular targets for optional dependencies:
+CTP is exported through the unified `clio-core` CMake package — `find_package`
+it once and link the modular CTP targets you need:
 
 ```cmake
-find_package(ClioCtp CONFIG REQUIRED)
+find_package(clio-core CONFIG REQUIRED)
 
 target_link_libraries(your_target
   ctp::cxx              # Core library (required)
-  ctp::configure        # YAML configuration parsing (instead of yaml-cpp directly)
-  ctp::serialize        # Object serialization (instead of cereal directly)
+  ctp::configure        # YAML configuration parsing (prefer over yaml-cpp directly)
+  ctp::serialize        # Object serialization (prefer over cereal directly)
   ctp::interceptor      # ELF interception for adapters
   ctp::lightbeam        # Network transport (ZMQ, libfabric, Thallium)
   ctp::thread_all       # Threading support (pthread, OpenMP)
-  ctp::mpi              # MPI support (use only where needed)
+  ctp::mpi              # MPI support (only where needed)
   ctp::compress         # Compression utilities
   ctp::encrypt          # Encryption utilities
 )
 ```
 
-**Key Guidelines:**
-- Always link `ctp::cxx` as the base
-- Use `ctp::configure` instead of linking to `yaml-cpp` directly
-- Use `ctp::serialize` instead of linking to `cereal` directly
-- Link only the modular targets you actually need
-- Each modular target includes appropriate compile definitions
+**Guidelines:**
 
-### GPU Support
+- Always link `ctp::cxx` as the base.
+- Prefer `ctp::configure` / `ctp::serialize` over linking yaml-cpp / cereal
+  directly — each modular target carries the compile definitions CTP needs.
+- For GPU code, link `ctp::cudacxx` (CUDA) or `ctp::rocmcxx_gpu` (ROCm)
+  instead of `ctp::cxx`.
 
-**CUDA Version:**
-```cmake
-find_package(ClioCtp CONFIG REQUIRED)
-target_link_libraries(your_target ctp::cudacxx)
+## Headers
+
+The canonical include root is `<clio_ctp/...>`:
+
+```cpp
+#include <clio_ctp/clio_ctp.h>                                // umbrella
+#include <clio_ctp/data_structures/ipc/vector.h>
+#include <clio_ctp/memory/allocator/stack_allocator.h>
+#include <clio_ctp/thread/lock/mutex.h>
 ```
 
-**ROCm Version:**
-```cmake
-find_package(ClioCtp CONFIG REQUIRED)
-target_link_libraries(your_target ctp::rocmcxx_gpu)
+## Project structure
+
+```
+include/clio_ctp/
+  data_structures/      IPC-safe containers, serialization
+    ipc/                vector, list, unordered_map, ring queues
+    internal/           implementation details
+    serialization/      serialization utilities
+  memory/
+    allocator/          malloc, stack, heap, GPU allocators
+    backend/            memory backend implementations
+  thread/
+    lock/               lock implementations
+    thread_model/       thread model abstractions
+  util/
+    compress/           compression utilities
+    encrypt/            crypto primitives
+  lightbeam/            networking layer (ZMQ, libfabric, Thallium)
+  types/                shared type definitions
+  introspect/           system topology / NUMA introspection
+src/                    core library implementation
 ```
 
 ## Tests
 
-To run the tests, do the following:
-```
-ctest
-```
-
-To run the MPSC queue tests, do the following:
-```
-ctest -VV -R test_mpsc_ring_buffer_mpi
+```bash
+cd build/release
+ctest -R ctp           # core CTP tests
+ctest -R mpsc_ring     # MPSC queue tests
 ```
 
-## Project Structure
+## License
 
-- `include/clio_ctp/` - Public API headers organized by functional modules
-  - `data_structures/` - Shared memory compatible data structures
-    - `ipc/` - IPC-safe containers (vector, list, unordered_map, ring queues, etc.)
-    - `internal/` - Internal implementation details
-    - `serialization/` - Serialization utilities
-  - `memory/` - Memory management subsystem
-    - `allocator/` - Allocator implementations (malloc, GPU stack, heap allocators)
-    - `backend/` - Memory backend implementations
-  - `thread/` - Threading and synchronization primitives
-    - `lock/` - Lock implementations
-    - `thread_model/` - Thread model abstractions
-  - `util/` - Utility functions
-    - `compress/` - Compression utilities
-    - `encrypt/` - Encryption utilities
-  - `lightbeam/` - Networking layer (ZMQ transport, networking utilities)
-  - `types/` - Type definitions and utilities
-  - `introspect/` - System introspection capabilities
-- `src/` - Core library implementation files
+BSD-3-Clause. See [LICENSE](../LICENSE).


### PR DESCRIPTION
Companion to [iowarp/docs PR #15](https://github.com/iowarp/docs/pull/15).

## Three pieces

### 1. New \`INSTALL.md\` at repo root
Source-build guide for bare-metal Linux. Sections:
- **TL;DR table** pointing pip / conda / release-tag users away from this file
- **Always-required system prerequisites** with apt + dnf install commands (one-liner each)
- **Per-feature dependency tables** for every \`CLIO_*_ENABLE_*\` flag:
  - Networking + RPC (MPI, libfabric, Thallium, io_uring)
  - Compression (zstd / lz4 / zlib / xz / brotli / blosc2)
  - Encryption (OpenSSL)
  - CTE adapters (POSIX, STDIO, MPI-IO, HDF5 VFD, HDF5 VOL, ADIOS2, FUSE3, NVIDIA GDS)
  - GPU acceleration (CUDA, ROCm, SYCL, NVSHMEM, NIXL)
  - Python bindings, OpenMP, Redis bench, LLM hooks, Globus
  - Testing + sanitizers + coverage + Doxygen
- **Build steps** with CMakePresets.json overview
- **Feature checklist** users can tick to assemble their \`cmake\` invocation
- **Verifying the install**

### 2. README brand cleanup (no \`chimaera\` anywhere)
- ASCII diagram: 'Chimaera Runtime' → 'CLIO Runtime'.
- Drop 'legacy: ~/.chimaera/chimaera.yaml' parenthetical from both config-seeding callouts.
- Drop the 'historical install-time names (\`chimaera::*\`, \`wrp_cte::*\`, \`wrp_cae::*\`)' sentence — those aliases are still exported, but the README isn't the right place to advertise them; point readers at Deprecation Notes instead.
- \`ctest -R chimaera\` → \`ctest -R runtime\` in the testing example.
- Add a link to the new INSTALL.md right above the existing source-install-methods pointer.

### 3. docs/ submodule bump → \`docs/no-chimaera-cli-brand\` (iowarp/docs#15)
Same cleanup on the docs site: 'chimaera CLI' → 'clio_run CLI', \`/tmp/chimaera.log\` → \`/tmp/clio.log\`, \`chimaera_pool_list\` → \`clio_run monitor\`, every YAML compose example → \`mod_name: clio_bdev\`. See the linked docs PR for the full list.

## Preserved on purpose
- C++ namespace references (\`chimaera::admin::Client\`, etc.), \`CHIMAERA_INIT\` / \`ChimaeraMode\` macro+enum, \`<chimaera/...>\` include paths, and \`find_package(chimaera ...)\` calls in SDK docs. Those describe the current C++ API; renaming docs without renaming the code would mismatch reality. Separate API-rebrand effort.
- \`deprecation-notes.md\` and the two legacy-paths callouts in \`docs/deployment/configuration.md\` (line 23) + \`docs/deployment/monitoring.md\` (line 205) — those exist specifically to document the legacy spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)