### PR TITLE
Alias gpu_worker_ onto scheduler worker when headroom is tight

### DIFF
--- a/context-runtime/src/scheduler/default_sched.cc
+++ b/context-runtime/src/scheduler/default_sched.cc
@@ -81,10 +81,16 @@ void DefaultScheduler::DivideWorkers(WorkOrchestrator *work_orch) {
 
   // GPU worker: needs its own worker so kGpuRecv polling doesn't fight with
   // periodic net tasks. Carve it out from before the net pair (N-3) when
-  // we have headroom; otherwise leave gpu_worker_ null (callers must
-  // tolerate this — none of the CPU-only paths exercised below need it).
+  // we have headroom. Below that, alias onto the scheduler worker — the
+  // GPU lane drain is cheap (a single Pop per iteration that returns
+  // immediately when empty), and Worker::Run() already calls
+  // ProcessNewTasksGpu() every loop iteration regardless of role. Leaving
+  // gpu_worker_ null at small N hangs any kernel that calls future.Wait()
+  // because nothing drains gpu2cpu_queue — see issue #448.
   if (total_workers >= 5) {
     gpu_worker_ = work_orch->GetWorker(total_workers - 3);
+  } else {
+    gpu_worker_ = scheduler_worker_;
   }
 
   // I/O workers live between the scheduler and the GPU/net block. With the

--- a/context-runtime/src/scheduler/local_sched.cc
+++ b/context-runtime/src/scheduler/local_sched.cc
@@ -66,6 +66,11 @@ void LocalScheduler::DivideWorkers(WorkOrchestrator *work_orch) {
 
   if (total_workers > 2) {
     gpu_worker_ = work_orch->GetWorker(total_workers - 2);
+  } else {
+    // No headroom for a dedicated GPU worker — alias onto worker 0 so the
+    // gpu2cpu_queue still gets drained. Worker::Run() calls
+    // ProcessNewTasksGpu() each iteration regardless of role. See #448.
+    gpu_worker_ = work_orch->GetWorker(0);
   }
 
   u32 num_sched_workers = (total_workers == 1) ? 1 : (total_workers - 1);


### PR DESCRIPTION
## Summary

- `DefaultScheduler::DivideWorkers` left `gpu_worker_` null when `total_workers < 5`, and `LocalScheduler::DivideWorkers` did the same when `total_workers <= 2`. The default `num_threads=4` config hit the first gate, so the per-device `gpu2cpu_queue` was created at server bring-up but never drained — any kernel that pushed onto it and called `gpu::Future::Wait()` spun on `FUTURE_COMPLETE` forever, hanging `cudaDeviceSynchronize` and timing out the test at 120s.
- Below those thresholds we now alias `gpu_worker_` onto the scheduler worker (or worker 0 for `LocalScheduler`). `Worker::Run()` already calls `ProcessNewTasksGpu()` every iteration regardless of role, so the aliased worker drains both its primary lane and the GPU queue with no extra threading machinery. The GPU drain is cheap when the queue is empty (a single `Pop` that returns immediately).

## Motivation

Fixes #448. Affects both `cr_gpu_kernel_stress_cuda` (the originally-reported hang) and `cte_gpu_vector_cuda` (same code path).

## Test plan

- [x] `ctest -R '^cr_gpu_kernel_stress_cuda$'` — was 120s timeout, now passes in **2.26s**.
- [x] `ctest -L gpu` — all 4 GPU tests pass (`cr_gpu_kernel_stress_cuda`, `cte_gpu_vector_cuda`, `cte_devmem_putget_cuda`, `test_round_robin_alloc_gpu`).
- [x] No new compiler warnings; build is clean.
- [x] CPU-only paths unaffected — when no GPU queues are registered, `gpu_worker_->SetGpuLanes()` is never called, so the aliased worker's `gpu_lanes_` stays empty and `ProcessNewTasksGpu()` is a no-op.

## Breaking changes

None. Behavior is unchanged when `total_workers >= 5` (DefaultScheduler) or `> 2` (LocalScheduler) — the original dedicated-GPU-worker layout is preserved.