### PR TITLE
hdf5_vol: re-wrap iterated objects so H5Literate2/H5Ovisit work through the VOL

### DIFF
--- a/context-transfer-engine/adapter/hdf5_vol/iowarp_vol.cc
+++ b/context-transfer-engine/adapter/hdf5_vol/iowarp_vol.cc
@@ -94,6 +94,21 @@ static iowarp_dataset_t *make_dataset_wrapper(void *under, hid_t under_vol_id,
   return dset;
 }
 
+/* VOL object-wrap context. HDF5 uses this during link/object iteration
+   (H5Literate2 / H5Lvisit2 / H5Ovisit2): before invoking the user's operator it
+   saves a wrap context from this connector, then for every iterated object it
+   calls iowarp_wrap_object() to re-wrap the native object back into our VOL so
+   the operator's hid_t routes through this connector. Mirrors the reference
+   pass-through connector (H5VLpassthru). The previous implementation returned
+   the native wrap context directly and had iowarp_wrap_object() skip
+   H5VLwrap_object(), which left the iterated object only half-wrapped and made
+   H5Literate2 abort with "... is not a VOL connector ID" — the deeper blocker
+   that kept neuroh5's group enumeration from completing. */
+struct iowarp_wrap_ctx_t {
+  hid_t under_vol_id;
+  void *under_wrap_ctx;
+};
+
 /* ========================================================================
  * Helper: Get CTE client
  * ======================================================================== */
