### PR TITLE
chore(release): bump version to 1.9.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.9.1 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.9.5 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options


### PR DESCRIPTION
Version bump in preparation for tagging \`v1.9.5\`. Both \`build-pip.yml\` and \`build-packages.yml\`'s \`check-version\` jobs refuse to publish unless \`project(iowarp-core VERSION ...)\` in \`CMakeLists.txt\` matches the tag. \`scikit-build-core\` also regex-extracts the version from this line for the wheel metadata.

### Why v1.9.5 (skipping v1.9.2–v1.9.4)
Test tag to verify the end-to-end release pipeline now that \`build-packages.yml\` (DEB / RPM / AppImage) is fixed (#445) and gated on the same \`check-version\` job + publishes to the same GitHub Release as the wheels. v1.9.0 only shipped wheels; this is the first tag where the packaging workflow should actually complete successfully and append the three native packages to the release.

### Expected release contents on \`v1.9.5\`
- **16 wheels** (cp310–cp313 × Linux x86_64 / Linux aarch64 / macOS arm64 / Windows x64) → uploaded by \`build-pip.yml\`'s \`github-release\` job
- **1 .deb** (Ubuntu) + **1 .rpm** (Fedora) + **1 .AppImage** (portable Linux) → appended by \`build-packages.yml\`'s \`publish-release\` job
- **PyPI** publish via \`pypa/gh-action-pypi-publish@release/v1\` (\`skip-existing: true\`)

### Test plan
- [ ] PR CI green
- [ ] Merge to main
- [ ] Tag \`v1.9.5\` from main HEAD; push tag
- [ ] Confirm GitHub Release at \`v1.9.5\` contains all 19 assets above
- [ ] Confirm PyPI shows \`iowarp-core==1.9.5\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)