### PR TITLE
fix(asan): heap-use-after-free in UnregisterTarget and SIGUSR1 startup kill

### DIFF
--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -238,12 +238,17 @@ void Worker::Run() {
   SetAsCurrentWorker();
   is_running_ = true;
 
-  // Set up thread ID and signal event via EventManager
+  // Set up the signal event BEFORE publishing the tid. AwakenWorker
+  // tgkill(SIGUSR1)s any published tid unconditionally; if a producer fires
+  // in the window between SetTid and AddSignalEvent (which blocks SIGUSR1
+  // on this thread), the default disposition kills the whole process
+  // (issue #520). On Windows the same order matters for liveness: Signal()
+  // on a tid without a registered event is a lost wakeup.
   int tid = ctp::SystemInfo::GetTid();
+  event_manager_.AddSignalEvent(nullptr);
   if (assigned_lane_) {
     assigned_lane_->SetTid(tid);
   }
-  event_manager_.AddSignalEvent(nullptr);
 
   // Main worker loop - process tasks from assigned lane
   while (is_running_) {

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -665,7 +665,10 @@ chi::TaskResume Runtime::UnregisterTarget(
         CLIO_CO_RETURN;
       }
 
-      const chi::PoolId &target_id = *target_id_ptr;
+      // Copy by value: target_id_ptr points into the map node that
+      // erase(target_name) below frees, and target_id is still read in the
+      // target_list_ loop after that (ASan heap-use-after-free, issue #520).
+      const chi::PoolId target_id = *target_id_ptr;
       if (!registered_targets_.contains(target_id)) {
         task->return_code_ = 1;
         CLIO_CO_RETURN;


### PR DESCRIPTION
## Summary
- **heap-use-after-free in `Runtime::UnregisterTarget`** (4 failed asan tests: `cte_client_config_all`, `cte_runtime_coverage_all` and their `force_net` variants): the code bound a reference to the `PoolId` stored inside the `target_name_to_id_` map node, erased that node, then compared the freed `UniqueId` in the `target_list_` sweep. The id is now copied by value before the erase.
- **SIGUSR1 process kill during worker startup** (`cr_streaming_bitfield_tests`): `Worker::Run` published its tid via `SetTid` before `AddSignalEvent` blocked SIGUSR1 on the thread. `IpcManager::AwakenWorker` tgkill(SIGUSR1)s any published tid unconditionally, so a producer firing in that window delivered SIGUSR1 to an unmasked thread and the default disposition terminated the process. The signal event is now installed before the tid is published; on Windows this order also avoids a lost wakeup (`Signal()` to an unregistered tid returns -1).

## Motivation
Fixes #520 — the 5 failed tests on the asan dashboard build https://my.cdash.org/builds/3601775 (site ubu-24.amd64-asan).

## Test plan
- [x] All 5 previously failing tests pass locally: `ctest -R cte_client_config_all|cte_runtime_coverage_all|cr_streaming_bitfield|cte_client_config_force_net|cte_runtime_coverage_force_net` (7/7 incl. cleanup fixtures)
- [x] Full suite via `run_vol.bat` (win-11 / VS 18 2026 / vcpkg): 0 compiler errors, 100% tests passed (187/187), submitted to CDash
- [ ] CI sanitizers job (ASan) green — the authoritative check for both fixes

## Breaking changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)