### PR TITLE
fix(config): align default pool layout with kCtePoolId/kCaePoolId (fixes 44 coverage SEGFAULTs)

### DIFF
--- a/context-runtime/config/chimaera_default.yaml
+++ b/context-runtime/config/chimaera_default.yaml
@@ -40,17 +40,24 @@ runtime:
 # -- Compose ------------------------------------------------------------------
 # Modules started automatically with the runtime.
 #
-# Default layout puts CAE (clio_cae_core) at pool 512.0 — the address
-# every CTE client targets via clio::cte::core::kCtePoolId — and the
-# CTE core (clio_cte_core) behind it at pool 513.0. CAE forwards
-# GetOrCreateTag / PutBlob / GetBlob through to CTE so the data path
-# is unchanged, but every PutBlob now passes through CAE first. That
-# gives us a single interception point for transparent labeling /
-# indexing / discovery work without any client-side changes.
+# Default layout matches the canonical pool-id constants in the source:
+# CTE core (clio_cte_core) sits at pool 512.0 — the address every CTE
+# client targets via clio::cte::core::kCtePoolId — and CAE
+# (clio_cae_core) sits at its own pool 400.0 (clio::cae::core::kCaePoolId)
+# with next_pool_id pointing at CTE. CAE is the assimilation / discovery
+# entrypoint (CEE -> ParseOmni) and forwards the data path it owns
+# (GetOrCreateTag / PutBlob / GetBlob / SemanticSearch) on to CTE.
 #
-# Only clio_bdev is strictly required. Drop either the CAE or CTE
-# entry if you don't need it (if you drop CAE, change CTE's pool_id
-# back to 512.0 so existing clients continue to resolve).
+# NOTE: do NOT put CAE in front of CTE at 512.0. CAE only mirrors the
+# four data-path method ids above; the rest of its method ids collide
+# with CTE's (e.g. CAE kParseOmni == CTE kRegisterTarget == 10), so a
+# CTE client hitting CAE for RegisterTarget / TagQuery / BlobQuery is
+# dispatched to the wrong handler and crashes. Transparent CTE-client
+# interception therefore lives only in the dedicated interceptor test
+# configs, never in this default.
+#
+# Only clio_bdev is strictly required. Drop the CAE or CTE entry if you
+# don't need it.
 compose:
 
   # === Block Device (DRAM) ===
@@ -71,16 +78,15 @@ compose:
   #   bdev_type: file                    # Options: file, ram, hbm, pinned, noop
   #   capacity: "100GB"
 
-  # === Context Assimilation Engine (CAE) — CTE interceptor ===
-  # Sits at the canonical CTE entrypoint (512.0) and forwards data-path
-  # tasks to the CTE core at 513.0. Forwarding is transparent —
-  # standard CTE clients (CLIO_CTE_CLIENT, FUSE adapter, etc.) work
-  # without modification.
+  # === Context Assimilation Engine (CAE) ===
+  # Assimilation / discovery entrypoint at its own pool 400.0
+  # (clio::cae::core::kCaePoolId). CEE calls ParseOmni here; CAE forwards
+  # the data-path tasks it owns to the CTE core at next_pool_id (512.0).
   - mod_name: clio_cae_core
     pool_name: cae_main
     pool_query: local
-    pool_id: "512.0"
-    next_pool_id: "513.0"               # CTE core pool — see entry below
+    pool_id: "400.0"
+    next_pool_id: "512.0"               # CTE core pool — see entry below
 
     # Transparent LLM labeling — optional. When enabled, PutBlob calls
     # `model` on `label_endpoint` for every blob whose tag+name matches
@@ -98,14 +104,14 @@ compose:
     #     context_length: 4096                  # tokens (Ollama num_ctx)
 
   # === Context Transfer Engine (CTE) ===
-  # High-performance data buffering and transfer engine. Sits behind
-  # CAE at 513.0 so CAE can intercept the data path. Remove this and
-  # the CAE entry above (or change CAE's pool_id to 513.0 and skip
-  # this) if you do not need CTE.
+  # High-performance data buffering and transfer engine. Sits at the
+  # canonical CTE entrypoint 512.0 (clio::cte::core::kCtePoolId) so every
+  # CTE client / FUSE adapter resolves to it directly. Remove this (and
+  # the CAE entry above) if you do not need CTE.
   - mod_name: clio_cte_core
     pool_name: cte_main
     pool_query: local
-    pool_id: "513.0"
+    pool_id: "512.0"
 
     # Storage tiers ---------------------------------------------------------
     # Each entry creates a block device for CTE to buffer data onto.


### PR DESCRIPTION
## Problem

The **coverage** CDash build (site `ubu-24.amd64`) reports **44 failed tests** — 42 SEGFAULTs plus a `Failed` and a `Subprocess aborted`: `cte_query_*`, `cte_tag_*`, `cte_client_config_*`, `cte_runtime_coverage_*`, all `*_force_net` variants, `test_context_bundle`, and every `cee_*` test.

These were invisible elsewhere:
- The conda recipe's `test:` step only checks that library files exist — it **never runs ctest**, so `install.sh` never exercises these tests.
- The coverage job submits via `ctest -S ... || true`, so the GitHub "Build and Test" job stays green regardless.

## Root cause

`context-runtime/config/chimaera_default.yaml` (seeded to `~/.clio/clio.yaml`) placed the **CAE interceptor at pool `512.0`** and **CTE core at `513.0`**. But the source constants are `clio::cte::core::kCtePoolId = 512` and `clio::cae::core::kCaePoolId = 400`.

So a generic CTE/CEE test creates a client targeting pool 512 (expecting CTE) and instead lands on the **CAE** container. Method IDs overlap across the two engines — `CTE kRegisterTarget == CAE kParseOmni == 10` — so a CTE `RegisterTarget` task is dispatched to CAE's `ParseOmni`, which deserializes the task bytes as a `std::vector<AssimilationCtx>`:

```
ParseOmni called with 20 bytes of serialized data
ParseOmni: Failed to deserialize AssimilationCtx vector: vector::_M_default_append   # std::length_error
=> SEGFAULT
```

(20 bytes can't hold even one `AssimilationCtx` (~127 bytes); the bogus vector length blows up `resize()`.) The CEE tests have the mirror problem — they target `kCaePoolId=400`, which the bad config left empty.

## Fix

Restore the canonical layout that the code constants, **every other deployment config** (`docker/quickstart`, `clio_config_example`, `demo`, the globus integration config, …), and the interceptor unit tests already use:

- CTE core (`cte_main`) → `512.0` (`kCtePoolId`)
- CAE (`cae_main`) → `400.0` (`kCaePoolId`), `next_pool_id: 512.0`

The dedicated interceptor test configs (`test_cae_cte_interceptor_config`, `test_cae_labeling_config`, `test_cae_semantic_search_config`) intentionally keep the CAE@512/CTE@513 layout — they only exercise the four forwarded data-path methods (GetOrCreateTag/PutBlob/GetBlob/SemanticSearch), so they're unaffected.

One file changed (mostly comments documenting why CAE must not sit in front of CTE at 512).

## Validation (local debug build)

- Reproduced the exact `cte_query_tag_exact` SEGFAULT with the old config.
- With the fix: **all 44 previously-failing tests pass** (CTE query/tag/client_config/runtime_coverage, all `force_net` variants, `test_context_bundle`, all `cee_*`).
- **No regression:** interceptor tests (`cae_cte_interceptor`, `cae_string_assim`, `cae_labeling`, `cae_semantic`) and CTE core data-path tests (`cte_core_*`, `cte_config_*`, `cte_dpe_*`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)