### PR TITLE
ci: clean up site name in sanitizers.yml (#516)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -50,4 +50,4 @@ jobs:
         ./CI/run_sanitizers.sh \
           --${{ matrix.sanitizer }} \
           --build \
-          --site "ubu-24.amd64-${{ matrix.sanitizer }}"
+          --site "ubu-24.amd64"


### PR DESCRIPTION
Fixes #516.

Removes the redundant `-${{ matrix.sanitizer }}` suffix from the CTest `--site` argument in `sanitizers.yml`, so all sanitizer jobs report under a single, clean site name (`ubu-24.amd64`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)