### PR TITLE
ci: standardize mac-test CDash build name to cnd/d

### DIFF
--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -73,10 +73,12 @@ jobs:
 
           # Mirror the coverage build's option overrides so we exercise the
           # same test set CDash reported failing, minus coverage tooling
-          # (lcov/gcov is Linux-only). SITE/BUILDNAME label the CDash build.
+          # (lcov/gcov is Linux-only). SITE/BUILDNAME label the CDash build:
+          # SITE is the runner, BUILDNAME the standard config label
+          # (cnd = conda deps, d = debug).
           cmake --preset=debug \
             -DSITE="${{ matrix.os }}" \
-            -DBUILDNAME="mac-test-${{ matrix.os }}" \
+            -DBUILDNAME="cnd/d" \
             -DCLIO_CORE_ENABLE_COVERAGE=OFF \
             -DCLIO_CORE_ENABLE_CONDA=ON \
             -DCLIO_CORE_ENABLE_DOCKER_CI=OFF \


### PR DESCRIPTION
## Summary
- Change `-DBUILDNAME` in `mac-test.yml` from `mac-test-${{ matrix.os }}` to the standard config label `cnd/d` (cnd = conda deps, d = debug).

## Motivation
Fixes #522. `SITE` already identifies the runner OS, so repeating it in the build name cluttered the CDash dashboard; `cnd/d` matches the naming used by other submissions.

## Test plan
- [ ] mac-test workflow runs on this PR and submits to CDash under the new name
- [ ] No other workflow references the old BUILDNAME (verified by grep; the `mac-test-logs-*` artifact name is unrelated)

## Breaking changes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)