### PR TITLE
fix(ci): pass --ignore-errors gcov to lcov capture

### DIFF
--- a/CI/calculate_coverage.sh
+++ b/CI/calculate_coverage.sh
@@ -375,9 +375,14 @@ print_info "Capturing final coverage data with lcov..."
 # --ignore-errors list so that stale .gcda files, missing sources, or
 # version mismatches do not abort the capture.
 if [ "${LCOV_MAJOR}" -ge 2 ] 2>/dev/null; then
-    LCOV_IGNORE_OPTS=(--ignore-errors source,graph,mismatch,empty,unused,negative,count,inconsistent)
+    # 'gcov' covers the case where a single .gcda is corrupted (partial
+    # flush after a crashed/timeout'd test invocation, or a race between
+    # two writers on the same .gcda). Without it, lcov fails the entire
+    # capture run on one bad file. We'd rather drop that file from the
+    # report than fail the whole Build and Test job.
+    LCOV_IGNORE_OPTS=(--ignore-errors source,graph,mismatch,empty,unused,negative,count,inconsistent,gcov)
 else
-    LCOV_IGNORE_OPTS=(--ignore-errors source,graph)
+    LCOV_IGNORE_OPTS=(--ignore-errors source,graph,gcov)
 fi
 
 lcov --capture \


### PR DESCRIPTION
## Summary
A single corrupted \`.gcda\` file (e.g., \`test_reorganize_blob.cc.gcda:corrupted\`) was failing the entire \"Calculate coverage\" step on amd64 Build and Test — even when every unit test passed:

\`\`\`
geninfo: ERROR: GCOV failed for .../test_reorganize_blob.cc.gcda!
(use \"geninfo --ignore-errors gcov ...\" to bypass this error)
\`\`\`

\`.gcda\` corruption is a known intermittent — partial flush after a crashed/timed-out test binary, or a race between two writers on the same \`.gcda\` from a re-invoked test (e.g. Python wrapper invoking the C++ binary twice).

Add \`gcov\` to the existing \`--ignore-errors\` list so the coverage step drops the one bad file from the report instead of failing the whole job.

## Test plan
- [ ] CI green
- [ ] Next .gcda corruption only nukes that one file from the report rather than the whole step

🤖 Generated with [Claude Code](https://claude.com/claude-code)