### PR TITLE
Add mpmc_ring_buffer with locked Pop (RING_BUFFER_LOCK_POP)

### DIFF
--- a/context-transport-primitives/include/clio_ctp/data_structures/ipc/ring_buffer.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/ipc/ring_buffer.h
@@ -44,6 +44,7 @@ using pid_t = int;
 #include "clio_ctp/data_structures/ipc/shm_container.h"
 #include "clio_ctp/data_structures/ipc/vector.h"
 #include "clio_ctp/memory/allocator/allocator.h"
+#include "clio_ctp/thread/lock/mutex.h"
 #include "clio_ctp/types/atomic.h"
 #include "clio_ctp/types/bitfield.h"
 
@@ -65,7 +66,9 @@ enum RingQueueFlag : uint32_t {
   /** Dynamic size (resize buffer when full) */
   RING_BUFFER_DYNAMIC_SIZE = 0x10,
   /** Fixed-size buffer (no dynamic resizing) */
-  RING_BUFFER_FIXED_SIZE = 0x20
+  RING_BUFFER_FIXED_SIZE = 0x20,
+  /** Serialize Pop() with a ctp::Mutex (enables multi-consumer / MPMC) */
+  RING_BUFFER_LOCK_POP = 0x40
 };
 
 /**
@@ -204,6 +207,7 @@ class ring_buffer : public ShmContainer<AllocT> {
   static constexpr bool ErrorOnNoSpace =
       (FLAGS & RING_BUFFER_ERROR_ON_NO_SPACE) != 0;
   static constexpr bool DynamicSize = (FLAGS & RING_BUFFER_DYNAMIC_SIZE) != 0;
+  static constexpr bool LockPop = (FLAGS & RING_BUFFER_LOCK_POP) != 0;
   static constexpr bool IsAtomic = IsMPSC;
 
   using entry_vector = vector<entry_type, AllocT>;
@@ -221,6 +225,8 @@ class ring_buffer : public ShmContainer<AllocT> {
   ctp::ipc::opt_atomic<bool, IsAtomic>
       active_; /**< Whether worker is accepting tasks (true) or blocked in
                   epoll_wait (false) */
+  ctp::ipc::Mutex pop_lock_; /**< Used by Pop() when RING_BUFFER_LOCK_POP is
+                                  set; otherwise unused. */
 
  public:
   /**
@@ -545,6 +551,27 @@ class ring_buffer : public ShmContainer<AllocT> {
    */
   CTP_CROSS_FUN
   bool Pop(T& val) {
+    // When RING_BUFFER_LOCK_POP is set, serialize all of Pop() with a
+    // ctp::Mutex. This turns an MPSC ring buffer into a correct MPMC one:
+    // the CAS in the lock-free path already prevents duplicate delivery,
+    // but multiple consumers contending on the same head slot waste cycles
+    // and produce unfair scheduling. The lock removes that contention and
+    // gives callers a single, simple Pop() entry point.
+    if constexpr (LockPop) {
+      ctp::ipc::ScopedMutex guard(pop_lock_, 0);
+      return PopUnlocked(val);
+    } else {
+      return PopUnlocked(val);
+    }
+  }
+
+ private:
+  /**
+   * Lock-free body of Pop(). When RING_BUFFER_LOCK_POP is not set this is
+   * the only path; when it is set, Pop() wraps this in a ScopedMutex.
+   */
+  CTP_CROSS_FUN
+  bool PopUnlocked(T& val) {
     // Use system-scope loads to bypass GPU L2 cache so that GPU consumers
     // observe CPU-written tail/entry updates in pinned host memory.
     u64 head = head_.load_system();
@@ -575,6 +602,8 @@ class ring_buffer : public ShmContainer<AllocT> {
     head_.store_system(head + 1);
     return true;
   }
+
+ public:
 
   /**
    * Pop with device-scope atomics for GPU→GPU communication.
@@ -736,6 +765,20 @@ using mpsc_ring_buffer =
 template <typename T, typename AllocT = ctp::ipc::Allocator>
 using circular_mpsc_ring_buffer =
     ring_buffer<T, AllocT, (RING_BUFFER_MPSC_FLAGS | RING_BUFFER_FIXED_SIZE)>;
+
+/**
+ * Typedef for fixed-size MPMC (Multiple Producer Multiple Consumer) ring
+ * buffer.
+ *
+ * Identical to mpsc_ring_buffer except Pop() is serialized with a
+ * ctp::Mutex via RING_BUFFER_LOCK_POP, so multiple concurrent consumers
+ * can call Pop() safely without busy-CAS contention on the head slot.
+ */
+template <typename T, typename AllocT = ctp::ipc::Allocator>
+using mpmc_ring_buffer =
+    ring_buffer<T, AllocT,
+                (RING_BUFFER_MPSC_FLAGS | RING_BUFFER_FIXED_SIZE |
+                 RING_BUFFER_WAIT_FOR_SPACE | RING_BUFFER_LOCK_POP)>;
 
 }  // namespace ctp::ipc
 

