### PR TITLE
build: fix compiler and configure warnings on macOS

### DIFF
--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -119,7 +119,7 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
   // Start dedicated recv threads in IpcManagerRun2Run.
   CLIO_IPC->GetRun2Run()->StartRecvThreads();
   // Stop recv threads before the main transport is freed.
-  CLIO_IPC->RegisterTransportShutdownHook([this]() {
+  CLIO_IPC->RegisterTransportShutdownHook([]() {
     CLIO_IPC->GetRun2Run()->StopRecvThreads();
   });
 

--- a/context-runtime/test/unit/test_autogen_coverage.cc
+++ b/context-runtime/test/unit/test_autogen_coverage.cc
@@ -12070,7 +12070,16 @@ TEST_CASE("Autogen - PoolQuery copy and assignment", "[autogen][poolquery][copy]
 
   SECTION("Self assignment") {
     auto q1 = chi::PoolQuery::Physical(42);
+    // Intentional self-assignment to exercise operator=; silence the
+    // expected -Wself-assign-overloaded diagnostic.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
     q1 = q1;
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
     REQUIRE(q1.IsPhysicalMode());
     REQUIRE(q1.GetNodeId() == 42);
     INFO("PoolQuery self assignment completed");

--- a/context-runtime/test/unit/test_unordered_map_ll.cc
+++ b/context-runtime/test/unit/test_unordered_map_ll.cc
@@ -516,7 +516,7 @@ TEST_F(UnorderedMapLLTest, ConcurrentInsertReadNoExternalLock) {
 
   // Inserter threads: disjoint key ranges, deterministic values.
   for (int t = 0; t < num_inserters; ++t) {
-    threads.emplace_back([&map, t, keys_per_inserter]() {
+    threads.emplace_back([&map, t]() {
       const int begin = t * keys_per_inserter;
       const int end = begin + keys_per_inserter;
       for (int k = begin; k < end; ++k) {

--- a/context-transport-primitives/CMakeLists.txt
+++ b/context-transport-primitives/CMakeLists.txt
@@ -356,7 +356,15 @@ if(CLIO_CTP_ENABLE_IO_URING)
         endif()
         message(STATUS "io_uring enabled: ${URING_INCLUDE_DIR} / ${URING_LIBRARY}")
     else()
-        message(WARNING "io_uring requested but liburing not found, disabling io_uring")
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            # On Linux a missing liburing is actionable (install liburing-dev),
+            # so surface it as a warning.
+            message(WARNING "io_uring requested but liburing not found, disabling io_uring")
+        else()
+            # io_uring is a Linux-only kernel interface and can never be present
+            # on macOS/Windows/BSD, so this is expected, not a misconfiguration.
+            message(STATUS "io_uring unavailable on ${CMAKE_SYSTEM_NAME}, disabling io_uring")
+        endif()
         set(CLIO_CTP_ENABLE_IO_URING OFF)
     endif()
 endif()

--- a/context-transport-primitives/src/system_info.cc
+++ b/context-transport-primitives/src/system_info.cc
@@ -284,7 +284,10 @@ int SystemInfo::GetTid() {
 int SystemInfo::GetPid() {
 #if CTP_ENABLE_PROCFS_SYSINFO
 #ifdef SYS_getpid
-#ifdef __OpenBSD__
+#if defined(__OpenBSD__) || defined(__APPLE__)
+  // syscall(2) is deprecated on macOS; getpid() is the supported interface and
+  // is not subject to the fork-caching issue this raw syscall historically
+  // worked around on glibc.
   return (pid_t)getpid();
 #else
   return (pid_t)syscall(SYS_getpid);


### PR DESCRIPTION
## Summary
- Eliminate four compiler warnings and one CMake configure warning seen when building `clio-core` on macOS.
- No behavior change — purely warning cleanup.

## Motivation
Fixes #514. A warning-free build makes real regressions easier to spot in CI logs.

## Changes
| File | Warning | Fix |
|------|---------|-----|
| `context-transport-primitives/src/system_info.cc` | `'syscall' is deprecated` (macOS) | Use `getpid()` on Apple (extends the existing OpenBSD branch); the raw `syscall` only dodged glibc's fork-time getpid caching, which is not a concern on macOS |
| `context-runtime/modules/admin/src/admin_runtime.cc` | `lambda capture 'this' is not used` | `[this]` → `[]` (lambda only uses the `CLIO_IPC` global) |
| `context-runtime/test/unit/test_unordered_map_ll.cc` | `lambda capture 'keys_per_inserter' is not required` | Dropped from capture list (it is a `const int` constant expression) |
| `context-runtime/test/unit/test_autogen_coverage.cc` | `explicitly assigning value … to itself` | Wrapped the intentional self-assignment test in a `-Wself-assign-overloaded` pragma push/pop |
| `context-transport-primitives/CMakeLists.txt` | `io_uring requested but liburing not found` | io_uring is Linux-only; keep the actionable `WARNING` on Linux, emit a quiet `STATUS` note on macOS/Windows/BSD |

## Test plan
- [x] Full build: **0 warnings, 0 errors** (Homebrew LLVM 22 on macOS)
- [x] Configure: **0 CMake warnings** (now prints `-- io_uring unavailable on Darwin, disabling io_uring`)
- [x] `ctest` suite: **192/192 passing** (CI exclusion set)
- [ ] clang-format: existing files are not fully clang-format-clean against the local binary (whole-file include/pointer churn); edits match each file's surrounding style to avoid unrelated reformatting

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)