### PR TITLE
chore(release): bump version to 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 1.9.7 LANGUAGES C CXX)
+project(iowarp-core VERSION 2.0.0 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options


### PR DESCRIPTION
## Summary
- Bump \`project(iowarp-core VERSION 1.9.7 → 2.0.0)\`

Major version bump marking the first release where the full pipeline (multi-arch wheels on PyPI + GitHub Release, native .deb/.rpm/.AppImage on both x86_64 and arm64, conda) ships end-to-end clean. v1.9.7 fixed the last batch of release-assembly bugs surfaced by v1.9.6.

## Test plan
- [ ] CI green
- [ ] After merge: tag v2.0.0
- [ ] Verify 22-asset GitHub Release lands (2 .deb + 2 .rpm + 2 .AppImage + 16 wheels)
- [ ] Verify PyPI publishes iowarp-core==2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)