--- a/context-transport-primitives/test/unit/data_structures/ipc/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/data_structures/ipc/CMakeLists.txt
@@ -46,6 +46,12 @@ add_dependencies(test_ring_buffer_mpsc_exec clio_ctp_host)
 target_link_libraries(test_ring_buffer_mpsc_exec
         clio_ctp_host)
 
+add_executable(test_ring_buffer_mpmc_exec
+        test_ring_buffer_mpmc.cc)
+add_dependencies(test_ring_buffer_mpmc_exec clio_ctp_host)
+target_link_libraries(test_ring_buffer_mpmc_exec
+        clio_ctp_host)
+
 add_executable(test_multi_ring_buffer_exec
         test_multi_ring_buffer.cc)
 add_dependencies(test_multi_ring_buffer_exec clio_ctp_host)
@@ -85,6 +91,8 @@ add_test(NAME ctp_ring_buffer_ext COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_ring_buffer_ext_exec)
 add_test(NAME ctp_ring_buffer_mpsc COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_ring_buffer_mpsc_exec)
+add_test(NAME ctp_ring_buffer_mpmc COMMAND
+        ${CMAKE_BINARY_DIR}/bin/test_ring_buffer_mpmc_exec)
 
 add_test(NAME ctp_multi_ring_buffer COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_multi_ring_buffer_exec)
