### PR TITLE
docs(readme): replace nonexistent CLIO_X env var with CLIO_SERVER_CONF

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ clio_run start          # foreground
 clio_run start &        # background
 ```
 
-To override the configuration, point `CLIO_X` at your own YAML file:
+To override the configuration, point `CLIO_SERVER_CONF` at your own YAML file:
 
 ```bash
-export CLIO_X=/path/to/my_config.yaml
+export CLIO_SERVER_CONF=/path/to/my_config.yaml
 clio_run start
 ```
 


### PR DESCRIPTION
The README's Quickstart had this snippet:

\`\`\`bash
export CLIO_X=/path/to/my_config.yaml
clio_run start
\`\`\`

\`CLIO_X\` matches nothing — \`grep -rn 'CLIO_X' /workspace\` excluding build/external returns zero \`getenv\` calls anywhere in the source tree. A user copying this would get silent fallthrough to whichever lookup-chain entry happens to exist (\`~/.clio/clio.yaml\` etc.), not the file they thought they were pointing at.

The actual env var the runtime checks is **\`CLIO_SERVER_CONF\`** (legacy alias \`CHI_SERVER_CONF\` honored via the env-compat layer). See \`ConfigManager::GetServerConfigPath\` at \`context-runtime/src/config_manager.cc:107\`.

Fix both the prose mention on line 134 and the \`export\` command on line 137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)