### PR TITLE
Rename ctests with chimaera_ prefix to cr_

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -910,19 +910,19 @@ if(CLIO_CORE_ENABLE_TESTS)
 
     if(UNIX)
       add_test(
-          NAME chimaera_pre_test_cleanup
+          NAME cr_pre_test_cleanup
           COMMAND bash -c "${_chimaera_cleanup_cmd}"
       )
-      set_tests_properties(chimaera_pre_test_cleanup PROPERTIES
+      set_tests_properties(cr_pre_test_cleanup PROPERTIES
           TIMEOUT 30
           FIXTURES_SETUP chimaera_test_cleanup_fixture
       )
 
       add_test(
-          NAME chimaera_post_test_cleanup
+          NAME cr_post_test_cleanup
           COMMAND bash -c "${_chimaera_cleanup_cmd}"
       )
-      set_tests_properties(chimaera_post_test_cleanup PROPERTIES
+      set_tests_properties(cr_post_test_cleanup PROPERTIES
           TIMEOUT 30
           FIXTURES_CLEANUP chimaera_test_cleanup_fixture
       )
@@ -948,19 +948,19 @@ if(CLIO_CORE_ENABLE_TESTS)
            exit 0")
 
       add_test(
-          NAME chimaera_pre_test_cleanup
+          NAME cr_pre_test_cleanup
           COMMAND powershell -NoProfile -ExecutionPolicy Bypass -Command "${_chimaera_cleanup_cmd_win}"
       )
-      set_tests_properties(chimaera_pre_test_cleanup PROPERTIES
+      set_tests_properties(cr_pre_test_cleanup PROPERTIES
           TIMEOUT 30
           FIXTURES_SETUP chimaera_test_cleanup_fixture
       )
 
       add_test(
-          NAME chimaera_post_test_cleanup
+          NAME cr_post_test_cleanup
           COMMAND powershell -NoProfile -ExecutionPolicy Bypass -Command "${_chimaera_cleanup_cmd_win}"
       )
-      set_tests_properties(chimaera_post_test_cleanup PROPERTIES
+      set_tests_properties(cr_post_test_cleanup PROPERTIES
           TIMEOUT 30
           FIXTURES_CLEANUP chimaera_test_cleanup_fixture
       )
@@ -1147,14 +1147,14 @@ if(CLIO_CORE_ENABLE_TESTS)
 
     # -----------------------------------------------------------------------
     # Apply the cleanup fixture to every component test so that the
-    # chimaera_post_test_cleanup hook runs after the whole suite, even when
+    # cr_post_test_cleanup hook runs after the whole suite, even when
     # individual tests fail. Excludes the cleanup fixtures themselves.
     # -----------------------------------------------------------------------
     function(_chimaera_require_cleanup_fixture_recursive dir)
         get_directory_property(_tests DIRECTORY "${dir}" TESTS)
         foreach(_t ${_tests})
-            if(NOT _t STREQUAL "chimaera_pre_test_cleanup" AND
-               NOT _t STREQUAL "chimaera_post_test_cleanup")
+            if(NOT _t STREQUAL "cr_pre_test_cleanup" AND
+               NOT _t STREQUAL "cr_post_test_cleanup")
                 set_property(TEST ${_t} DIRECTORY "${dir}" APPEND PROPERTY
                     FIXTURES_REQUIRED chimaera_test_cleanup_fixture)
             endif()

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -578,11 +578,11 @@ if(CLIO_CORE_ENABLE_TESTS)
   # Previously 8 redundant entries each invoked the full unfiltered binary, which
   # serialized via RESOURCE_LOCK but multiplied chimaera shutdown ZMQ-race exposure.
   add_test(
-    NAME cr_chimaera_unit_tests
+    NAME cr_unit_tests
     COMMAND ${TEST_TARGET}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
   )
-  set_tests_properties(cr_chimaera_unit_tests PROPERTIES
+  set_tests_properties(cr_unit_tests PROPERTIES
     ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;CHIMAERA_TEST_MODE=1;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
     TIMEOUT 600
   )
@@ -921,7 +921,7 @@ if(CLIO_CORE_ENABLE_TESTS)
   # Mark all CR runtime tests as msan_skip (they use ZMQ which is uninstrumented).
   # The fork-based tests are excluded on Windows (not built there).
   set(_msan_skip_tests
-    cr_chimaera_unit_tests
+    cr_unit_tests
     cr_ipc_allocate_buffer_basic_tests
     cr_ipc_allocate_buffer_types_tests
     cr_ipc_allocate_buffer_sizes_tests


### PR DESCRIPTION
## Summary

Three registered ctests still carried the legacy `chimaera_` prefix instead of the `cr_` (Clio Runtime) naming used across the rest of the suite:

| Old name | New name |
|---|---|
| `chimaera_pre_test_cleanup` | `cr_pre_test_cleanup` |
| `chimaera_post_test_cleanup` | `cr_post_test_cleanup` |
| `cr_chimaera_unit_tests` | `cr_unit_tests` |

Pure rename, no behavior change. The internal fixture identifier `chimaera_test_cleanup_fixture` (a CMake property value, not a ctest name) is intentionally left alone to keep the diff minimal.

## Motivation

Fixes #451.

## Test plan

- [x] `ctest -N | grep -i chimaera` — returns nothing.
- [x] `ctest -N` shows the three new names at the expected positions (#1, #2, #91).
- [x] Cleanup fixture chain still works: sample run of `cr_pre_test_cleanup` → `cr_unit_tests` + `cr_gpu_kernel_stress_cuda` → `cr_post_test_cleanup` ordered correctly with the `FIXTURES_SETUP` / `FIXTURES_CLEANUP` / `FIXTURES_REQUIRED` properties.

## Breaking changes

Any external script that filters ctest output by the old names (`chimaera_pre_test_cleanup`, `chimaera_post_test_cleanup`, `cr_chimaera_unit_tests`) needs to update its patterns. None known in this repo or in `iowarp` / `clio-kit`.