### PR TITLE
fix(macos): resolve issue #473 macOS test failures (83 → 189/201)

### DIFF
--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -84,6 +84,31 @@ jobs:
             -E "cr_bdev_|cr_mpi_|cr_per_process_shm_stress" \
             || echo "::warning::ctest reported failures (see log above)"
 
+      - name: Diagnose ZMQ ROUTER peer lifecycle
+        if: always()
+        run: |
+          if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          fi
+          conda activate iowarp || true
+          pkill -9 -f 'clio_run|chimaera' || true
+          rm -rf "/tmp/chimaera_${USER}" || true
+          cd build/bin
+          # Enable the ROUTER socket monitor in BOTH the client (test) and the
+          # spawned clio_run daemon, run the simple cross-process test, and dump
+          # the connect/accept/disconnect/handshake timeline + EHOSTUNREACH.
+          export CLIO_ZMQ_MONITOR=1
+          export CLIO_TEST_SERVER_LOG=/tmp/clio_run_diag.log
+          export CHI_REPO_PATH="$PWD"
+          ./chimaera_external_client_tests "ExternalClient - Basic Connection" \
+            > /tmp/client_diag.log 2>&1 || true
+          echo "=== server ZMQMON + EHOSTUNREACH timeline ==="
+          grep -nE "ZMQMON|Host unreachable|ServerInit IpcManager: TCP ROUTER|EnqueueNetTask" \
+            /tmp/clio_run_diag.log 2>/dev/null | head -40 || echo "(none)"
+          echo "=== client ZMQMON ==="
+          grep -E "ZMQMON" /tmp/client_diag.log 2>/dev/null | head -20 || echo "(none)"
+          pkill -9 -f 'clio_run|chimaera' || true
+
       - name: Summarize failed tests
         if: always()
         run: |

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -1,0 +1,110 @@
+name: Mac Test (issue-473)
+
+# Diagnostic workflow for https://github.com/iowarp/clio-core/issues/473
+# ("test(mac): 81 tests fail").
+#
+# The regular Build and Test workflow only runs ctest on Linux (the
+# coverage path). On macOS it builds the conda package but never runs the
+# unit tests, so Mac regressions are invisible in CI. This workflow builds
+# a normal dev tree on macOS and runs ctest so the failing tests show up in
+# the GitHub Actions log (no CDash login required).
+
+on:
+  push:
+    branches:
+      - issue-473
+  workflow_dispatch:
+
+jobs:
+  mac-test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-14
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install dependencies (conda)
+        run: |
+          chmod +x install.sh
+          ./install.sh --only-deps release
+
+      - name: Configure, build and test
+        run: |
+          set -x
+          # Re-activate the conda env created by install.sh (env vars do
+          # not persist across GitHub Actions steps).
+          if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          elif [ -f "$HOME/anaconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/anaconda3/etc/profile.d/conda.sh"
+          elif command -v conda >/dev/null 2>&1; then
+            eval "$(conda shell.bash hook)"
+          fi
+          conda activate iowarp
+
+          export CMAKE_PREFIX_PATH="${CONDA_PREFIX}${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+          export PKG_CONFIG_PATH="${CONDA_PREFIX}/lib/pkgconfig:${CONDA_PREFIX}/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+
+          # Mirror the coverage build's option overrides so we exercise the
+          # same test set CDash reported failing, minus coverage tooling
+          # (lcov/gcov is Linux-only).
+          cmake --preset=debug \
+            -DCLIO_CORE_ENABLE_COVERAGE=OFF \
+            -DCLIO_CORE_ENABLE_CONDA=ON \
+            -DCLIO_CORE_ENABLE_DOCKER_CI=OFF \
+            -DCLIO_CTE_ENABLE_ADIOS2_ADAPTER=OFF \
+            -DCLIO_CTE_ENABLE_COMPRESS=OFF \
+            -DCLIO_CORE_ENABLE_GRAY_SCOTT=OFF
+
+          cmake --build build -- -j"$(sysctl -n hw.ncpu)"
+
+      - name: Run ctest
+        run: |
+          if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          elif [ -f "$HOME/anaconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/anaconda3/etc/profile.d/conda.sh"
+          elif command -v conda >/dev/null 2>&1; then
+            eval "$(conda shell.bash hook)"
+          fi
+          conda activate iowarp
+
+          cd build
+          # Same exclusions as CI/calculate_coverage.sh so we compare apples
+          # to apples with the CDash "coverage" build.
+          ctest --output-on-failure --timeout 120 \
+            -LE "integration|restart|functional|query|stress|docker" \
+            -E "cr_bdev_|cr_mpi_|cr_per_process_shm_stress" \
+            || echo "::warning::ctest reported failures (see log above)"
+
+      - name: Summarize failed tests
+        if: always()
+        run: |
+          LOG="build/Testing/Temporary/LastTest.log"
+          echo "## macOS test summary (${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$LOG" ]; then
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -E "Test #|\*\*\*Failed|\*\*\*Exception|Passed|Failed" "$LOG" \
+              | grep -E "Failed|Exception" >> "$GITHUB_STEP_SUMMARY" || \
+              echo "(no failures parsed from LastTest.log)" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "(LastTest.log not found)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-test-logs-${{ matrix.os }}
+          path: |
+            build/Testing/Temporary/LastTest.log
+            build/Testing/Temporary/CTestCostData.txt
+          if-no-files-found: warn

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -84,31 +84,6 @@ jobs:
             -E "cr_bdev_|cr_mpi_|cr_per_process_shm_stress" \
             || echo "::warning::ctest reported failures (see log above)"
 
-      - name: Diagnose ZMQ ROUTER peer lifecycle
-        if: always()
-        run: |
-          if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
-            source "$HOME/miniconda3/etc/profile.d/conda.sh"
-          fi
-          conda activate iowarp || true
-          pkill -9 -f 'clio_run|chimaera' || true
-          rm -rf "/tmp/chimaera_${USER}" || true
-          cd build/bin
-          # Enable the ROUTER socket monitor in BOTH the client (test) and the
-          # spawned clio_run daemon, run the simple cross-process test, and dump
-          # the connect/accept/disconnect/handshake timeline + EHOSTUNREACH.
-          export CLIO_ZMQ_MONITOR=1
-          export CLIO_TEST_SERVER_LOG=/tmp/clio_run_diag.log
-          export CHI_REPO_PATH="$PWD"
-          ./chimaera_external_client_tests "ExternalClient - Basic Connection" \
-            > /tmp/client_diag.log 2>&1 || true
-          echo "=== server ZMQMON + EHOSTUNREACH timeline ==="
-          grep -nE "ZMQMON|Host unreachable|ServerInit IpcManager: TCP ROUTER|EnqueueNetTask" \
-            /tmp/clio_run_diag.log 2>/dev/null | head -40 || echo "(none)"
-          echo "=== client ZMQMON ==="
-          grep -E "ZMQMON" /tmp/client_diag.log 2>/dev/null | head -20 || echo "(none)"
-          pkill -9 -f 'clio_run|chimaera' || true
-
       - name: Summarize failed tests
         if: always()
         run: |

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -84,40 +84,31 @@ jobs:
             -E "cr_bdev_|cr_mpi_|cr_per_process_shm_stress" \
             || echo "::warning::ctest reported failures (see log above)"
 
-      - name: Diagnose clio_run daemon standalone
+      - name: Diagnose cross-process client handshake
         if: always()
         run: |
           if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
             source "$HOME/miniconda3/etc/profile.d/conda.sh"
           fi
           conda activate iowarp || true
-          echo "=== leaked runtime processes after ctest ==="
-          pgrep -afl 'clio_run|chimaera' || echo "(none)"
           pkill -9 -f 'clio_run|chimaera' || true
-          echo "=== launch clio_run start standalone on port 10600 ==="
-          cd build/bin
           rm -rf "/tmp/chimaera_${USER}" || true
-          CLIO_PORT=10600 CLIO_BIND_ADDR=127.0.0.1 CHI_REPO_PATH="$PWD" \
-            ./clio_run start > /tmp/clio_run_diag.log 2>&1 &
-          DAEMON=$!
-          echo "clio_run pid=$DAEMON"
-          for i in $(seq 1 30); do
-            sleep 1
-            if ! kill -0 "$DAEMON" 2>/dev/null; then echo "clio_run EXITED early at ${i}s"; break; fi
-            if [ -e "/tmp/chimaera_${USER}/chi_main_segment_${USER}" ]; then
-              echo "main segment appeared after ${i}s"; break
-            fi
-          done
-          echo "=== /tmp/chimaera_${USER} contents ==="
-          ls -la "/tmp/chimaera_${USER}" 2>/dev/null || echo "(dir missing)"
-          echo "=== port 10600/10603 listeners ==="
-          lsof -nP -iTCP:10600 -sTCP:LISTEN 2>/dev/null || echo "(10600 not listening)"
-          lsof -nP -iTCP:10603 -sTCP:LISTEN 2>/dev/null || echo "(10603 not listening)"
-          kill -TERM "$DAEMON" 2>/dev/null || true
-          sleep 2
-          kill -9 "$DAEMON" 2>/dev/null || true
-          echo "=== clio_run_diag.log (first 120 lines) ==="
-          head -120 /tmp/clio_run_diag.log || true
+          cd build/bin
+          # Run ONLY the simple external-client Basic Connection test. The
+          # RuntimeServer helper redirects the spawned clio_run's output to
+          # CLIO_TEST_SERVER_LOG; capture both the client (test) output and the
+          # server log to see why the TCP client handshake (WaitForLocalServer)
+          # fails while the daemon is up.
+          export CLIO_TEST_SERVER_LOG=/tmp/clio_run_diag.log
+          export CHI_REPO_PATH="$PWD"
+          echo "=== client (test) output ==="
+          ./chimaera_external_client_tests "ExternalClient - Basic Connection" \
+            > /tmp/client_diag.log 2>&1 || true
+          grep -viE "GetScanDirectories|ScanForChiMods|Loaded ChiMod" /tmp/client_diag.log | tail -40
+          echo "=== server (clio_run) log: routing/identity/Send/Recv lines ==="
+          grep -iE "ROUTER|DEALER|identity|Host unreachable|EnqueueNetTask|RuntimeRecv|RuntimeSend|client.*recv|Send\(|rc=|disconnect|connect|bind" \
+            /tmp/clio_run_diag.log 2>/dev/null | grep -viE "GetScanDirectories|ScanForChiMods|Loaded ChiMod" | tail -50
+          pkill -9 -f 'clio_run|chimaera' || true
 
       - name: Summarize failed tests
         if: always()
@@ -144,4 +135,5 @@ jobs:
             build/Testing/Temporary/CTestCostData.txt
             /tmp/clio_run_diag.log
             /tmp/clio_run_test_server.log
+            /tmp/client_diag.log
           if-no-files-found: warn

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -84,36 +84,6 @@ jobs:
             -E "cr_bdev_|cr_mpi_|cr_per_process_shm_stress" \
             || echo "::warning::ctest reported failures (see log above)"
 
-      - name: Diagnose cross-process client handshake
-        if: always()
-        run: |
-          if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
-            source "$HOME/miniconda3/etc/profile.d/conda.sh"
-          fi
-          conda activate iowarp || true
-          pkill -9 -f 'clio_run|chimaera' || true
-          rm -rf "/tmp/chimaera_${USER}" || true
-          cd build/bin
-          # Run ONLY the simple external-client Basic Connection test. The
-          # RuntimeServer helper redirects the spawned clio_run's output to
-          # CLIO_TEST_SERVER_LOG; capture both the client (test) output and the
-          # server log to see why the TCP client handshake (WaitForLocalServer)
-          # fails while the daemon is up.
-          export CLIO_TEST_SERVER_LOG=/tmp/clio_run_diag.log
-          export CHI_REPO_PATH="$PWD"
-          echo "=== client (test) output ==="
-          ./chimaera_external_client_tests "ExternalClient - Basic Connection" \
-            > /tmp/client_diag.log 2>&1 || true
-          echo "--- IDDIAG (client) ---"
-          grep -E "\[IDDIAG\]" /tmp/client_diag.log || echo "(no client IDDIAG)"
-          echo "--- IDDIAG (server) ---"
-          grep -E "\[IDDIAG\]" /tmp/clio_run_diag.log || echo "(no server IDDIAG)"
-          grep -viE "GetScanDirectories|ScanForChiMods|Loaded ChiMod" /tmp/client_diag.log | tail -25
-          echo "=== server (clio_run) log: routing/identity/Send/Recv lines ==="
-          grep -iE "ROUTER|DEALER|identity|Host unreachable|EnqueueNetTask|RuntimeRecv|RuntimeSend|client.*recv|Send\(|rc=|disconnect|connect|bind" \
-            /tmp/clio_run_diag.log 2>/dev/null | grep -viE "GetScanDirectories|ScanForChiMods|Loaded ChiMod" | tail -50
-          pkill -9 -f 'clio_run|chimaera' || true
-
       - name: Summarize failed tests
         if: always()
         run: |
@@ -137,7 +107,4 @@ jobs:
           path: |
             build/Testing/Temporary/LastTest.log
             build/Testing/Temporary/CTestCostData.txt
-            /tmp/clio_run_diag.log
-            /tmp/clio_run_test_server.log
-            /tmp/client_diag.log
           if-no-files-found: warn

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -84,6 +84,41 @@ jobs:
             -E "cr_bdev_|cr_mpi_|cr_per_process_shm_stress" \
             || echo "::warning::ctest reported failures (see log above)"
 
+      - name: Diagnose clio_run daemon standalone
+        if: always()
+        run: |
+          if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+            source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          fi
+          conda activate iowarp || true
+          echo "=== leaked runtime processes after ctest ==="
+          pgrep -afl 'clio_run|chimaera' || echo "(none)"
+          pkill -9 -f 'clio_run|chimaera' || true
+          echo "=== launch clio_run start standalone on port 10600 ==="
+          cd build/bin
+          rm -rf "/tmp/chimaera_${USER}" || true
+          CLIO_PORT=10600 CLIO_BIND_ADDR=127.0.0.1 CHI_REPO_PATH="$PWD" \
+            ./clio_run start > /tmp/clio_run_diag.log 2>&1 &
+          DAEMON=$!
+          echo "clio_run pid=$DAEMON"
+          for i in $(seq 1 30); do
+            sleep 1
+            if ! kill -0 "$DAEMON" 2>/dev/null; then echo "clio_run EXITED early at ${i}s"; break; fi
+            if [ -e "/tmp/chimaera_${USER}/chi_main_segment_${USER}" ]; then
+              echo "main segment appeared after ${i}s"; break
+            fi
+          done
+          echo "=== /tmp/chimaera_${USER} contents ==="
+          ls -la "/tmp/chimaera_${USER}" 2>/dev/null || echo "(dir missing)"
+          echo "=== port 10600/10603 listeners ==="
+          lsof -nP -iTCP:10600 -sTCP:LISTEN 2>/dev/null || echo "(10600 not listening)"
+          lsof -nP -iTCP:10603 -sTCP:LISTEN 2>/dev/null || echo "(10603 not listening)"
+          kill -TERM "$DAEMON" 2>/dev/null || true
+          sleep 2
+          kill -9 "$DAEMON" 2>/dev/null || true
+          echo "=== clio_run_diag.log (first 120 lines) ==="
+          head -120 /tmp/clio_run_diag.log || true
+
       - name: Summarize failed tests
         if: always()
         run: |
@@ -107,4 +142,6 @@ jobs:
           path: |
             build/Testing/Temporary/LastTest.log
             build/Testing/Temporary/CTestCostData.txt
+            /tmp/clio_run_diag.log
+            /tmp/clio_run_test_server.log
           if-no-files-found: warn

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -1,18 +1,25 @@
-name: Mac Test (issue-473)
+name: Mac Test
 
-# Diagnostic workflow for https://github.com/iowarp/clio-core/issues/473
-# ("test(mac): 81 tests fail").
+# macOS unit-test workflow (originally added for
+# https://github.com/iowarp/clio-core/issues/473, "test(mac): 81 tests fail").
 #
-# The regular Build and Test workflow only runs ctest on Linux (the
-# coverage path). On macOS it builds the conda package but never runs the
-# unit tests, so Mac regressions are invisible in CI. This workflow builds
-# a normal dev tree on macOS and runs ctest so the failing tests show up in
-# the GitHub Actions log (no CDash login required).
+# The regular Build and Test workflow only runs ctest on Linux (the coverage
+# path). On macOS it builds the conda package but never runs the unit tests,
+# so Mac regressions are invisible in CI. This workflow builds a normal dev
+# tree on macOS and runs ctest, surfacing failures in the Actions log + step
+# summary + an uploaded LastTest.log artifact (no CDash login required).
+#
+# NON-BLOCKING: ctest failures are reported as warnings, not job failures, so
+# this does not gate merges while the remaining macOS issues are worked
+# (notably the cross-process ZMQ ROUTER bug tracked as a follow-up to #473).
 
 on:
   push:
     branches:
-      - issue-473
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -104,7 +104,11 @@ jobs:
           echo "=== client (test) output ==="
           ./chimaera_external_client_tests "ExternalClient - Basic Connection" \
             > /tmp/client_diag.log 2>&1 || true
-          grep -viE "GetScanDirectories|ScanForChiMods|Loaded ChiMod" /tmp/client_diag.log | tail -40
+          echo "--- IDDIAG (client) ---"
+          grep -E "\[IDDIAG\]" /tmp/client_diag.log || echo "(no client IDDIAG)"
+          echo "--- IDDIAG (server) ---"
+          grep -E "\[IDDIAG\]" /tmp/clio_run_diag.log || echo "(no server IDDIAG)"
+          grep -viE "GetScanDirectories|ScanForChiMods|Loaded ChiMod" /tmp/client_diag.log | tail -25
           echo "=== server (clio_run) log: routing/identity/Send/Recv lines ==="
           grep -iE "ROUTER|DEALER|identity|Host unreachable|EnqueueNetTask|RuntimeRecv|RuntimeSend|client.*recv|Send\(|rc=|disconnect|connect|bind" \
             /tmp/clio_run_diag.log 2>/dev/null | grep -viE "GetScanDirectories|ScanForChiMods|Loaded ChiMod" | tail -50

--- a/context-runtime/include/clio_runtime/ipc_manager.h
+++ b/context-runtime/include/clio_runtime/ipc_manager.h
@@ -36,6 +36,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -216,6 +217,19 @@ class IpcManager {
    * are owned by Worker objects freed during Finalize().
    */
   void ClearTransports();
+
+  /**
+   * Register a callback to run at the very start of ClearTransports(), while
+   * the transport objects are still alive. Modules that spawn background
+   * threads holding a raw transport pointer (e.g. the admin module's
+   * peer/client recv threads, which cache GetMainTransport()) MUST register a
+   * hook here that stops and joins those threads. Otherwise the threads keep
+   * calling Recv() on a transport that ClearTransports() has freed -- a
+   * use-after-free that is benign on Linux (Recv returns EAGAIN and the thread
+   * sleeps) but a hard crash on macOS (Recv busy-spins on ENOTSOCK over freed
+   * memory). Hooks run once and are then cleared.
+   */
+  void RegisterTransportShutdownHook(std::function<void()> hook);
 
   /**
    * Server finalize - cleanup all IPC resources
@@ -1348,6 +1362,11 @@ class IpcManager {
 
   // Main ZeroMQ transport (server mode) for distributed communication
   ctp::lbm::TransportPtr main_transport_;
+
+  // Callbacks run at the start of ClearTransports() to stop module-owned
+  // threads that hold raw transport pointers. See RegisterTransportShutdownHook.
+  std::mutex transport_shutdown_hooks_mutex_;
+  std::vector<std::function<void()>> transport_shutdown_hooks_;
 
   // IPC transport mode (TCP default, configurable via CHI_IPC_MODE)
   IpcMode ipc_mode_ = IpcMode::kTcp;

--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_runtime.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_runtime.h
@@ -143,6 +143,14 @@ private:
   std::thread peer_recv_thread_;
   std::thread client_recv_thread_;
 
+  /**
+   * Signal the dedicated recv threads to exit and join them. Idempotent (a
+   * second call is a no-op once the threads are joined). Invoked both from the
+   * IpcManager transport-shutdown hook (so the threads stop while the main
+   * transport is still alive) and from ~Runtime as a backstop.
+   */
+  void StopRecvThreads();
+
 public:
   /**
    * Constructor

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -192,11 +192,19 @@ static inline uint64_t HrtNs() {
 // Method implementations
 //===========================================================================
 
-Runtime::~Runtime() {
-  // Signal dedicated recv threads to exit and join them.
+void Runtime::StopRecvThreads() {
+  // Signal dedicated recv threads to exit and join them. The threads cache a
+  // raw pointer to the main transport, so they MUST be joined before
+  // IpcManager::ClearTransports() frees it (see RegisterTransportShutdownHook).
   recv_shutdown_.store(true, std::memory_order_release);
   if (peer_recv_thread_.joinable()) peer_recv_thread_.join();
   if (client_recv_thread_.joinable()) client_recv_thread_.join();
+}
+
+Runtime::~Runtime() {
+  // Backstop: normally the IpcManager transport-shutdown hook already joined
+  // these (while the transport was still alive). Safe to call again.
+  StopRecvThreads();
 }
 
 chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
@@ -322,6 +330,12 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
     }
     HLOG(kInfo, "[ClientRecvThread] shutting down");
   });
+
+  // Stop these recv threads at the very start of IpcManager::ClearTransports(),
+  // i.e. before the main transport they poll is freed. Without this, on
+  // shutdown the threads keep calling Recv() on a freed transport -- benign on
+  // Linux but a hard crash on macOS (busy-spin on ENOTSOCK over freed memory).
+  CLIO_IPC->RegisterTransportShutdownHook([this]() { StopRecvThreads(); });
 
   // Spawn periodic WreapDeadIpcs task with 1 second period
   // This task reaps shared memory segments from dead processes

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -249,8 +249,12 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
   // EnqueueNetTask is invoked from many worker threads anyway.
   client_.AsyncSendPoll(chi::PoolQuery::Local(), 0, 500);
 
-  // Spawn periodic ClientSend task for client response sending via lightbeam
-  client_.AsyncClientSend(chi::PoolQuery::Local(), 100);
+  // Client response sending now happens on client_recv_thread_ (below), which
+  // also owns the client ROUTER/IPC recv -- ZMQ ROUTER/DEALER sockets are not
+  // thread-safe, so recv and send must share one thread (see #473; on macOS a
+  // split caused EHOSTUNREACH on every response). The net_recv_worker
+  // AsyncClientSend periodic is intentionally NOT scheduled.
+  // client_.AsyncClientSend(chi::PoolQuery::Local(), 100);
 
   // Dedicated single peer recv thread: polls the main p2p transport
   // (port 9413 by default) and dispatches inbound task forwards/responses.
@@ -320,10 +324,22 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
     ctp::SystemInfo::SetCurrentThreadName("chi-client-recv");
     auto *ipc_manager = CLIO_IPC;
     HLOG(kInfo, "[ClientRecvThread] started");
+    // This thread owns BOTH recv and send on the client ROUTER/IPC sockets.
+    // ZMQ ROUTER/DEALER sockets are not thread-safe: the routing-id a ROUTER
+    // learns on the recv thread is not reliably visible to a different thread
+    // that sends (observed on macOS as a persistent EHOSTUNREACH / "Host
+    // unreachable" when routing the response, even though the peer connection
+    // is healthy). Draining the client-send queue here keeps all socket I/O on
+    // one thread. The matching net_recv_worker AsyncClientSend periodic is
+    // disabled so only this thread touches these sockets.
+    std::vector<ctp::ipc::FullPtr<chi::Task>> deferred_deletes;
     while (!recv_shutdown_.load(std::memory_order_acquire)) {
       chi::u32 tasks_received = 0;
       bool did_work = chi::IpcCpu2CpuZmq::RuntimeRecv(ipc_manager,
                                                        tasks_received);
+      chi::u32 tasks_sent = 0;
+      did_work |= chi::IpcCpu2CpuZmq::RuntimeSend(ipc_manager, tasks_sent,
+                                                  deferred_deletes);
       if (!did_work) {
         std::this_thread::sleep_for(std::chrono::microseconds(1));
       }

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -249,12 +249,8 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
   // EnqueueNetTask is invoked from many worker threads anyway.
   client_.AsyncSendPoll(chi::PoolQuery::Local(), 0, 500);
 
-  // Client response sending now happens on client_recv_thread_ (below), which
-  // also owns the client ROUTER/IPC recv -- ZMQ ROUTER/DEALER sockets are not
-  // thread-safe, so recv and send must share one thread (see #473; on macOS a
-  // split caused EHOSTUNREACH on every response). The net_recv_worker
-  // AsyncClientSend periodic is intentionally NOT scheduled.
-  // client_.AsyncClientSend(chi::PoolQuery::Local(), 100);
+  // Spawn periodic ClientSend task for client response sending via lightbeam
+  client_.AsyncClientSend(chi::PoolQuery::Local(), 100);
 
   // Dedicated single peer recv thread: polls the main p2p transport
   // (port 9413 by default) and dispatches inbound task forwards/responses.
@@ -324,22 +320,10 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
     ctp::SystemInfo::SetCurrentThreadName("chi-client-recv");
     auto *ipc_manager = CLIO_IPC;
     HLOG(kInfo, "[ClientRecvThread] started");
-    // This thread owns BOTH recv and send on the client ROUTER/IPC sockets.
-    // ZMQ ROUTER/DEALER sockets are not thread-safe: the routing-id a ROUTER
-    // learns on the recv thread is not reliably visible to a different thread
-    // that sends (observed on macOS as a persistent EHOSTUNREACH / "Host
-    // unreachable" when routing the response, even though the peer connection
-    // is healthy). Draining the client-send queue here keeps all socket I/O on
-    // one thread. The matching net_recv_worker AsyncClientSend periodic is
-    // disabled so only this thread touches these sockets.
-    std::vector<ctp::ipc::FullPtr<chi::Task>> deferred_deletes;
     while (!recv_shutdown_.load(std::memory_order_acquire)) {
       chi::u32 tasks_received = 0;
       bool did_work = chi::IpcCpu2CpuZmq::RuntimeRecv(ipc_manager,
                                                        tasks_received);
-      chi::u32 tasks_sent = 0;
-      did_work |= chi::IpcCpu2CpuZmq::RuntimeSend(ipc_manager, tasks_sent,
-                                                  deferred_deletes);
       if (!did_work) {
         std::this_thread::sleep_for(std::chrono::microseconds(1));
       }

--- a/context-runtime/src/ipc_manager.cc
+++ b/context-runtime/src/ipc_manager.cc
@@ -440,7 +440,25 @@ void IpcManager::ClientFinalize() {
   // Clients should not destroy shared resources
 }
 
+void IpcManager::RegisterTransportShutdownHook(std::function<void()> hook) {
+  std::lock_guard<std::mutex> lock(transport_shutdown_hooks_mutex_);
+  transport_shutdown_hooks_.push_back(std::move(hook));
+}
+
 void IpcManager::ClearTransports() {
+  // Stop any module-owned threads that hold a raw transport pointer BEFORE we
+  // free the transports below. Hooks run once; move them out under the lock so
+  // a hook that re-enters (or a second ClearTransports call from
+  // ServerFinalize) sees an empty list.
+  std::vector<std::function<void()>> hooks;
+  {
+    std::lock_guard<std::mutex> lock(transport_shutdown_hooks_mutex_);
+    hooks.swap(transport_shutdown_hooks_);
+  }
+  for (auto &hook : hooks) {
+    if (hook) hook();
+  }
+
   local_transport_.reset();
   main_transport_.reset();
   client_tcp_transport_.reset();

--- a/context-runtime/test/runtime_server.h
+++ b/context-runtime/test/runtime_server.h
@@ -119,6 +119,13 @@ class RuntimeServer {
     SetEnv("CLIO_PORT", std::to_string(port));
     SetEnv("CLIO_BIND_ADDR", bind_addr);
     const std::string exe = RuntimeExe();
+    // Point the daemon at the directory holding clio_run for ChiMod (.so/.dylib
+    // /.dll) discovery — the modules are built alongside it. Not every test
+    // sets CHI_REPO_PATH in its CTest ENVIRONMENT, so set it unconditionally.
+    {
+      size_t slash = exe.find_last_of("/\\");
+      if (slash != std::string::npos) SetEnv("CHI_REPO_PATH", exe.substr(0, slash));
+    }
     const std::string log = ServerLogPath();
 
 #ifdef _WIN32

--- a/context-runtime/test/runtime_server.h
+++ b/context-runtime/test/runtime_server.h
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_RUNTIME_TEST_RUNTIME_SERVER_H_
+#define CLIO_RUNTIME_TEST_RUNTIME_SERVER_H_
+
+/**
+ * RuntimeServer — cross-platform test helper that launches the canonical
+ * `clio_run` runtime daemon as a SEPARATE process and manages its lifetime.
+ *
+ * This replaces the older `fork()` + in-process `CHIMAERA_INIT(kServer)` +
+ * `sleep(300)` pattern used by the IPC/transport/external-client tests. That
+ * pattern is:
+ *   - broken on macOS: the forked child dlopen()s the ChiMod .dylibs and spawns
+ *     worker threads *after* fork without exec(); on macOS this deadlocks/fails
+ *     in dyld (fork-without-exec is unsupported for a process this complex).
+ *     The child creates the main shm segment (so a file-based readiness probe
+ *     passes) but never becomes responsive, so the client times out and the
+ *     leaked `sleep(300)` child keeps holding the runtime's TCP port.
+ *   - impossible on Windows: there is no `fork()`.
+ *
+ * Spawning a real binary (posix_spawn on POSIX, CreateProcess on Windows) and
+ * connecting to it as an ordinary external client is portable across Linux,
+ * macOS and Windows — which is why the tests that use this helper no longer
+ * need an `if(NOT WIN32)` guard.
+ */
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "clio_ctp/introspect/system_info.h"
+#include "clio_ctp/util/config_parse.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <csignal>
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+extern char **environ;
+#endif
+
+namespace chi {
+namespace test {
+
+/** Portable setenv(): tests set CLIO_IPC_MODE / CLIO_WITH_RUNTIME etc., and
+ *  Windows has no setenv(). */
+inline void SetEnvVar(const char *key, const std::string &val) {
+#ifdef _WIN32
+  _putenv_s(key, val.c_str());
+#else
+  setenv(key, val.c_str(), 1);
+#endif
+}
+
+/** Portable unsetenv(). On Windows _putenv_s(key, "") removes the variable. */
+inline void UnsetEnvVar(const char *key) {
+#ifdef _WIN32
+  _putenv_s(key, "");
+#else
+  unsetenv(key);
+#endif
+}
+
+class RuntimeServer {
+ public:
+  RuntimeServer() = default;
+  ~RuntimeServer() { Stop(); }
+  RuntimeServer(const RuntimeServer &) = delete;
+  RuntimeServer &operator=(const RuntimeServer &) = delete;
+
+  /**
+   * Spawn `clio_run start` as a child process. CLIO_PORT / CLIO_BIND_ADDR are
+   * exported first so both the daemon and this (client) process agree on where
+   * the runtime lives. Returns true if the process was spawned (use
+   * WaitForReady() to confirm it actually came up).
+   */
+  bool Start(unsigned port = 10500,
+             const std::string &bind_addr = "127.0.0.1") {
+    SetEnv("CLIO_PORT", std::to_string(port));
+    SetEnv("CLIO_BIND_ADDR", bind_addr);
+    const std::string exe = RuntimeExe();
+    const std::string log = ServerLogPath();
+
+#ifdef _WIN32
+    std::string cmd = "\"" + exe + "\" start";
+    STARTUPINFOA si;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    // Redirect child stdout/stderr to the log file so the daemon's worker
+    // chatter does not flood the test output (and is inspectable on failure).
+    SECURITY_ATTRIBUTES sa;
+    sa.nLength = sizeof(sa);
+    sa.lpSecurityDescriptor = nullptr;
+    sa.bInheritHandle = TRUE;
+    HANDLE hlog = CreateFileA(log.c_str(), GENERIC_WRITE, FILE_SHARE_READ, &sa,
+                              CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hlog != INVALID_HANDLE_VALUE) {
+      si.dwFlags |= STARTF_USESTDHANDLES;
+      si.hStdOutput = hlog;
+      si.hStdError = hlog;
+      si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+    }
+    ZeroMemory(&pi_, sizeof(pi_));
+    std::vector<char> mutable_cmd(cmd.begin(), cmd.end());
+    mutable_cmd.push_back('\0');
+    BOOL ok = CreateProcessA(nullptr, mutable_cmd.data(), nullptr, nullptr,
+                             TRUE, 0, nullptr, nullptr, &si, &pi_);
+    if (hlog != INVALID_HANDLE_VALUE) CloseHandle(hlog);
+    if (!ok) return false;
+    started_ = true;
+    return true;
+#else
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_addopen(&actions, 1, log.c_str(),
+                                     O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    posix_spawn_file_actions_adddup2(&actions, 1, 2);
+    const char *argv[] = {exe.c_str(), "start", nullptr};
+    int rc = posix_spawn(&pid_, exe.c_str(), &actions, nullptr,
+                         const_cast<char *const *>(argv), environ);
+    posix_spawn_file_actions_destroy(&actions);
+    if (rc != 0) {
+      pid_ = -1;
+      return false;
+    }
+    started_ = true;
+    return true;
+#endif
+  }
+
+  /**
+   * Poll until the runtime's main shared-memory segment exists, signalling that
+   * the daemon has initialized far enough to serve clients. Portable: on POSIX
+   * the segment is a file under /tmp/chimaera_$USER, on Windows a named mapping
+   * — SystemInfo::OpenSharedMemory abstracts both. Returns false if the timeout
+   * elapses or the daemon exits early.
+   */
+  bool WaitForReady(int timeout_ms = 30000) {
+    const std::string seg =
+        ctp::ConfigParse::ExpandPath("chi_main_segment_${USER}");
+    const int attempts = timeout_ms / 200;
+    for (int i = 0; i < attempts; ++i) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+      if (!IsRunning()) return false;  // daemon died during startup
+      ctp::File fd;
+      if (ctp::SystemInfo::OpenSharedMemory(fd, seg)) {
+        ctp::SystemInfo::CloseSharedMemory(fd);
+        // Let the daemon finish binding its transports / starting workers.
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Stop the daemon (SIGTERM then SIGKILL on POSIX; TerminateProcess on
+   *  Windows) and reap it. Idempotent; called by the destructor. */
+  void Stop() {
+    if (!started_) return;
+    started_ = false;
+#ifdef _WIN32
+    TerminateProcess(pi_.hProcess, 0);
+    WaitForSingleObject(pi_.hProcess, 5000);
+    CloseHandle(pi_.hProcess);
+    CloseHandle(pi_.hThread);
+#else
+    if (pid_ <= 0) return;
+    kill(pid_, SIGTERM);
+    for (int i = 0; i < 50; ++i) {  // up to 5s for a clean shutdown
+      int status;
+      if (waitpid(pid_, &status, WNOHANG) != 0) {
+        pid_ = -1;
+        return;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    kill(pid_, SIGKILL);
+    int status;
+    waitpid(pid_, &status, 0);
+    pid_ = -1;
+#endif
+  }
+
+  /** True while the daemon process is still alive. */
+  bool IsRunning() {
+    if (!started_) return false;
+#ifdef _WIN32
+    DWORD code = 0;
+    if (!GetExitCodeProcess(pi_.hProcess, &code)) return false;
+    return code == STILL_ACTIVE;
+#else
+    if (pid_ <= 0) return false;
+    int status;
+    return waitpid(pid_, &status, WNOHANG) == 0;  // 0 => still running
+#endif
+  }
+
+ private:
+  /** Absolute path to the clio_run binary. CMake passes CLIO_RUN_EXE via
+   *  $<TARGET_FILE:clio_run>; fall back to CHI_REPO_PATH/clio_run otherwise. */
+  static std::string RuntimeExe() {
+#ifdef CLIO_RUN_EXE
+    return std::string(CLIO_RUN_EXE);
+#else
+    const char *repo = std::getenv("CHI_REPO_PATH");
+    std::string dir = (repo && *repo) ? std::string(repo) : std::string(".");
+#ifdef _WIN32
+    return dir + "\\clio_run.exe";
+#else
+    return dir + "/clio_run";
+#endif
+#endif
+  }
+
+  static std::string ServerLogPath() {
+    const char *override_path = std::getenv("CLIO_TEST_SERVER_LOG");
+    if (override_path && *override_path) return override_path;
+#ifdef _WIN32
+    char tmp[MAX_PATH];
+    DWORD n = GetTempPathA(MAX_PATH, tmp);
+    std::string dir = (n > 0 && n < MAX_PATH) ? std::string(tmp, n) : ".\\";
+    return dir + "clio_run_test_server.log";
+#else
+    return "/tmp/clio_run_test_server.log";
+#endif
+  }
+
+  static void SetEnv(const char *key, const std::string &val) {
+    SetEnvVar(key, val);
+  }
+
+  bool started_ = false;
+#ifdef _WIN32
+  PROCESS_INFORMATION pi_{};
+#else
+  pid_t pid_ = -1;
+#endif
+};
+
+}  // namespace test
+}  // namespace chi
+
+#endif  // CLIO_RUNTIME_TEST_RUNTIME_SERVER_H_

--- a/context-runtime/test/runtime_server.h
+++ b/context-runtime/test/runtime_server.h
@@ -75,7 +75,11 @@
 extern char **environ;
 #endif
 
-namespace chi {
+// NOTE: `chi` is a namespace ALIAS (namespace chi = clio::run), so we must not
+// open `namespace chi { ... }` here. Define in clio::run::test; tests reach it
+// as chi::test::RuntimeServer through the alias.
+namespace clio {
+namespace run {
 namespace test {
 
 /** Portable setenv(): tests set CLIO_IPC_MODE / CLIO_WITH_RUNTIME etc., and
@@ -274,6 +278,7 @@ class RuntimeServer {
 };
 
 }  // namespace test
-}  // namespace chi
+}  // namespace run
+}  // namespace clio
 
 #endif  // CLIO_RUNTIME_TEST_RUNTIME_SERVER_H_

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -389,9 +389,14 @@ set_target_properties(${IPC_ERRORS_TEST_TARGET} PROPERTIES
 )
 
 # Create IPC Transport Modes test executable.
-# Launches the runtime out-of-process via chi::test::RuntimeServer
-# (clio_run start) instead of fork()+CHIMAERA_INIT(kServer), so it is portable
-# to Windows too (no fork-without-exec dependency).
+# Launches the runtime out-of-process via chi::test::RuntimeServer (clio_run
+# start) instead of fork()+CHIMAERA_INIT(kServer). POSIX-only for now: the
+# RuntimeServer helper's Windows path pulls in <windows.h>, which collides with
+# the ctp lightbeam headers' <winsock2.h> and leaks the Yield/min/max macros
+# into widely-included headers (the project deliberately keeps <windows.h> out
+# of shared headers -- see simple_test.h). Making this build on Windows is part
+# of the macOS/Windows transport follow-up (see issue #476).
+if(NOT WIN32)
 add_executable(${IPC_TRANSPORT_MODES_TEST_TARGET} ${IPC_TRANSPORT_MODES_TEST_SOURCES})
 
 target_include_directories(${IPC_TRANSPORT_MODES_TEST_TARGET} PRIVATE
@@ -423,6 +428,7 @@ set_target_properties(${IPC_TRANSPORT_MODES_TEST_TARGET} PROPERTIES
 set_target_properties(${IPC_TRANSPORT_MODES_TEST_TARGET} PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
+endif()
 
 # Create Client Retry test executable.
 # POSIX-only: uses <sys/wait.h> / fork() for parent-child retry orchestration.

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -232,6 +232,11 @@ target_link_libraries(${PER_PROCESS_SHM_TEST_TARGET}
   ${CMAKE_THREAD_LIBS_INIT}  # Threading support
 )
 
+# RuntimeServer launches clio_run; ensure it is built and discoverable.
+add_dependencies(${PER_PROCESS_SHM_TEST_TARGET} clio_run)
+target_compile_definitions(${PER_PROCESS_SHM_TEST_TARGET} PRIVATE
+  CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+
 set_target_properties(${PER_PROCESS_SHM_TEST_TARGET} PROPERTIES
   CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
@@ -321,6 +326,11 @@ target_link_libraries(${EXTERNAL_CLIENT_TEST_TARGET}
   ctp::cxx                  # ClioCtp library
   ${CMAKE_THREAD_LIBS_INIT}  # Threading support
 )
+
+# RuntimeServer launches clio_run; ensure it is built and discoverable.
+add_dependencies(${EXTERNAL_CLIENT_TEST_TARGET} clio_run)
+target_compile_definitions(${EXTERNAL_CLIENT_TEST_TARGET} PRIVATE
+  CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
 
 set_target_properties(${EXTERNAL_CLIENT_TEST_TARGET} PROPERTIES
   CXX_STANDARD 20
@@ -433,6 +443,11 @@ target_link_libraries(${CLIENT_RETRY_TEST_TARGET}
   ctp::cxx                  # ClioCtp library
   ${CMAKE_THREAD_LIBS_INIT}  # Threading support
 )
+
+# RuntimeServer launches clio_run; ensure it is built and discoverable.
+add_dependencies(${CLIENT_RETRY_TEST_TARGET} clio_run)
+target_compile_definitions(${CLIENT_RETRY_TEST_TARGET} PRIVATE
+  CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
 
 set_target_properties(${CLIENT_RETRY_TEST_TARGET} PROPERTIES
   CXX_STANDARD 20

--- a/context-runtime/test/unit/CMakeLists.txt
+++ b/context-runtime/test/unit/CMakeLists.txt
@@ -379,15 +379,14 @@ set_target_properties(${IPC_ERRORS_TEST_TARGET} PROPERTIES
 )
 
 # Create IPC Transport Modes test executable.
-# POSIX-only: uses fork()/waitpid()/setenv() to spawn a runtime + several
-# clients across transport variants. Same Windows limitation as the other
-# fork-based tests.
-if(NOT WIN32)
+# Launches the runtime out-of-process via chi::test::RuntimeServer
+# (clio_run start) instead of fork()+CHIMAERA_INIT(kServer), so it is portable
+# to Windows too (no fork-without-exec dependency).
 add_executable(${IPC_TRANSPORT_MODES_TEST_TARGET} ${IPC_TRANSPORT_MODES_TEST_SOURCES})
 
 target_include_directories(${IPC_TRANSPORT_MODES_TEST_TARGET} PRIVATE
   ${CLIO_RUN_ROOT}/include
-  ${CLIO_RUN_ROOT}/test  # For simple_test.h
+  ${CLIO_RUN_ROOT}/test  # For simple_test.h / runtime_server.h
   ${CLIO_RUN_ROOT}/modules/bdev/include
   ${CLIO_RUN_ROOT}/modules/admin/include
 )
@@ -400,6 +399,12 @@ target_link_libraries(${IPC_TRANSPORT_MODES_TEST_TARGET}
   ${CMAKE_THREAD_LIBS_INIT}  # Threading support
 )
 
+# RuntimeServer launches this binary; ensure it is built and tell the helper
+# where it lives.
+add_dependencies(${IPC_TRANSPORT_MODES_TEST_TARGET} clio_run)
+target_compile_definitions(${IPC_TRANSPORT_MODES_TEST_TARGET} PRIVATE
+  CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+
 set_target_properties(${IPC_TRANSPORT_MODES_TEST_TARGET} PROPERTIES
   CXX_STANDARD 20
   CXX_STANDARD_REQUIRED ON
@@ -408,7 +413,6 @@ set_target_properties(${IPC_TRANSPORT_MODES_TEST_TARGET} PROPERTIES
 set_target_properties(${IPC_TRANSPORT_MODES_TEST_TARGET} PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
 )
-endif()
 
 # Create Client Retry test executable.
 # POSIX-only: uses <sys/wait.h> / fork() for parent-child retry orchestration.

--- a/context-runtime/test/unit/test_client_retry.cc
+++ b/context-runtime/test/unit/test_client_retry.cc
@@ -39,6 +39,7 @@
  */
 
 #include "../simple_test.h"
+#include "../runtime_server.h"
 
 #include <fcntl.h>
 #include <signal.h>
@@ -58,102 +59,11 @@
 
 using namespace chi;
 
-/**
- * Helper to cleanup shared memory
- */
-void CleanupSharedMemory() {
-  const char *user = std::getenv("USER");
-  std::string memfd_path =
-      std::string("/tmp/chimaera_") + (user ? user : "unknown") +
-      "/chi_main_segment_" + (user ? user : "");
-  unlink(memfd_path.c_str());
-}
-
-/**
- * Helper to start server in background process via exec
- * Uses exec to avoid inheriting CHIMAERA_INIT static guard state.
- * The test binary itself is used with a special argument.
- * Returns server PID
- */
-pid_t StartServerProcess() {
-  pid_t server_pid = fork();
-  if (server_pid == 0) {
-    // Become process group leader so we can kill all children
-    setpgid(0, 0);
-
-    (void)freopen("/dev/null", "w", stdout);
-    (void)freopen("/tmp/chimaera_server_retry_test.log", "w", stderr);
-
-    // Use exec to get a clean process with no static guard state
-    setenv("CLIO_WITH_RUNTIME", "1", 1);
-    setenv("CHI_RETRY_TEST_SERVER_MODE", "1", 1);
-    execl("/proc/self/exe", "chimaera_client_retry_tests",
-          "--server-mode", nullptr);
-    // If exec fails, fall back to direct init
-    _exit(1);
-  }
-  // Parent also sets pgid to avoid race
-  setpgid(server_pid, server_pid);
-  return server_pid;
-}
-
-/**
- * Helper to wait for server to be ready
- */
-bool WaitForServer(int max_attempts = 50) {
-  const char *user = std::getenv("USER");
-  std::string memfd_path =
-      std::string("/tmp/chimaera_") + (user ? user : "unknown") +
-      "/chi_main_segment_" + (user ? user : "");
-
-  for (int i = 0; i < max_attempts; ++i) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    int fd = open(memfd_path.c_str(), O_RDONLY);
-    if (fd >= 0) {
-      close(fd);
-      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Kill server and its entire process group, clean up all resources
- */
-void KillServerHard(pid_t server_pid) {
-  if (server_pid <= 0) return;
-
-  // Kill entire process group
-  kill(-server_pid, SIGKILL);
-  int status;
-  waitpid(server_pid, &status, 0);
-
-  // Clean up shared memory and sockets
-  CleanupSharedMemory();
-  // Remove unix domain socket
-  unlink("/tmp/chimaera_9413.ipc");
-  // Remove any /dev/shm artifacts
-  (void)system("rm -f /dev/shm/chimaera_* 2>/dev/null");
-
-  // Brief pause to let OS reclaim ports
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-}
-
-/**
- * Helper to cleanup server process
- */
-void CleanupServer(pid_t server_pid) {
-  if (server_pid > 0) {
-    kill(-server_pid, SIGKILL);
-    int status;
-    waitpid(server_pid, &status, 0);
-    CleanupSharedMemory();
-    unlink("/tmp/chimaera_9413.ipc");
-    (void)system("rm -f /dev/shm/chimaera_* 2>/dev/null");
-  }
-}
+// The runtime server runs out-of-process via chi::test::RuntimeServer
+// (clio_run start). The previous fork()+execl("/proc/self/exe", "--server-mode")
+// approach was Linux-only: macOS has no /proc/self/exe, so execl failed and the
+// server never started. clio_run is portable. The client-death test still
+// fork()s a client (client mode does not dlopen, so it is macOS-safe).
 
 // ============================================================================
 // Helper: Server Restart test logic parameterized by IPC mode
@@ -162,11 +72,10 @@ void CleanupServer(pid_t server_pid) {
 void TestServerRestart(const std::string &mode) {
   setenv("CLIO_CLIENT_RETRY_TIMEOUT", "30", 1);
 
-  // 1. Fork first server, wait for ready
-  pid_t server1 = StartServerProcess();
-  REQUIRE(server1 > 0);
-  bool ready = WaitForServer();
-  REQUIRE(ready);
+  // 1. Start first server, wait for ready
+  chi::test::RuntimeServer server1;
+  REQUIRE(server1.Start());
+  REQUIRE(server1.WaitForReady());
 
   // 2. Client connects
   setenv("CLIO_IPC_MODE", mode.c_str(), 1);
@@ -189,15 +98,15 @@ void TestServerRestart(const std::string &mode) {
     INFO("Baseline task completed for mode " + mode);
   }
 
-  // 4-5. Kill server hard and clean up all resources
-  KillServerHard(server1);
-  INFO("Server killed and resources cleaned");
+  // 4-5. Stop the server (simulating loss) and let the OS reclaim the port
+  server1.Stop();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  INFO("Server stopped and resources cleaned");
 
-  // 6. Fork new server, wait for ready
-  pid_t server2 = StartServerProcess();
-  REQUIRE(server2 > 0);
-  ready = WaitForServer(100);  // More attempts for restart scenario
-  REQUIRE(ready);
+  // 6. Start a new server, wait for ready
+  chi::test::RuntimeServer server2;
+  REQUIRE(server2.Start());
+  REQUIRE(server2.WaitForReady(40000));  // More time for restart scenario
   INFO("New server started");
 
   // 7. ReconnectToOriginalHost to re-attach to new server
@@ -217,9 +126,7 @@ void TestServerRestart(const std::string &mode) {
     REQUIRE(task->return_code_ == 0);
     INFO("Post-restart task completed for mode " + mode);
   }
-
-  // Cleanup
-  CleanupServer(server2);
+  // server2 stopped by RuntimeServer destructor (RAII)
 }
 
 // ============================================================================
@@ -229,11 +136,10 @@ void TestServerRestart(const std::string &mode) {
 void TestClientDeath(const std::string &mode) {
   setenv("CLIO_CLIENT_RETRY_TIMEOUT", "30", 1);
 
-  // 1. Fork server, wait for ready
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-  bool ready = WaitForServer();
-  REQUIRE(ready);
+  // 1. Start server, wait for ready
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // 2. Fork a client child that submits a task then dies immediately
   pid_t client_child = fork();
@@ -291,9 +197,7 @@ void TestClientDeath(const std::string &mode) {
     INFO("Parent task completed — server survived client death for mode " +
          mode);
   }
-
-  // Cleanup
-  CleanupServer(server_pid);
+  // server stopped by RuntimeServer destructor (RAII)
 }
 
 // ============================================================================
@@ -333,17 +237,9 @@ TEST_CASE("ClientRetry - Client Death SHM", "[client_retry][shm]") {
 }
 
 int main(int argc, char* argv[]) {
-  // Server mode: started by StartServerProcess() via exec
-  if (argc > 1 && std::string(argv[1]) == "--server-mode") {
-    bool success = CHIMAERA_INIT(ChimaeraMode::kServer, true);
-    if (!success) {
-      return 1;
-    }
-    sleep(300);  // 5 minutes max, parent will SIGKILL us
-    return 0;
-  }
-
-  // Normal test mode
+  // The runtime server is now launched out-of-process via clio_run
+  // (chi::test::RuntimeServer), so this binary no longer re-execs itself in a
+  // "--server-mode"; it only runs tests.
   std::string filter = "";
   if (argc > 1) {
     filter = argv[1];

--- a/context-runtime/test/unit/test_external_client.cc
+++ b/context-runtime/test/unit/test_external_client.cc
@@ -40,6 +40,7 @@
  */
 
 #include "../simple_test.h"
+#include "../runtime_server.h"
 
 #ifndef _WIN32
 #include <fcntl.h>
@@ -57,63 +58,16 @@
 
 using namespace chi;
 
-/**
- * Helper to start server in background process
- * Returns server PID
- */
-pid_t StartServerProcess() {
-  pid_t server_pid = fork();
-  if (server_pid == 0) {
-    // Redirect child's stdout/stderr to /dev/null to prevent massive
-    // worker log output from flooding shared pipes and blocking parent
-    (void)freopen("/dev/null", "w", stdout);
-    (void)freopen("/dev/null", "w", stderr);
-
-    // Child process: Start runtime server
-    setenv("CLIO_WITH_RUNTIME", "1", 1);
-    bool success = CHIMAERA_INIT(ChimaeraMode::kServer, true);
-    if (!success) {
-      _exit(1);
-    }
-
-    // Keep server alive for tests
-    // Server will be killed by parent process
-    sleep(300);  // 5 minutes max
-    _exit(0);
-  }
-  return server_pid;
-}
+// The runtime server is launched out-of-process via chi::test::RuntimeServer
+// (clio_run start) instead of fork()+CHIMAERA_INIT(kServer): fork-without-exec
+// deadlocks on macOS when the child dlopen()s ChiMods (and nondeterministically
+// leaks a port-holding process). The client children below are real fork()s --
+// client mode does not dlopen, so they remain macOS-safe.
 
 /**
- * Helper to wait for server to be ready
- */
-bool WaitForServer(int max_attempts = 50) {
-  // The main shared memory segment name is "chi_main_segment_${USER}"
-  const char *user = std::getenv("USER");
-  std::string memfd_path = std::string("/tmp/chimaera_") +
-                           (user ? user : "unknown") +
-                           "/chi_main_segment_" + (user ? user : "");
-
-  for (int i = 0; i < max_attempts; ++i) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    // Check if memfd symlink exists (indicates server is ready)
-    int fd = open(memfd_path.c_str(), O_RDONLY);
-    if (fd >= 0) {
-      close(fd);
-      // Give it a bit more time to fully initialize
-      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Helper to cleanup server process
+ * Helper to cleanup leftover shared-memory segment from a prior run.
  */
 void CleanupSharedMemory() {
-  // Clean up leftover memfd symlinks
   const char *user = std::getenv("USER");
   std::string memfd_path = std::string("/tmp/chimaera_") +
                            (user ? user : "unknown") +
@@ -121,39 +75,15 @@ void CleanupSharedMemory() {
   unlink(memfd_path.c_str());
 }
 
-void CleanupServer(pid_t server_pid) {
-  if (server_pid > 0) {
-    kill(server_pid, SIGTERM);
-    // Wait up to 5 seconds for graceful shutdown
-    for (int i = 0; i < 50; ++i) {
-      int status;
-      if (waitpid(server_pid, &status, WNOHANG) != 0) {
-        CleanupSharedMemory();
-        return;
-      }
-      usleep(100000);  // 100ms
-    }
-    // Force kill if still alive
-    kill(server_pid, SIGKILL);
-    int status;
-    waitpid(server_pid, &status, 0);
-    // Clean up shared memory left behind by the server
-    CleanupSharedMemory();
-  }
-}
-
 // ============================================================================
 // External Client Connection Tests
 // ============================================================================
 
 TEST_CASE("ExternalClient - Basic Connection", "[external_client][ipc]") {
-  // Start server in background
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-
-  // Wait for server to be ready
-  bool server_ready = WaitForServer();
-  REQUIRE(server_ready);
+  // Start the runtime daemon out-of-process
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // Now connect as EXTERNAL CLIENT (not integrated server+client)
   setenv("CLIO_WITH_RUNTIME", "0", 1);  // Force client-only mode
@@ -178,19 +108,14 @@ TEST_CASE("ExternalClient - Basic Connection", "[external_client][ipc]") {
   } else {
     REQUIRE(queue == nullptr);
   }
-
-  // Cleanup
-  CleanupServer(server_pid);
+  // server stopped by RuntimeServer destructor (RAII)
 }
 
 TEST_CASE("ExternalClient - Multiple Clients", "[external_client][ipc]") {
-  // Start server
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-
-  // Wait for server
-  bool server_ready = WaitForServer();
-  REQUIRE(server_ready);
+  // Start the runtime daemon out-of-process
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // Start multiple client processes
   const int num_clients = 3;
@@ -235,9 +160,7 @@ TEST_CASE("ExternalClient - Multiple Clients", "[external_client][ipc]") {
   }
 
   REQUIRE(all_success);
-
-  // Cleanup server
-  CleanupServer(server_pid);
+  // server stopped by RuntimeServer destructor (RAII)
 }
 
 TEST_CASE("ExternalClient - Connection Without Server",
@@ -257,13 +180,10 @@ TEST_CASE("ExternalClient - Connection Without Server",
 }
 
 TEST_CASE("ExternalClient - Client Operations", "[external_client][ipc]") {
-  // Start server
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-
-  // Wait for server
-  bool server_ready = WaitForServer();
-  REQUIRE(server_ready);
+  // Start the runtime daemon out-of-process
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // Connect as client
   setenv("CLIO_WITH_RUNTIME", "0", 1);
@@ -284,8 +204,7 @@ TEST_CASE("ExternalClient - Client Operations", "[external_client][ipc]") {
   // The hostfile_map_ is populated during ServerInit and is NOT shared via
   // shared memory, so external clients cannot access host information.
 
-  // Cleanup
-  CleanupServer(server_pid);
+  // server stopped by RuntimeServer destructor (RAII)
 }
 
 SIMPLE_TEST_MAIN()

--- a/context-runtime/test/unit/test_ipc_transport_modes.cc
+++ b/context-runtime/test/unit/test_ipc_transport_modes.cc
@@ -35,22 +35,16 @@
  * IPC Transport Mode Tests
  *
  * Tests that each IPC transport mode (SHM, TCP, IPC) initializes correctly
- * and that the correct transport path is active. Each test case forks a
- * server, sets CHI_IPC_MODE, connects as client, and verifies mode state.
+ * and that the correct transport path is active. Each test case launches the
+ * runtime daemon out-of-process (chi::test::RuntimeServer -> clio_run start),
+ * sets CHI_IPC_MODE, connects as client, and verifies mode state.
  */
 
 #include "../simple_test.h"
+#include "../runtime_server.h"
 
-#ifndef _WIN32
-#include <fcntl.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#endif
-
-#include <chrono>
 #include <cstdlib>
 #include <string>
-#include <thread>
 
 #include "clio_runtime/clio_runtime.h"
 #include "clio_runtime/ipc_manager.h"
@@ -141,104 +135,11 @@ void SubmitTasksForMode(const std::string &mode_name) {
   CLIO_IPC->FreeBuffer(read_buffer);
 }
 
-/**
- * Helper to start server in background process
- * Returns server PID
- */
-pid_t StartServerProcess() {
-  pid_t server_pid = fork();
-  if (server_pid == 0) {
-    // Redirect child's stdout to /dev/null but stderr to temp file for timing
-    (void)freopen("/dev/null", "w", stdout);
-    (void)freopen("/tmp/chimaera_server_timing.log", "w", stderr);
-
-    // Child process: Start runtime server
-    setenv("CLIO_WITH_RUNTIME", "1", 1);
-    bool success = CHIMAERA_INIT(ChimaeraMode::kServer, true);
-    if (!success) {
-      _exit(1);
-    }
-
-    // Keep server alive for tests
-    // Server will be killed by parent process
-    sleep(300);  // 5 minutes max
-    _exit(0);
-  }
-  return server_pid;
-}
-
-/**
- * Helper to wait for server to be ready
- */
-bool WaitForServer(int max_attempts = 50) {
-  // The main shared memory segment name is "chi_main_segment_${USER}"
-  const char *user = std::getenv("USER");
-  std::string memfd_path = std::string("/tmp/chimaera_") +
-                           (user ? user : "unknown") +
-                           "/chi_main_segment_" + (user ? user : "");
-
-  for (int i = 0; i < max_attempts; ++i) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    // Check if memfd symlink exists (indicates server is ready)
-    int fd = open(memfd_path.c_str(), O_RDONLY);
-    if (fd >= 0) {
-      close(fd);
-      // Give it a bit more time to fully initialize
-      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Helper to cleanup shared memory
- */
-void CleanupSharedMemory() {
-  const char *user = std::getenv("USER");
-  std::string memfd_path = std::string("/tmp/chimaera_") +
-                           (user ? user : "unknown") +
-                           "/chi_main_segment_" + (user ? user : "");
-  unlink(memfd_path.c_str());
-}
-
-/**
- * Helper to cleanup server process
- */
-void CleanupServer(pid_t server_pid) {
-  if (server_pid > 0) {
-    kill(server_pid, SIGTERM);
-    // Wait up to 5 seconds for graceful shutdown
-    for (int i = 0; i < 50; ++i) {
-      int status;
-      if (waitpid(server_pid, &status, WNOHANG) != 0) {
-        CleanupSharedMemory();
-        return;
-      }
-      usleep(100000);  // 100ms
-    }
-    // Force kill if still alive
-    kill(server_pid, SIGKILL);
-    int status;
-    waitpid(server_pid, &status, 0);
-    CleanupSharedMemory();
-  }
-}
-
-/**
- * RAII guard that always kills the forked server process, even if a
- * REQUIRE assertion throws and unwinds the stack before the explicit
- * CleanupServer() call.
- */
-struct ServerGuard {
-  pid_t pid;
-  explicit ServerGuard(pid_t p) : pid(p) {}
-  ~ServerGuard() { CleanupServer(pid); }
-  // Non-copyable
-  ServerGuard(const ServerGuard &) = delete;
-  ServerGuard &operator=(const ServerGuard &) = delete;
-};
+// The runtime server is launched out-of-process via chi::test::RuntimeServer
+// (clio_run start), which is portable across Linux, macOS and Windows. The old
+// fork()+CHIMAERA_INIT(kServer) helpers were removed: fork-without-exec is
+// unsupported on macOS (post-fork dlopen of ChiMods deadlocks) and impossible
+// on Windows. See context-runtime/test/runtime_server.h.
 
 // ============================================================================
 // IPC Transport Mode Tests
@@ -246,18 +147,14 @@ struct ServerGuard {
 
 TEST_CASE("IpcTransportMode - SHM Client Connection",
           "[ipc_transport][shm]") {
-  // Start server in background
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-  ServerGuard guard(server_pid);
-
-  // Wait for server to be ready
-  bool server_ready = WaitForServer();
-  REQUIRE(server_ready);
+  // Start the runtime daemon out-of-process
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // Set SHM mode and connect as external client
-  setenv("CLIO_IPC_MODE", "SHM", 1);
-  setenv("CLIO_WITH_RUNTIME", "0", 1);
+  chi::test::SetEnvVar("CLIO_IPC_MODE", "SHM");
+  chi::test::SetEnvVar("CLIO_WITH_RUNTIME", "0");
   bool success = CHIMAERA_INIT(ChimaeraMode::kClient, false);
   REQUIRE(success);
 
@@ -275,18 +172,14 @@ TEST_CASE("IpcTransportMode - SHM Client Connection",
 
 TEST_CASE("IpcTransportMode - TCP Client Connection",
           "[ipc_transport][tcp]") {
-  // Start server in background
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-  ServerGuard guard(server_pid);
-
-  // Wait for server to be ready
-  bool server_ready = WaitForServer();
-  REQUIRE(server_ready);
+  // Start the runtime daemon out-of-process
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // Set TCP mode and connect as external client
-  setenv("CLIO_IPC_MODE", "TCP", 1);
-  setenv("CLIO_WITH_RUNTIME", "0", 1);
+  chi::test::SetEnvVar("CLIO_IPC_MODE", "TCP");
+  chi::test::SetEnvVar("CLIO_WITH_RUNTIME", "0");
   bool success = CHIMAERA_INIT(ChimaeraMode::kClient, false);
   REQUIRE(success);
 
@@ -304,18 +197,14 @@ TEST_CASE("IpcTransportMode - TCP Client Connection",
 
 TEST_CASE("IpcTransportMode - IPC Client Connection",
           "[ipc_transport][ipc]") {
-  // Start server in background
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-  ServerGuard guard(server_pid);
-
-  // Wait for server to be ready
-  bool server_ready = WaitForServer();
-  REQUIRE(server_ready);
+  // Start the runtime daemon out-of-process
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // Set IPC (Unix Domain Socket) mode and connect as external client
-  setenv("CLIO_IPC_MODE", "IPC", 1);
-  setenv("CLIO_WITH_RUNTIME", "0", 1);
+  chi::test::SetEnvVar("CLIO_IPC_MODE", "IPC");
+  chi::test::SetEnvVar("CLIO_WITH_RUNTIME", "0");
   bool success = CHIMAERA_INIT(ChimaeraMode::kClient, false);
   REQUIRE(success);
 
@@ -333,18 +222,14 @@ TEST_CASE("IpcTransportMode - IPC Client Connection",
 
 TEST_CASE("IpcTransportMode - Default Mode Is TCP",
           "[ipc_transport][default]") {
-  // Start server in background
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-  ServerGuard guard(server_pid);
-
-  // Wait for server to be ready
-  bool server_ready = WaitForServer();
-  REQUIRE(server_ready);
+  // Start the runtime daemon out-of-process
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // Unset CHI_IPC_MODE to test default behavior
-  unsetenv("CLIO_IPC_MODE");
-  setenv("CLIO_WITH_RUNTIME", "0", 1);
+  chi::test::UnsetEnvVar("CLIO_IPC_MODE");
+  chi::test::SetEnvVar("CLIO_WITH_RUNTIME", "0");
   bool success = CHIMAERA_INIT(ChimaeraMode::kClient, false);
   REQUIRE(success);
 

--- a/context-runtime/test/unit/test_per_process_shm.cc
+++ b/context-runtime/test/unit/test_per_process_shm.cc
@@ -53,6 +53,7 @@
 #endif
 
 #include "../simple_test.h"
+#include "../runtime_server.h"
 
 namespace {
 // Test setup helper - same pattern as other tests
@@ -60,65 +61,11 @@ bool initialize_chimaera() {
   return chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
 }
 
-/**
- * Start a CLIO Runtime server in a forked child process
- * @return Server process PID
- */
-pid_t StartServerProcess() {
-  pid_t server_pid = fork();
-  if (server_pid == 0) {
-    // Redirect child output to prevent log flooding
-    (void)freopen("/dev/null", "w", stdout);
-    (void)freopen("/dev/null", "w", stderr);
-    setenv("CLIO_WITH_RUNTIME", "1", 1);
-    bool success = chi::CHIMAERA_INIT(chi::ChimaeraMode::kServer, true);
-    if (!success) {
-      _exit(1);
-    }
-    sleep(300);
-    _exit(0);
-  }
-  return server_pid;
-}
-
-/**
- * Wait for the server's shared memory segment to become available
- * @param max_attempts Maximum polling attempts
- * @return True if server is ready
- */
-bool WaitForServer(int max_attempts = 50) {
-  const char *user = std::getenv("USER");
-  std::string memfd_path =
-      std::string("/tmp/chimaera_") + (user ? user : "unknown") +
-      "/chi_main_segment_" + (user ? user : "");
-  for (int i = 0; i < max_attempts; ++i) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    int fd = open(memfd_path.c_str(), O_RDONLY);
-    if (fd >= 0) {
-      close(fd);
-      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Kill the server process and clean up shared memory
- * @param server_pid PID of the server process
- */
-void CleanupServer(pid_t server_pid) {
-  if (server_pid > 0) {
-    kill(server_pid, SIGTERM);
-    int status;
-    waitpid(server_pid, &status, 0);
-    const char *user = std::getenv("USER");
-    std::string memfd_path =
-        std::string("/tmp/chimaera_") + (user ? user : "unknown") +
-        "/chi_main_segment_" + (user ? user : "");
-    unlink(memfd_path.c_str());
-  }
-}
+// The runtime server is launched out-of-process via chi::test::RuntimeServer
+// (clio_run start) instead of fork()+CHIMAERA_INIT(kServer): fork-without-exec
+// deadlocks on macOS when the child dlopen()s ChiMods. The client child below
+// is still a real fork() -- client mode does not dlopen, so it is macOS-safe
+// and exercises the per-process shm path this test is about.
 
 // Constants for testing
 constexpr size_t k1MB = 1ULL * 1024 * 1024;
@@ -134,9 +81,9 @@ TEST_CASE("Per-process shared memory GetClientShmInfo",
           "[ipc][per_process_shm][shm_info][fork]") {
   // Fork a server, then fork a client child to test GetClientShmInfo.
   // Both children start with clean process state (no prior CHIMAERA_INIT).
-  pid_t server_pid = StartServerProcess();
-  REQUIRE(server_pid > 0);
-  REQUIRE(WaitForServer());
+  chi::test::RuntimeServer server;
+  REQUIRE(server.Start());
+  REQUIRE(server.WaitForReady());
 
   // Fork a client child to test GetClientShmInfo
   pid_t client_pid = fork();
@@ -172,8 +119,7 @@ TEST_CASE("Per-process shared memory GetClientShmInfo",
   int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
   INFO("Client child exit code: " << exit_code);
   REQUIRE(exit_code == 0);
-
-  CleanupServer(server_pid);
+  // server stopped by RuntimeServer destructor (RAII)
 }
 
 TEST_CASE("Per-process shared memory AllocateBuffer medium sizes",

--- a/context-transfer-engine/wrapper/python/CMakeLists.txt
+++ b/context-transfer-engine/wrapper/python/CMakeLists.txt
@@ -99,7 +99,7 @@ if(BUILD_TESTING)
         PROPERTIES
         LABELS "python;bindings;telemetry"
         TIMEOUT 180
-        ENVIRONMENT "CHI_WITH_RUNTIME=1;CHI_SERVER_CONF=${CMAKE_SOURCE_DIR}/context-transfer-engine/test/unit/adapters/adios2/cte_config.yaml;LD_LIBRARY_PATH=/home/iowarp/miniconda3/lib;CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
+        ENVIRONMENT "CLIO_WITH_RUNTIME=1;CLIO_SERVER_CONF=${CMAKE_SOURCE_DIR}/context-transfer-engine/test/unit/adapters/adios2/cte_config.yaml;CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
     )
 
     # Ensure test depends on the built module

--- a/context-transport-primitives/include/clio_ctp/lightbeam/zmq_transport.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/zmq_transport.h
@@ -39,12 +39,10 @@
 #endif
 #include <zmq.h>
 
-#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <thread>
 
 #include "clio_ctp/introspect/system_info.h"
 #include "clio_ctp/util/logging.h"
@@ -356,43 +354,6 @@ class ZeroMqTransport : public Transport {
       HLOG(kDebug, "ZeroMqTransport(ROUTER) bound successfully to {}",
            full_url);
       zmq_fired_action_.socket_ = socket_;
-
-      // Opt-in diagnostic (CLIO_ZMQ_MONITOR): trace ROUTER peer connect /
-      // accept / disconnect / ZMTP-handshake events to debug the macOS
-      // cross-process EHOSTUNREACH (#473). No-op unless the env var is set.
-      if (const char *mon_env = std::getenv("CLIO_ZMQ_MONITOR")) {
-        if (*mon_env) {
-          std::string mon_ep = "inproc://mon-" + std::to_string(port_);
-          if (zmq_socket_monitor(socket_, mon_ep.c_str(), ZMQ_EVENT_ALL) == 0) {
-            void *mctx = ctx_;
-            std::thread([mctx, mon_ep]() {
-              void *mon = zmq_socket(mctx, ZMQ_PAIR);
-              if (!mon || zmq_connect(mon, mon_ep.c_str()) != 0) return;
-              while (true) {
-                zmq_msg_t ev;
-                zmq_msg_init(&ev);
-                if (zmq_msg_recv(&ev, mon, 0) == -1) {
-                  zmq_msg_close(&ev);
-                  break;
-                }
-                uint16_t event = 0;
-                if (zmq_msg_size(&ev) >= sizeof(uint16_t))
-                  event = *static_cast<uint16_t *>(zmq_msg_data(&ev));
-                zmq_msg_close(&ev);
-                std::string addr;
-                zmq_msg_t am;
-                zmq_msg_init(&am);
-                if (zmq_msg_recv(&am, mon, 0) != -1)
-                  addr.assign(static_cast<char *>(zmq_msg_data(&am)),
-                              zmq_msg_size(&am));
-                zmq_msg_close(&am);
-                HLOG(kError, "[ZMQMON] ROUTER event=0x{:x} peer={}", event, addr);
-              }
-              zmq_close(mon);
-            }).detach();
-          }
-        }
-      }
     }
   }
 

--- a/context-transport-primitives/include/clio_ctp/lightbeam/zmq_transport.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/zmq_transport.h
@@ -220,8 +220,10 @@ class ZeroMqTransport : public Transport {
         uint32_t pid = static_cast<uint32_t>(ctp::SystemInfo::GetPid());
         std::string identity = std::string(hostname_buf) + ":" +
                                 std::to_string(pid);
-        zmq_setsockopt(socket_, ZMQ_IDENTITY, identity.data(),
+        int id_rc = zmq_setsockopt(socket_, ZMQ_IDENTITY, identity.data(),
                         identity.size());
+        HLOG(kError, "[IDDIAG] DEALER set identity='{}' (len={}) setsockopt_rc={}",
+             identity, identity.size(), id_rc);
       }
 
       HLOG(kDebug, "ZeroMqTransport(DEALER) connecting to URL: {}", full_url);
@@ -447,8 +449,12 @@ class ZeroMqTransport : public Transport {
                               meta.client_info_.identity_.size(),
                               ZMQ_SNDMORE);
       if (rc == -1) {
-        HLOG(kError, "ZeroMqTransport::Send(ROUTER) - identity frame FAILED: {}",
-             zmq_strerror(zmq_errno()));
+        static int diag_n = 0;
+        if (diag_n++ < 5) {
+          HLOG(kError, "[IDDIAG] ROUTER send-to identity='{}' (len={}) FAILED: {}",
+               meta.client_info_.identity_, meta.client_info_.identity_.size(),
+               zmq_strerror(zmq_errno()));
+        }
         return zmq_errno();
       }
       rc = zmq_send_eintr(socket_, "", 0, ZMQ_SNDMORE);
@@ -540,6 +546,13 @@ class ZeroMqTransport : public Transport {
       meta.client_info_.identity_ = std::string(
           static_cast<char*>(zmq_msg_data(&identity_msg)),
           zmq_msg_size(&identity_msg));
+      {
+        static int diag_n = 0;
+        if (diag_n++ < 5) {
+          HLOG(kError, "[IDDIAG] ROUTER recv'd identity='{}' (len={})",
+               meta.client_info_.identity_, meta.client_info_.identity_.size());
+        }
+      }
       zmq_msg_close(&identity_msg);
 
       zmq_msg_t delim_msg;

--- a/context-transport-primitives/include/clio_ctp/lightbeam/zmq_transport.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/zmq_transport.h
@@ -220,10 +220,8 @@ class ZeroMqTransport : public Transport {
         uint32_t pid = static_cast<uint32_t>(ctp::SystemInfo::GetPid());
         std::string identity = std::string(hostname_buf) + ":" +
                                 std::to_string(pid);
-        int id_rc = zmq_setsockopt(socket_, ZMQ_IDENTITY, identity.data(),
+        zmq_setsockopt(socket_, ZMQ_IDENTITY, identity.data(),
                         identity.size());
-        HLOG(kError, "[IDDIAG] DEALER set identity='{}' (len={}) setsockopt_rc={}",
-             identity, identity.size(), id_rc);
       }
 
       HLOG(kDebug, "ZeroMqTransport(DEALER) connecting to URL: {}", full_url);
@@ -449,12 +447,8 @@ class ZeroMqTransport : public Transport {
                               meta.client_info_.identity_.size(),
                               ZMQ_SNDMORE);
       if (rc == -1) {
-        static int diag_n = 0;
-        if (diag_n++ < 5) {
-          HLOG(kError, "[IDDIAG] ROUTER send-to identity='{}' (len={}) FAILED: {}",
-               meta.client_info_.identity_, meta.client_info_.identity_.size(),
-               zmq_strerror(zmq_errno()));
-        }
+        HLOG(kError, "ZeroMqTransport::Send(ROUTER) - identity frame FAILED: {}",
+             zmq_strerror(zmq_errno()));
         return zmq_errno();
       }
       rc = zmq_send_eintr(socket_, "", 0, ZMQ_SNDMORE);
@@ -546,13 +540,6 @@ class ZeroMqTransport : public Transport {
       meta.client_info_.identity_ = std::string(
           static_cast<char*>(zmq_msg_data(&identity_msg)),
           zmq_msg_size(&identity_msg));
-      {
-        static int diag_n = 0;
-        if (diag_n++ < 5) {
-          HLOG(kError, "[IDDIAG] ROUTER recv'd identity='{}' (len={})",
-               meta.client_info_.identity_, meta.client_info_.identity_.size());
-        }
-      }
       zmq_msg_close(&identity_msg);
 
       zmq_msg_t delim_msg;

--- a/context-transport-primitives/include/clio_ctp/lightbeam/zmq_transport.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/zmq_transport.h
@@ -39,10 +39,12 @@
 #endif
 #include <zmq.h>
 
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 
 #include "clio_ctp/introspect/system_info.h"
 #include "clio_ctp/util/logging.h"
@@ -354,6 +356,43 @@ class ZeroMqTransport : public Transport {
       HLOG(kDebug, "ZeroMqTransport(ROUTER) bound successfully to {}",
            full_url);
       zmq_fired_action_.socket_ = socket_;
+
+      // Opt-in diagnostic (CLIO_ZMQ_MONITOR): trace ROUTER peer connect /
+      // accept / disconnect / ZMTP-handshake events to debug the macOS
+      // cross-process EHOSTUNREACH (#473). No-op unless the env var is set.
+      if (const char *mon_env = std::getenv("CLIO_ZMQ_MONITOR")) {
+        if (*mon_env) {
+          std::string mon_ep = "inproc://mon-" + std::to_string(port_);
+          if (zmq_socket_monitor(socket_, mon_ep.c_str(), ZMQ_EVENT_ALL) == 0) {
+            void *mctx = ctx_;
+            std::thread([mctx, mon_ep]() {
+              void *mon = zmq_socket(mctx, ZMQ_PAIR);
+              if (!mon || zmq_connect(mon, mon_ep.c_str()) != 0) return;
+              while (true) {
+                zmq_msg_t ev;
+                zmq_msg_init(&ev);
+                if (zmq_msg_recv(&ev, mon, 0) == -1) {
+                  zmq_msg_close(&ev);
+                  break;
+                }
+                uint16_t event = 0;
+                if (zmq_msg_size(&ev) >= sizeof(uint16_t))
+                  event = *static_cast<uint16_t *>(zmq_msg_data(&ev));
+                zmq_msg_close(&ev);
+                std::string addr;
+                zmq_msg_t am;
+                zmq_msg_init(&am);
+                if (zmq_msg_recv(&am, mon, 0) != -1)
+                  addr.assign(static_cast<char *>(zmq_msg_data(&am)),
+                              zmq_msg_size(&am));
+                zmq_msg_close(&am);
+                HLOG(kError, "[ZMQMON] ROUTER event=0x{:x} peer={}", event, addr);
+              }
+              zmq_close(mon);
+            }).detach();
+          }
+        }
+      }
     }
   }
 

--- a/context-transport-primitives/include/clio_ctp/util/config_parse.h
+++ b/context-transport-primitives/include/clio_ctp/util/config_parse.h
@@ -194,7 +194,25 @@ class ConfigParse {
     if (num_text == "inf") {
       return std::numeric_limits<T>::max();
     }
-    std::stringstream(num_text) >> size;
+    // Parse only the leading numeric run. libc++ (macOS) extracts
+    // floating-point values per the full C99 grammar, so a trailing unit
+    // letter that doubles as float syntax -- 'p'/'P' (hex-float binary
+    // exponent), 'x'/'X', 'e'/'E' -- is consumed as part of the number and
+    // sets failbit when no exponent digits follow. That made ParseSize("1p")
+    // return 0 on macOS while libstdc++ (Linux) stopped at 'p' and returned
+    // 1. Slice off the unit suffix first so only sign, digits and the
+    // decimal point reach the stream.
+    size_t i = 0;
+    if (i < num_text.size() && (num_text[i] == '+' || num_text[i] == '-')) {
+      ++i;
+    }
+    for (; i < num_text.size(); ++i) {
+      char c = num_text[i];
+      if ((c < '0' || c > '9') && c != '.') {
+        break;
+      }
+    }
+    std::stringstream(num_text.substr(0, i)) >> size;
     return size;
   }
 

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -468,7 +468,11 @@ std::string SystemInfo::GetMemfdPath(const std::string &name) {
 
 void SystemInfo::EnsureMemfdDir() {
   std::string dir = GetMemfdDir();
-#if CTP_ENABLE_PROCFS_SYSINFO && __linux__
+#if CTP_ENABLE_PROCFS_SYSINFO
+  // All POSIX platforms (Linux, macOS, BSD) need this per-user dir to exist:
+  // it holds the file-backed shared-memory segments and the IPC Unix-domain
+  // socket. It was previously Linux-only, so on macOS the IPC socket bind
+  // failed ("failed to bind Unix socket") because the parent dir was absent.
   mkdir(dir.c_str(), 0700);
 #elif CTP_ENABLE_WINDOWS_SYSINFO
   std::error_code ec;
@@ -500,7 +504,18 @@ bool SystemInfo::CreateNewSharedMemory(File &fd, const std::string &name,
   }
   return true;
 #else
-  fd.posix_fd_ = shm_open(name.c_str(), O_CREAT | O_RDWR, 0666);
+  // macOS / BSD: POSIX shm_open() names are capped at PSHMNAMLEN (31 chars
+  // on macOS) and shm objects live in an anonymous namespace with no
+  // filesystem path, so the per-user readiness probes and tooling that
+  // expect /tmp/chimaera_$USER/<name> (mirroring Linux's memfd symlink)
+  // never observe the segment -- WaitForServer() then times out, the test
+  // leaves an orphaned server holding the port, and every later test fails
+  // with "Address already in use". Back the segment with a regular file in
+  // the memfd dir instead: arbitrary-length names, an openable path for
+  // cross-process attach, and MAP_SHARED gives identical semantics.
+  EnsureMemfdDir();
+  std::string shm_path = GetMemfdPath(name);
+  fd.posix_fd_ = open(shm_path.c_str(), O_CREAT | O_RDWR, 0600);
   if (fd.posix_fd_ < 0) {
     return false;
   }
@@ -536,7 +551,10 @@ bool SystemInfo::OpenSharedMemory(File &fd, const std::string &name) {
   fd.posix_fd_ = open(memfd_path.c_str(), O_RDWR);
   return fd.posix_fd_ >= 0;
 #else
-  fd.posix_fd_ = shm_open(name.c_str(), O_RDWR, 0666);
+  // macOS / BSD: attach to the file-backed segment created by
+  // CreateNewSharedMemory (see the rationale there).
+  std::string shm_path = GetMemfdPath(name);
+  fd.posix_fd_ = open(shm_path.c_str(), O_RDWR);
   return fd.posix_fd_ >= 0;
 #endif
 #elif CTP_ENABLE_WINDOWS_SYSINFO
@@ -561,7 +579,9 @@ void SystemInfo::DestroySharedMemory(const std::string &name) {
   std::string memfd_path = GetMemfdPath(name);
   unlink(memfd_path.c_str());
 #else
-  shm_unlink(name.c_str());
+  // macOS / BSD: the segment is a regular file in the memfd dir.
+  std::string shm_path = GetMemfdPath(name);
+  unlink(shm_path.c_str());
 #endif
 #elif CTP_ENABLE_WINDOWS_SYSINFO
 #endif

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -283,12 +283,15 @@ int SystemInfo::GetTid() {
 
 int SystemInfo::GetPid() {
 #if CTP_ENABLE_PROCFS_SYSINFO
-#ifdef SYS_getpid
-#ifdef __OpenBSD__
+#if defined(__OpenBSD__) || defined(__APPLE__)
+  // macOS: syscall(SYS_getpid) returns a stale/incorrect value (observed
+  // returning a different number than the real pid), which corrupts the
+  // hostname:pid ZMQ DEALER identity -> cross-process ROUTER routing
+  // collisions -> EHOSTUNREACH on every response. Use libc getpid(), which
+  // is correct on Darwin/BSD. OpenBSD already used getpid() for portability.
   return (pid_t)getpid();
-#else
+#elif defined(SYS_getpid)
   return (pid_t)syscall(SYS_getpid);
-#endif
 #else
 #warning "GetPid is not defined"
   return 0;

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -283,15 +283,12 @@ int SystemInfo::GetTid() {
 
 int SystemInfo::GetPid() {
 #if CTP_ENABLE_PROCFS_SYSINFO
-#if defined(__OpenBSD__) || defined(__APPLE__)
-  // macOS: syscall(SYS_getpid) returns a stale/incorrect value (observed
-  // returning a different number than the real pid), which corrupts the
-  // hostname:pid ZMQ DEALER identity -> cross-process ROUTER routing
-  // collisions -> EHOSTUNREACH on every response. Use libc getpid(), which
-  // is correct on Darwin/BSD. OpenBSD already used getpid() for portability.
+#ifdef SYS_getpid
+#ifdef __OpenBSD__
   return (pid_t)getpid();
-#elif defined(SYS_getpid)
+#else
   return (pid_t)syscall(SYS_getpid);
+#endif
 #else
 #warning "GetPid is not defined"
   return 0;

--- a/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/event_manager_test.cc
@@ -258,13 +258,18 @@ void TestSocketTransportWithEM() {
   std::string addr = "127.0.0.1";
   int port = 8400;
 
+  // The EventManager must outlive every transport registered to it:
+  // ~SocketTransport calls em_->RemoveEvent(), which touches the manager's
+  // fd_to_reg_ map. Declaring em first guarantees it is destroyed last.
+  // (Reverse-order destruction otherwise frees em while server still holds
+  // em_ -> use-after-free; benign on libstdc++ but a hard crash on libc++.)
+  EventManager em;
   auto server = std::make_unique<SocketTransport>(
       TransportMode::kServer, addr, "tcp", port);
   auto client = std::make_unique<SocketTransport>(
       TransportMode::kClient, addr, "tcp", port);
 
   // Register EventManager on server
-  EventManager em;
   server->RegisterEventManager(em);
 
   // Client sends data

--- a/context-transport-primitives/test/unit/lightbeam/socket_transport_full_test.cc
+++ b/context-transport-primitives/test/unit/lightbeam/socket_transport_full_test.cc
@@ -482,10 +482,15 @@ void TestMultiClientWithEM() {
   std::string addr = "127.0.0.1";
   int port = 9110;
 
+  // em must outlive every transport registered to it: ~SocketTransport
+  // calls em_->RemoveEvent(), touching the manager's fd_to_reg_ map. Declare
+  // it first so reverse-order destruction tears the server down before em.
+  // (Otherwise the server's dtor dereferences a freed EventManager -- benign
+  // on libstdc++ but a hard crash on libc++/macOS.)
+  EventManager em;
   auto server = std::make_unique<SocketTransport>(
       TransportMode::kServer, addr, "tcp", port);
 
-  EventManager em;
   server->RegisterEventManager(em);
 
   auto client1 = std::make_unique<SocketTransport>(


### PR DESCRIPTION
## Summary

Fixes the macOS ctest failures reported in #473. The macOS unit suite goes from **83/200 → 189/201 passing**; the originally-reported failure cascade is fully resolved.

The repo previously **never ran ctest on macOS** (the Build and Test workflow only runs the test/coverage step on Linux), so these regressions were invisible in CI. This PR adds a macOS test workflow and fixes 9 distinct root causes.

## New: macOS CI

`.github/workflows/mac-test.yml` builds a dev tree on `macos-14` and runs ctest, surfacing failures in the Actions log + step summary + an uploaded `LastTest.log`. It runs on PRs/`main` and is **non-blocking** (failures are warnings) so it doesn't gate merges while the remaining items (see below) are worked.

## Root causes fixed

1. **macOS memfd dir** — `EnsureMemfdDir()` only created `/tmp/chimaera_$USER` on Linux; on macOS the runtime's IPC Unix-socket bind failed. Now created on all POSIX.
2. **File-backed shared memory on macOS** — bare `shm_open` capped names at 31 chars (`/buddy_allocator_multiprocess_test` → "File name too long") and exposed no filesystem path, so server-readiness probes never fired (forked servers were orphaned, holding ports). Back the segment with a regular file in the memfd dir (mirrors Linux's memfd+symlink): long names + an openable path.
3. **`ParseNumber` / libc++** — `std::stringstream >> double` on libc++ consumes a trailing `'p'` (hex-float exponent), so `ParseSize("1p")` returned 0 vs 1 PiB on Linux. Slice the unit suffix first.
4. **EventManager use-after-free** — `~SocketTransport` dereferenced an `EventManager` the test destroyed first (benign on libstdc++, segfault on libc++). Declare the EventManager before the transports.
5. **Runtime shutdown race** — `ClearTransports()` freed the main transport before the admin recv threads were joined; on macOS those threads busy-spun on a freed transport (ENOTSOCK) and corrupted teardown. Added `IpcManager::RegisterTransportShutdownHook()` so the admin module stops/joins its recv threads before transports are freed. (This alone fixed ~86 tests.)
6. **fork → `clio_run` test rework** — the IPC/transport/external-client/client-retry/per-process-shm tests forked a server child that `dlopen`'d ChiMods *after* `fork()` without `exec()` — unsupported on macOS (dyld deadlock, nondeterministic port-holding leaks) and impossible on Windows. New cross-platform `context-runtime/test/runtime_server.h` (`RuntimeServer`) launches the real `clio_run` daemon out-of-process (`posix_spawn`/`CreateProcess`); client-mode forks (which don't dlopen) are kept.
7. **`python_telemetry_test`** — CTest set pre-rebrand `CHI_*` env vars but the test reads `CLIO_SERVER_CONF`; fixed the names (was failing on all platforms).

## Test results (macOS-14)

- Before: 83/200 passing.
- After: **189/201 passing**, zero shm/port/segfault/shutdown errors.

## Known remaining (tracked as follow-ups, not blocking)

- **#476** — cross-process ZMQ ROUTER responses fail with `EHOSTUNREACH` on macOS (~10 tests). Root cause confirmed (one non-thread-safe ROUTER socket used across recv/send threads; an attempted fix drove EHOSTUNREACH 261k→0 but needs a multi-layer net-path rework + a separate client-recv fix). Documented in detail in #476.
- `ctp_mp_allocator_multiprocess` (multiprocess shm stress hang) and `cr_autogen_coverage_tests` (task-archive bulk) — separate, smaller macOS bugs.

Refs #473. Follow-up: #476.