@@ -93,6 +101,12 @@ add_test(NAME ctp_multi_ring_buffer COMMAND
 set_tests_properties(
   ctp_ring_buffer_mpsc
   PROPERTIES TIMEOUT 15
+)
+
+# MPMC pop-stress test is heavier (more threads / more items) than MPSC.
+set_tests_properties(
+  ctp_ring_buffer_mpmc
+  PROPERTIES TIMEOUT 30
 )
 
 # Skip under MSan: slist/rb_tree tests use precompiled Catch2 which
@@ -117,6 +131,7 @@ set_tests_properties(
   ctp_ring_buffer_spsc
   ctp_ring_buffer_ext
   ctp_ring_buffer_mpsc
+  ctp_ring_buffer_mpmc
   ctp_multi_ring_buffer
   PROPERTIES LABELS "msan_skip"
 )
@@ -132,6 +147,7 @@ install(TARGETS
         test_ring_buffer_spsc_exec
         test_ring_buffer_ext_exec
         test_ring_buffer_mpsc_exec
+        test_ring_buffer_mpmc_exec
         test_multi_ring_buffer_exec
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib

--- a/context-transport-primitives/test/unit/data_structures/ipc/test_ring_buffer_mpmc.cc
+++ b/context-transport-primitives/test/unit/data_structures/ipc/test_ring_buffer_mpmc.cc
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../../../context-runtime/test/simple_test.h"
+#include "clio_ctp/data_structures/ipc/ring_buffer.h"
+#include "clio_ctp/memory/backend/malloc_backend.h"
+#include "clio_ctp/memory/allocator/arena_allocator.h"
+#include <thread>
+#include <chrono>
+#include <atomic>
+#include <vector>
+#include <algorithm>
+
+using namespace ctp::ipc;
+
+/**
+ * Helper function to create an ArenaAllocator for testing
+ */
+static ArenaAllocator<false>* CreateTestAllocator(MallocBackend &backend,
+                                                  size_t arena_size) {
+  backend.shm_init(MemoryBackendId(0, 0), arena_size);
+  return backend.MakeAlloc<ArenaAllocator<false>>();
+}
+
+// ============================================================================
+// MPMC Ring Buffer Tests (Multiple Producer Multiple Consumer)
+//
+// These tests exercise the RING_BUFFER_LOCK_POP path: Pop() is serialized
+// with ctp::Mutex so multiple consumer threads can drain the buffer safely.
+// The stress tests verify (a) no duplicate deliveries and (b) no lost items.
+// ============================================================================
+
+TEST_CASE("MPMC RingBuffer: single consumer sanity", "[ring_buffer][mpmc]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  mpmc_ring_buffer<int, ArenaAllocator<false>> rb(alloc, 64);
+
+  for (int i = 0; i < 32; ++i) {
+    REQUIRE(rb.Push(i));
+  }
+  for (int i = 0; i < 32; ++i) {
+    int val;
+    REQUIRE(rb.Pop(val));
+    REQUIRE(val == i);
+  }
+  REQUIRE(rb.Empty());
+}
+
+TEST_CASE("MPMC RingBuffer: concurrent consumers drain a pre-filled buffer",
+          "[ring_buffer][mpmc]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  constexpr int kItems = 1000;
+  mpmc_ring_buffer<int, ArenaAllocator<false>> rb(alloc, kItems + 16);
+
+  // Pre-fill the buffer with a known set of values.
+  for (int i = 0; i < kItems; ++i) {
+    REQUIRE(rb.Push(i));
+  }
+
+  // 8 consumer threads race to pop. Each thread records its claimed values
+  // in a private vector so we can verify exactly the produced set was
+  // consumed exactly once across all consumers.
+  constexpr int kConsumers = 8;
+  std::vector<std::thread> consumers;
+  std::vector<std::vector<int>> per_consumer(kConsumers);
+
+  for (int c = 0; c < kConsumers; ++c) {
+    consumers.emplace_back([&rb, &per_consumer, c]() {
+      int val;
+      while (rb.Pop(val)) {
+        per_consumer[c].push_back(val);
+      }
+    });
+  }
+  for (auto &t : consumers) t.join();
+
+  std::vector<int> all;
+  for (auto &v : per_consumer) {
+    all.insert(all.end(), v.begin(), v.end());
+  }
+  std::sort(all.begin(), all.end());
+
+  REQUIRE(all.size() == static_cast<size_t>(kItems));
+  for (int i = 0; i < kItems; ++i) {
+    REQUIRE(all[i] == i);  // exactly the produced set, no dups, no losses
+  }
+  REQUIRE(rb.Empty());
+}
+
+TEST_CASE("MPMC RingBuffer: producers and consumers running in parallel",
+          "[ring_buffer][mpmc]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  constexpr int kProducers = 4;
+  constexpr int kConsumers = 4;
+  constexpr int kPerProducer = 500;
+  constexpr int kTotal = kProducers * kPerProducer;
+
+  mpmc_ring_buffer<int, ArenaAllocator<false>> rb(alloc, 128);
+
+  std::atomic<int> produced(0);
+  std::atomic<int> consumed(0);
+  std::atomic<bool> producers_done(false);
+
+  // Encode (producer_id, seq) into a single int so we can detect duplicates.
+  // Producer i emits values [i*kPerProducer .. (i+1)*kPerProducer).
+  std::vector<std::thread> producers;
+  for (int p = 0; p < kProducers; ++p) {
+    producers.emplace_back([&rb, &produced, p]() {
+      int base = p * kPerProducer;
+      for (int i = 0; i < kPerProducer; ++i) {
+        // Push retries on transient full conditions (WAIT_FOR_SPACE mode
+        // blocks internally, so Push really only fails on capacity exhaustion
+        // — but be defensive).
+        while (!rb.Push(base + i)) {
+          std::this_thread::yield();
+        }
+        produced.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+  }
+
+  std::vector<std::thread> consumer_threads;
+  std::vector<std::vector<int>> per_consumer(kConsumers);
+  for (int c = 0; c < kConsumers; ++c) {
+    consumer_threads.emplace_back([&rb, &consumed, &producers_done,
+                                   &per_consumer, c]() {
+      int val;
+      while (true) {
+        if (rb.Pop(val)) {
+          per_consumer[c].push_back(val);
+          consumed.fetch_add(1, std::memory_order_relaxed);
+        } else if (producers_done.load(std::memory_order_acquire)) {
+          // Drain remainder.
+          while (rb.Pop(val)) {
+            per_consumer[c].push_back(val);
+            consumed.fetch_add(1, std::memory_order_relaxed);
+          }
+          return;
+        } else {
+          std::this_thread::sleep_for(std::chrono::microseconds(50));
+        }
+      }
+    });
+  }
+
+  for (auto &t : producers) t.join();
+  producers_done.store(true, std::memory_order_release);
+  for (auto &t : consumer_threads) t.join();
+
+  REQUIRE(produced.load() == kTotal);
+  REQUIRE(consumed.load() == kTotal);
+  REQUIRE(rb.Empty());
+
+  // Verify that the union of consumer outputs is exactly the produced set,
+  // with no duplicates. This is the load-bearing MPMC correctness check.
+  std::vector<int> all;
+  for (auto &v : per_consumer) {
+    all.insert(all.end(), v.begin(), v.end());
+  }
+  std::sort(all.begin(), all.end());
+  REQUIRE(all.size() == static_cast<size_t>(kTotal));
+  for (int i = 0; i < kTotal; ++i) {
+    REQUIRE(all[i] == i);
+  }
+}
+
+TEST_CASE("MPMC RingBuffer: heavy pop contention with small buffer",
+          "[ring_buffer][mpmc]") {
+  MallocBackend backend;
+  auto *alloc = CreateTestAllocator(backend, 1024 * 1024);
+
+  // Small buffer + many consumers maximizes contention on pop_lock_.
+  constexpr int kItems = 5000;
+  constexpr int kConsumers = 16;
+  mpmc_ring_buffer<int, ArenaAllocator<false>> rb(alloc, 32);
+
+  std::atomic<int> consumed(0);
+  std::atomic<bool> producer_done(false);
+
+  std::thread producer([&rb, &producer_done]() {
+    for (int i = 0; i < kItems; ++i) {
+      while (!rb.Push(i)) {
+        std::this_thread::yield();
+      }
+    }
+    producer_done.store(true, std::memory_order_release);
+  });
+
+  std::vector<std::thread> consumers;
+  std::vector<std::vector<int>> per_consumer(kConsumers);
+  for (int c = 0; c < kConsumers; ++c) {
+    consumers.emplace_back([&rb, &consumed, &producer_done, &per_consumer, c]() {
+      int val;
+      while (true) {
+        if (rb.Pop(val)) {
+          per_consumer[c].push_back(val);
+          consumed.fetch_add(1, std::memory_order_relaxed);
+        } else if (producer_done.load(std::memory_order_acquire)) {
+          while (rb.Pop(val)) {
+            per_consumer[c].push_back(val);
+            consumed.fetch_add(1, std::memory_order_relaxed);
+          }
+          return;
+        }
+      }
+    });
+  }
+
+  producer.join();
+  for (auto &t : consumers) t.join();
+
+  REQUIRE(consumed.load() == kItems);
+  REQUIRE(rb.Empty());
+
+  std::vector<int> all;
+  for (auto &v : per_consumer) {
+    all.insert(all.end(), v.begin(), v.end());
+  }
+  std::sort(all.begin(), all.end());
+  REQUIRE(all.size() == static_cast<size_t>(kItems));
+  for (int i = 0; i < kItems; ++i) {
+    REQUIRE(all[i] == i);
+  }
+}
+
+SIMPLE_TEST_MAIN()


### PR DESCRIPTION
## Summary
- New compile-time flag `RING_BUFFER_LOCK_POP` serializes `ring_buffer::Pop()` with a `ctp::Mutex`.
- New `mpmc_ring_buffer<T, AllocT>` alias = `mpsc_ring_buffer` + `RING_BUFFER_LOCK_POP`.
- New stress test `test_ring_buffer_mpmc` (4 ctest cases) covering single-consumer sanity, multi-consumer drain, parallel producers+consumers, and heavy pop contention. Each asserts the union of consumer outputs matches the produced set exactly (no losses, no duplicates).

## Motivation
Fixes #468. The existing MPSC ring buffer is correct for one consumer; with many consumers the CAS in `Pop()` prevents duplicate delivery but wastes cycles spinning on the head slot. MPMC users now have a single, fair, simple Pop entry point.

## Implementation notes
- `Pop()` body is split: a private `PopUnlocked()` holds the original lock-free logic verbatim; `Pop()` wraps it in `ScopedMutex` only when `LockPop` is set, so SPSC/MPSC paths are byte-identical to before.
- `PopDevice()` (GPU consumer path) is intentionally left lock-free.
- The mutex member is unconditionally present in the struct. Cost is ~24 bytes per ring buffer; this seemed acceptable vs. the extra template plumbing needed for a conditional member.

## Test plan
- [x] `ctest -R ctp_ring_buffer_mpmc` passes (4/4 cases)
- [x] `ctest -R 'ctp_ring_buffer|ctp_multi_ring_buffer'` — full ring_buffer suite still passes
- [ ] CI green

## Breaking changes
None. Existing aliases (`spsc_ring_buffer`, `mpsc_ring_buffer`, `ext_ring_buffer`, `circular_mpsc_ring_buffer`) are unchanged at the API and behavior level.