### PR TITLE
feat(spack): add fuse variant pulling libfuse@3

### DIFF
--- a/installers/spack/packages/iowarp/package.py
+++ b/installers/spack/packages/iowarp/package.py
@@ -45,6 +45,7 @@ class Iowarp(CMakePackage):
     variant('cuda', default=False, description='Enable CUDA support')
     variant('rocm', default=False, description='Enable ROCm support')
     variant('adios2', default=False, description='Build with ADIOS2 support')
+    variant('fuse', default=False, description='Enable FUSE3 adapter (CTE)')
 
     # Core dependencies (always required)
     depends_on('cmake@3.25:')
@@ -69,6 +70,9 @@ class Iowarp(CMakePackage):
     depends_on('mpi', when='+mpiio')
     depends_on('hdf5', when='+hdf5')
     depends_on('adios2', when='+adios2')
+    depends_on('libfuse@3:', when='+fuse')
+
+    conflicts('+fuse', when='~cte', msg='fuse adapter lives under CTE; enable +cte')
 
     # Networking libraries
     # +ares: build libfabric with the full Ares-rail fabric set. The
@@ -198,6 +202,8 @@ class Iowarp(CMakePackage):
                 args.append(self.define('CTE_ENABLE_CUDA', 'ON'))
             if '+rocm' in self.spec:
                 args.append(self.define('CTE_ENABLE_ROCM', 'ON'))
+            if '+fuse' in self.spec:
+                args.append(self.define('CLIO_CTE_ENABLE_FUSE_ADAPTER', 'ON'))
 
         # Context-assimilation-engine (CAE) options (if enabled)
         if '+cae' in self.spec:


### PR DESCRIPTION
## Summary
- New opt-in spack variant ``+fuse`` (default off)
- ``depends_on('libfuse@3:', when='+fuse')`` so spack pulls libfuse@3.16.2
- Wires ``CLIO_CTE_ENABLE_FUSE_ADAPTER=ON`` when the variant is set
- ``conflicts('+fuse', when='~cte')`` because the FUSE adapter lives under context-transfer-engine

## Test plan
- [x] ``spack spec iowarp +fuse`` concretizes and pulls ``libfuse@3.16.2``
- [x] ``spack spec iowarp +fuse ~cte`` is rejected with the conflict message
- [x] ``spack install iowarp +fuse`` builds end-to-end and produces ``clio_cte_fuse``

🤖 Generated with [Claude Code](https://claude.com/claude-code)