### PR TITLE
build: fix HDF5 VOL connector link failure with vcpkg CONFIG-mode HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,20 +662,39 @@ if(CLIO_CTE_ENABLE_HDF5_VOL)
         find_package(HDF5 COMPONENTS C QUIET)
     endif()
     if(HDF5_FOUND)
-        message(STATUS "found HDF5 at ${HDF5_INCLUDE_DIRS}")
-
         # Ensure HDF5_LIBRARIES is set for both CONFIG and MODULE mode
         if(NOT HDF5_LIBRARIES)
-            # CONFIG mode creates targets but may not set HDF5_LIBRARIES
-            # Prefer shared libraries over static for better compatibility
+            # CONFIG mode creates targets but may not set HDF5_LIBRARIES.
+            # HDF5's own hdf5-config.cmake (used by vcpkg and HDF Group
+            # binary installs) only exports namespaced hdf5::hdf5-{shared,
+            # static} targets, so check those too (issue #518: the VOL
+            # connector DLL linked without hdf5.lib on Windows/vcpkg).
+            # Prefer shared libraries over static for better compatibility.
             if(TARGET HDF5::HDF5)
                 set(HDF5_LIBRARIES HDF5::HDF5)
+            elseif(TARGET hdf5::hdf5-shared)
+                set(HDF5_LIBRARIES hdf5::hdf5-shared)
             elseif(TARGET hdf5-shared)
                 set(HDF5_LIBRARIES hdf5-shared)
+            elseif(TARGET hdf5::hdf5-static)
+                set(HDF5_LIBRARIES hdf5::hdf5-static)
             elseif(TARGET hdf5-static)
                 set(HDF5_LIBRARIES hdf5-static)
             endif()
         endif()
+        if(NOT HDF5_LIBRARIES)
+            message(FATAL_ERROR "HDF5 found but no linkable HDF5 target/"
+                                "library was identified (HDF5_DIR=${HDF5_DIR})")
+        endif()
+
+        # hdf5-config.cmake sets HDF5_INCLUDE_DIR (singular); consumers in
+        # this project use HDF5_INCLUDE_DIRS.
+        if(NOT HDF5_INCLUDE_DIRS AND HDF5_INCLUDE_DIR)
+            set(HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIR})
+        endif()
+
+        message(STATUS "found HDF5 ${HDF5_VERSION} at '${HDF5_INCLUDE_DIRS}' "
+                       "(libraries: ${HDF5_LIBRARIES})")
 
         # libhdf5.so (system package) depends on libcurl internally;
         # the linker needs it listed explicitly due to --as-needed.

--- a/context-transfer-engine/test/unit/adapters/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/adapters/CMakeLists.txt
@@ -24,3 +24,10 @@ endif()
 if(CLIO_CTE_ENABLE_FUSE_ADAPTER)
     add_subdirectory(libfuse)
 endif()
+
+# HDF5 VOL connector tests (doesn't require ELF or a running runtime).
+# The TARGET guard skips them when the connector itself was skipped
+# (HDF5 missing or < 1.14).
+if(CLIO_CTE_ENABLE_HDF5_VOL AND TARGET iowarp_hdf5_vol)
+    add_subdirectory(hdf5_vol)
+endif()

