### PR TITLE
chore(release): bump version to 1.9.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.9.5 LANGUAGES C CXX)
+project(iowarp-core VERSION 1.9.6 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options


### PR DESCRIPTION
Version bump for the next tag.

Follow-up to v1.9.5 (the test-tag that verified end-to-end release: 16 wheels + 1 .deb + 1 .rpm + 1 .AppImage on one GitHub Release). v1.9.6 picks up whatever lands on \`main\` between the two — e.g. once #458 merges, the next \`v*\` tag also gets the install-and-smoke-test gate on the native packages.

### Expected v1.9.6 release contents
- 16 wheels (cp310–cp313 × Linux x86_64 / Linux aarch64 / macOS arm64 / Windows x64)
- 1 .deb, 1 .rpm, 1 .AppImage (each smoke-tested if #458 is in)
- PyPI \`iowarp-core==1.9.6\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)