### PR TITLE
fix(pip/windows): add --ignore-existing to delvewheel repair command

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -150,6 +150,14 @@ jobs:
           CLIO_CORE_ENABLE_BENCHMARKS=OFF
         CIBW_BUILD_FRONTEND: "build"
         CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
+        # clio_cee_api.dll is already bundled in the wheel via CMake's
+        # pip_package install rules (bin/ destination), but delvewheel's
+        # default repair pass only searches PATH — not inside the wheel.
+        # --ignore-existing tells delvewheel to treat DLLs already in the
+        # wheel as satisfied, so it can traverse the dep graph without
+        # trying to locate them externally.
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+          delvewheel repair -w {dest_dir} -v --ignore-existing {wheel}
       run: cibuildwheel --output-dir installers/pip/wheelhouse
 
     - name: Upload Windows wheels


### PR DESCRIPTION
## Summary

- Fixes Windows wheel build failure: `FileNotFoundError: Unable to find library: clio_cee_api.dll`
- Root cause: `clio_cee.pyd` imports `clio_cee_api.dll`, which is already bundled into the wheel at `bin/` via CMake's `pip_package` install rules. However, `delvewheel`'s default repair pass only searches `PATH` — not inside the wheel — so it can't find the DLL.
- Fix: add `--ignore-existing` to `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS`, which tells delvewheel to recognize DLLs already present in the wheel when traversing the dependency graph.

## Test plan

- [ ] CI Windows wheel build passes (job [80235351385](https://github.com/iowarp/clio-core/actions/runs/27179491315/job/80235351385) was the failing job)
- [ ] All other wheel builds (Linux, macOS) are unaffected (only `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS` changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)