--- a/context-transfer-engine/test/unit/adapters/hdf5_vol/CMakeLists.txt
+++ b/context-transfer-engine/test/unit/adapters/hdf5_vol/CMakeLists.txt
@@ -1,0 +1,65 @@
+# HDF5 VOL Connector Unit Tests
+#
+# Exercises the connector's plugin entry points, class definition,
+# registration and property-list integration with HDF5. No Chimaera runtime
+# is required (the connector's initialize callback is nullptr), so these
+# tests run standalone without RESOURCE_LOCK / cleanup fixtures.
+#
+# Linking this test also regression-checks issue #518: it consumes
+# ${HDF5_LIBRARIES}, which was empty when HDF5 was found in CONFIG mode
+# (vcpkg exports only the namespaced hdf5::hdf5-shared target), making the
+# connector DLL fail to link with unresolved H5* symbols on Windows.
+
+add_executable(test_hdf5_vol_adapter
+    test_hdf5_vol_adapter.cc
+)
+
+target_include_directories(test_hdf5_vol_adapter PRIVATE
+    ${CMAKE_SOURCE_DIR}/context-transfer-engine/adapter/hdf5_vol
+    ${CMAKE_SOURCE_DIR}/context-runtime/test
+    ${HDF5_INCLUDE_DIRS}
+)
+
+target_link_libraries(test_hdf5_vol_adapter
+    iowarp_hdf5_vol
+    ctp::cxx
+    ${HDF5_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# simple_test.h filters by substring of the registered test name
+add_test(NAME cte_hdf5_vol_plugin_entry
+    COMMAND test_hdf5_vol_adapter "HDF5 VOL - Plugin Entry Points")
+
+add_test(NAME cte_hdf5_vol_class
+    COMMAND test_hdf5_vol_adapter "HDF5 VOL - Connector Class Definition")
+
+add_test(NAME cte_hdf5_vol_register
+    COMMAND test_hdf5_vol_adapter "HDF5 VOL - Registration Lifecycle")
+
+add_test(NAME cte_hdf5_vol_fapl
+    COMMAND test_hdf5_vol_adapter "HDF5 VOL - File Access Property List")
+
+add_test(NAME cte_hdf5_vol_introspect
+    COMMAND test_hdf5_vol_adapter "HDF5 VOL - Introspect Callbacks")
+
+add_test(NAME cte_hdf5_vol_info
+    COMMAND test_hdf5_vol_adapter "HDF5 VOL - Info Copy And Free")
+
+set_tests_properties(
+    cte_hdf5_vol_plugin_entry
+    cte_hdf5_vol_class
+    cte_hdf5_vol_register
+    cte_hdf5_vol_fapl
+    cte_hdf5_vol_introspect
+    cte_hdf5_vol_info
+    PROPERTIES
+        TIMEOUT 300
+        LABELS "unit;adapter;hdf5_vol;cte"
+        ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
+)
+
+install(
+    TARGETS test_hdf5_vol_adapter
+    RUNTIME DESTINATION bin
+)

--- a/context-transfer-engine/test/unit/adapters/hdf5_vol/test_hdf5_vol_adapter.cc
+++ b/context-transfer-engine/test/unit/adapters/hdf5_vol/test_hdf5_vol_adapter.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Unit tests for the IOWarp HDF5 VOL connector (iowarp_hdf5_vol).
+ *
+ * Exercises the connector through its public surface only: the HDF5 plugin
+ * discovery entry points and the H5VL registration / property-list APIs.
+ * The connector's initialize callback is nullptr, so none of this requires
+ * a running Chimaera runtime.
+ *
+ * These tests also serve as a link-time regression for issue #518: both the
+ * connector DLL and this executable consume ${HDF5_LIBRARIES}, which was
+ * empty when HDF5 was found in CONFIG mode (vcpkg exports only namespaced
+ * hdf5::hdf5-shared targets), leaving every H5* symbol unresolved.
+ */
+
+#include "simple_test.h"
+
+#include "iowarp_vol.h"
+
+#include <cstring>
+
+/* The plugin discovery entry points are the only symbols the connector
+   library is guaranteed to export on Windows (H5PLextern.h marks them
+   dllexport inside the plugin). Declare them locally instead of including
+   H5PLextern.h, which would re-declare them dllexport in this consumer TU.
+   H5VL_iowarp_cls / H5VL_iowarp_register carry no export decoration, so
+   they must not be referenced directly here. */
+extern "C" H5PL_type_t H5PLget_plugin_type(void);
+extern "C" const void *H5PLget_plugin_info(void);
+
+namespace {
+
+const H5VL_class_t *GetIowarpVolClass() {
+  return static_cast<const H5VL_class_t *>(H5PLget_plugin_info());
+}
+
+}  // namespace
+
+TEST_CASE("HDF5 VOL - Plugin Entry Points", "[hdf5_vol]") {
+  REQUIRE(H5PLget_plugin_type() == H5PL_TYPE_VOL);
+
+  const H5VL_class_t *cls = GetIowarpVolClass();
+  REQUIRE(cls != nullptr);
+  /* The same class pointer must be returned on every call (HDF5 caches it) */
+  REQUIRE(GetIowarpVolClass() == cls);
+}
+
+TEST_CASE("HDF5 VOL - Connector Class Definition", "[hdf5_vol]") {
+  const H5VL_class_t *cls = GetIowarpVolClass();
+  REQUIRE(cls != nullptr);
+
+  SECTION("identification");
+  REQUIRE(std::strcmp(cls->name, IOWARP_VOL_CONNECTOR_NAME) == 0);
+  REQUIRE(cls->value == IOWARP_VOL_CONNECTOR_VALUE);
+  REQUIRE(cls->version == H5VL_VERSION);
+  REQUIRE(cls->conn_version == IOWARP_VOL_CONNECTOR_VERSION);
+
+  SECTION("capability flags");
+  REQUIRE((cls->cap_flags & H5VL_CAP_FLAG_FILE_BASIC) != 0);
+  REQUIRE((cls->cap_flags & H5VL_CAP_FLAG_DATASET_BASIC) != 0);
+  REQUIRE((cls->cap_flags & H5VL_CAP_FLAG_GROUP_BASIC) != 0);
+  REQUIRE((cls->cap_flags & H5VL_CAP_FLAG_ATTR_BASIC) != 0);
+
+  SECTION("required callbacks are wired");
+  REQUIRE(cls->info_cls.size == sizeof(iowarp_vol_info_t));
+  REQUIRE(cls->info_cls.copy != nullptr);
+  REQUIRE(cls->info_cls.free != nullptr);
+  REQUIRE(cls->file_cls.create != nullptr);
+  REQUIRE(cls->file_cls.open != nullptr);
+  REQUIRE(cls->file_cls.close != nullptr);
+  REQUIRE(cls->dataset_cls.create != nullptr);
+  REQUIRE(cls->dataset_cls.open != nullptr);
+  REQUIRE(cls->dataset_cls.read != nullptr);
+  REQUIRE(cls->dataset_cls.write != nullptr);
+  REQUIRE(cls->dataset_cls.close != nullptr);
+  REQUIRE(cls->group_cls.create != nullptr);
+  REQUIRE(cls->group_cls.open != nullptr);
+  REQUIRE(cls->group_cls.close != nullptr);
+  REQUIRE(cls->attr_cls.create != nullptr);
+  REQUIRE(cls->attr_cls.read != nullptr);
+  REQUIRE(cls->attr_cls.write != nullptr);
+  REQUIRE(cls->attr_cls.close != nullptr);
+}
+
+TEST_CASE("HDF5 VOL - Registration Lifecycle", "[hdf5_vol]") {
+  REQUIRE(H5open() >= 0);
+
+  const H5VL_class_t *cls = GetIowarpVolClass();
+  REQUIRE(cls != nullptr);
+
+  SECTION("register");
+  hid_t connector_id = H5VLregister_connector(cls, H5P_DEFAULT);
+  REQUIRE(connector_id >= 0);
+  REQUIRE(H5VLis_connector_registered_by_name(IOWARP_VOL_CONNECTOR_NAME) > 0);
+  REQUIRE(H5VLis_connector_registered_by_value(
+              static_cast<H5VL_class_value_t>(IOWARP_VOL_CONNECTOR_VALUE)) > 0);
+
+  SECTION("lookup by name and value");
+  hid_t by_name = H5VLget_connector_id_by_name(IOWARP_VOL_CONNECTOR_NAME);
+  REQUIRE(by_name >= 0);
+  hid_t by_value = H5VLget_connector_id_by_value(
+      static_cast<H5VL_class_value_t>(IOWARP_VOL_CONNECTOR_VALUE));
+  REQUIRE(by_value >= 0);
+  REQUIRE(H5VLclose(by_name) >= 0);
+  REQUIRE(H5VLclose(by_value) >= 0);
+
+  SECTION("unregister");
+  REQUIRE(H5VLunregister_connector(connector_id) >= 0);
+  REQUIRE(H5VLis_connector_registered_by_name(IOWARP_VOL_CONNECTOR_NAME) == 0);
+}
+
+TEST_CASE("HDF5 VOL - File Access Property List", "[hdf5_vol]") {
+  REQUIRE(H5open() >= 0);
+
+  const H5VL_class_t *cls = GetIowarpVolClass();
+  hid_t connector_id = H5VLregister_connector(cls, H5P_DEFAULT);
+  REQUIRE(connector_id >= 0);
+
+  SECTION("install connector on a FAPL");
+  hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+  REQUIRE(fapl >= 0);
+
+  iowarp_vol_info_t info;
+  info.under_vol_id = H5I_INVALID_HID;
+  info.under_vol_info = nullptr;
+  info.chunk_size = IOWARP_VOL_DEFAULT_CHUNK_SIZE;
+  REQUIRE(H5Pset_vol(fapl, connector_id, &info) >= 0);
+
+  SECTION("read the connector back from the FAPL");
+  hid_t fapl_vol_id = H5I_INVALID_HID;
+  REQUIRE(H5Pget_vol_id(fapl, &fapl_vol_id) >= 0);
+  REQUIRE(fapl_vol_id >= 0);
+  REQUIRE(H5VLclose(fapl_vol_id) >= 0);
+
+  /* Closing the FAPL routes through iowarp_info_free for the copied info */
+  REQUIRE(H5Pclose(fapl) >= 0);
+  REQUIRE(H5VLunregister_connector(connector_id) >= 0);
+}
+
+TEST_CASE("HDF5 VOL - Introspect Callbacks", "[hdf5_vol]") {
+  const H5VL_class_t *cls = GetIowarpVolClass();
+  REQUIRE(cls != nullptr);
+
+  SECTION("get_conn_cls returns this connector");
+  REQUIRE(cls->introspect_cls.get_conn_cls != nullptr);
+  const H5VL_class_t *conn_cls = nullptr;
+  REQUIRE(cls->introspect_cls.get_conn_cls(nullptr, H5VL_GET_CONN_LVL_CURR,
+                                           &conn_cls) == 0);
+  REQUIRE(conn_cls == cls);
+
+  SECTION("get_cap_flags reports the basic capabilities");
+  REQUIRE(cls->introspect_cls.get_cap_flags != nullptr);
+  uint64_t cap_flags = 0;
+  REQUIRE(cls->introspect_cls.get_cap_flags(nullptr, &cap_flags) == 0);
+  REQUIRE((cap_flags & H5VL_CAP_FLAG_FILE_BASIC) != 0);
+  REQUIRE((cap_flags & H5VL_CAP_FLAG_DATASET_BASIC) != 0);
+  REQUIRE((cap_flags & H5VL_CAP_FLAG_GROUP_BASIC) != 0);
+  REQUIRE((cap_flags & H5VL_CAP_FLAG_ATTR_BASIC) != 0);
+  REQUIRE((cap_flags & H5VL_CAP_FLAG_LINK_BASIC) != 0);
+  REQUIRE((cap_flags & H5VL_CAP_FLAG_OBJECT_BASIC) != 0);
+
+  SECTION("opt_query reports no optional operations");
+  REQUIRE(cls->introspect_cls.opt_query != nullptr);
+  uint64_t opt_flags = ~static_cast<uint64_t>(0);
+  REQUIRE(cls->introspect_cls.opt_query(nullptr, H5VL_SUBCLS_DATASET, 0,
+                                        &opt_flags) == 0);
+  REQUIRE(opt_flags == 0);
+}
+
+TEST_CASE("HDF5 VOL - Info Copy And Free", "[hdf5_vol]") {
+  const H5VL_class_t *cls = GetIowarpVolClass();
+  REQUIRE(cls != nullptr);
+
+  iowarp_vol_info_t info;
+  info.under_vol_id = H5I_INVALID_HID;
+  info.under_vol_info = nullptr;
+  info.chunk_size = 4 * 1024;
+
+  SECTION("copy produces an independent equal info");
+  void *copied = cls->info_cls.copy(&info);
+  REQUIRE(copied != nullptr);
+  REQUIRE(copied != static_cast<void *>(&info));
+  auto *copy = static_cast<iowarp_vol_info_t *>(copied);
+  REQUIRE(copy->under_vol_id == info.under_vol_id);
+  REQUIRE(copy->under_vol_info == nullptr);
+  REQUIRE(copy->chunk_size == info.chunk_size);
+
+  SECTION("free releases the copy");
+  REQUIRE(cls->info_cls.free(copied) == 0);
+}
+
+SIMPLE_TEST_MAIN()


### PR DESCRIPTION
## Summary
- `HDF5_LIBRARIES` stayed empty when HDF5 was found in CONFIG mode because HDF5''s own `hdf5-config.cmake` (vcpkg, HDF Group binary installs) exports only the namespaced `hdf5::hdf5-{shared,static}` targets — the fallback only checked `HDF5::HDF5`/`hdf5-shared`/`hdf5-static`. `iowarp_hdf5_vol.dll` then linked without `hdf5.lib` and failed with 60 unresolved `__imp_H5*` externals.
- Check the namespaced targets, derive `HDF5_INCLUDE_DIRS` from CONFIG-mode''s singular `HDF5_INCLUDE_DIR`, and fail at configure time with a clear message when no linkable HDF5 target is identified.
- Add the first unit tests for the VOL connector (`test_hdf5_vol_adapter`, 6 ctest entries): plugin entry points, connector class definition, registration lifecycle, FAPL set/get round-trip, introspect callbacks, and info copy/free. They need no running Chimaera runtime and consume `${HDF5_LIBRARIES}` directly, so they double as a link regression check for this fix.

## Motivation
Fixes #518 (build: win-11 / vs-26 / vcpkg / vol fails)

## Test plan
- [x] Full clean build + `ctest -C Debug -D Experimental` via `run_vol.bat` on win-11 / VS 18 2026 / vcpkg: 0 compiler errors, 100% tests passed (187/187), results submitted to CDash
- [x] New regression tests pass: `ctest -R cte_hdf5_vol` (6/6)
- [x] Configure log now reports `found HDF5 2.1.1 at ''.../include'' (libraries: hdf5::hdf5-shared)` instead of an empty path
- [x] BSD 3-Clause headers on all new files

## Breaking changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)