@@ -144,37 +159,65 @@ static void *iowarp_wrap_get_object(const void *obj) {
 
 static herr_t iowarp_get_wrap_ctx(const void *obj, void **wrap_ctx) {
   auto *o = static_cast<const iowarp_obj_t *>(obj);
-  return H5VLget_wrap_ctx(o->under_object, o->under_vol_id, wrap_ctx);
+  /* Carry the under VOL id alongside its wrap context so iowarp_wrap_object()
+     can call H5VLwrap_object() against the right connector. */
+  auto *ctx = new iowarp_wrap_ctx_t;
+  ctx->under_vol_id = o->under_vol_id;
+  H5Iinc_ref(ctx->under_vol_id);
+  ctx->under_wrap_ctx = nullptr;
+  H5VLget_wrap_ctx(o->under_object, o->under_vol_id, &ctx->under_wrap_ctx);
+  *wrap_ctx = ctx;
+  return 0;
 }
 
 static void *iowarp_wrap_object(void *under_obj, H5I_type_t obj_type,
-                                void *wrap_ctx) {
-  (void)wrap_ctx;
-  /* For passthrough objects (groups, attributes, etc.). We don't have a
-     way to recover the parent file from wrap_ctx (HDF5's wrap context
-     is the native VOL's, not ours), so leave parent_file null —
-     anything created from this obj will fall back to native VOL.
-     A wrapped *dataset* must still be a full iowarp_dataset_t (non-cacheable
-     here, since no file/path), or dataset_read/close would mis-cast it. */
+                                void *_wrap_ctx) {
+  auto *ctx = static_cast<iowarp_wrap_ctx_t *>(_wrap_ctx);
+  hid_t under_vol_id = ctx ? ctx->under_vol_id : H5VL_NATIVE;
+  void *under_wrap_ctx = ctx ? ctx->under_wrap_ctx : nullptr;
+
+  /* Let the underlying (native) VOL wrap the raw iteration object first.
+     Skipping this step — as the old code did — left the object unusable by the
+     native VOL and made link/object iteration abort. */
+  void *under = H5VLwrap_object(under_obj, obj_type, under_vol_id,
+                                under_wrap_ctx);
+  if (!under) return nullptr;
+
+  /* parent_file is unknown during iteration, so everything wrapped here falls
+     back to the native VOL (correct, just uncached). A wrapped *dataset* must
+     still be a full iowarp_dataset_t (non-cacheable), or a later
+     dataset_read/close would mis-cast it. */
   if (obj_type == H5I_DATASET) {
-    return make_dataset_wrapper(under_obj, H5VL_NATIVE, nullptr, nullptr);
+    return make_dataset_wrapper(under, under_vol_id, nullptr, nullptr);
   }
   auto *o = new iowarp_obj_t;
-  o->under_object = under_obj;
-  o->under_vol_id = H5VL_NATIVE;
+  o->under_object = under;
+  o->under_vol_id = under_vol_id;
   o->parent_file = nullptr;
   return o;
 }
 
 static void *iowarp_unwrap_object(void *obj) {
   auto *o = static_cast<iowarp_obj_t *>(obj);
-  void *under = o->under_object;
-  delete o;
+  /* Symmetric with iowarp_wrap_object()'s H5VLwrap_object(): peel the native
+     wrapper back off before discarding our wrapper. */
+  void *under = H5VLunwrap_object(o->under_object, o->under_vol_id);
+  if (under) delete o;
   return under;
 }
 
-static herr_t iowarp_free_wrap_ctx(void *wrap_ctx) {
-  (void)wrap_ctx;
+static herr_t iowarp_free_wrap_ctx(void *_wrap_ctx) {
+  auto *ctx = static_cast<iowarp_wrap_ctx_t *>(_wrap_ctx);
+  if (!ctx) return 0;
+  /* Preserve the active HDF5 error stack across the cleanup calls, per the
+     reference connector. */
+  hid_t err_id = H5Eget_current_stack();
+  if (ctx->under_wrap_ctx) {
+    H5VLfree_wrap_ctx(ctx->under_wrap_ctx, ctx->under_vol_id);
+  }
+  H5Idec_ref(ctx->under_vol_id);
+  H5Eset_current_stack(err_id);
+  delete ctx;
   return 0;
 }
 


### PR DESCRIPTION
## Problem

After #475 made the CTE HDF5 VOL connector usable for read-existing-file workloads, group/object **iteration** still aborted under the connector with:

```
H5Literate2 ... is not a VOL connector ID
```

This blocked any real consumer that enumerates a file (e.g. neuroh5 walking `/Populations`, `/Projections`, and per-cell attribute groups via `H5Literate2`).

## Root cause

The connector's object-wrap machinery was incomplete:

- `get_wrap_ctx` returned the **native** wrap context directly, dropping the under-VOL id.
- `wrap_object` ignored the context and **skipped `H5VLwrap_object()`**, storing the raw iterated object as-is.

During link/object iteration HDF5 re-wraps each visited object through the active connector's `wrap_object`. With the object only half-wrapped, the `hid_t` passed to the user's operator callback was not a valid VOL object, so `H5Literate2`/`H5Ovisit` aborted.

## Fix

Implement the wrap-context machinery as in the reference pass-through connector (`H5VLpassthru`):

- `iowarp_wrap_ctx_t { under_vol_id, under_wrap_ctx }`.
- `get_wrap_ctx` allocates it, inc-refs the under VOL id, fetches the under wrap context.
- `wrap_object` calls `H5VLwrap_object()` against the under VOL first, then wraps the result — dispatching datasets to the full `iowarp_dataset_t` (non-cacheable during iteration, preserving the dataset mis-cast guard from #475) and everything else to a plain wrapper.
- `unwrap_object` made symmetric (`H5VLunwrap_object` before free).
- `free_wrap_ctx` releases the under context + id ref, preserving the HDF5 error stack.

## Validation

Both native vs `HDF5_VOL_CONNECTOR=iowarp`, identical results:

1. **Synthetic** recursive `H5Literate2` (`H5_INDEX_NAME`/`H5_ITER_INC`) walk of a real neuroh5 file (`dentate_test.h5`), opening every child group/dataset inside the iteration callback: **128 datasets, identical content checksum**.
2. **Real neuroh5** `io.so` — `read_population_ranges`, `read_projection_names`, `read_population_names`, `read_cell_attribute_info`: **byte-identical** output (population ranges from compound `/H5Types`, all 21 projection pairs from the `/Projections` `H5Literate2` enumeration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)