### PR TITLE
build: give static archives per-config output dirs on multi-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -975,12 +975,20 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-# For multi-config generators (Visual Studio, Xcode)
+# For multi-config generators (Visual Studio, Xcode), keep runtime artifacts
+# (.exe/.dll) in a flat bin/ for every configuration: tests and the module
+# loader resolve binaries at ${CMAKE_BINARY_DIR}/bin regardless of config.
+# Archives (static libs and DLL import libs) must NOT be flattened: they are
+# link-time-only inputs, and sharing one bin/<name>.lib across configurations
+# lets a Release build clobber the Debug archive (and vice versa), which then
+# fails the next Debug link with LNK2038 runtime-library mismatches (#528).
+# Leaving the per-config archive variables unset makes multi-config
+# generators append a per-configuration subdirectory (bin/Debug, bin/Release)
+# to CMAKE_ARCHIVE_OUTPUT_DIRECTORY automatically.
 foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/bin)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/bin)
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/bin)
 endforeach()
 
 #------------------------------------------------------------------------------

--- a/cmake/CheckPerConfigArchiveLayout.cmake
+++ b/cmake/CheckPerConfigArchiveLayout.cmake
@@ -1,0 +1,58 @@
+# CheckPerConfigArchiveLayout.cmake
+# Regression check for issue #528: on multi-config generators (Visual Studio,
+# Xcode), static archives must live in per-configuration directories
+# (bin/<CONFIG>) so that building one configuration cannot clobber the
+# archives of another, while runtime artifacts (.exe/.dll) stay in the flat
+# bin/ directory that tests and the module loader rely on.
+#
+# Invoked as a CTest test via:
+#   cmake -DARCHIVE_FILE=<path> -DEXE_FILE=<path> -DBIN_DIR=<path>
+#         -DCONFIG=<config> -P CheckPerConfigArchiveLayout.cmake
+#
+# Arguments:
+#   ARCHIVE_FILE - $<TARGET_FILE:...> of a static library in the active config
+#   EXE_FILE     - $<TARGET_FILE:...> of an executable in the active config
+#   BIN_DIR      - ${CMAKE_BINARY_DIR}/bin
+#   CONFIG       - $<CONFIG>, the active configuration name
+
+foreach(_var ARCHIVE_FILE EXE_FILE BIN_DIR CONFIG)
+  if(NOT DEFINED ${_var})
+    message(FATAL_ERROR "Missing required argument -D${_var}=...")
+  endif()
+endforeach()
+
+file(TO_CMAKE_PATH "${ARCHIVE_FILE}" _archive_file)
+file(TO_CMAKE_PATH "${EXE_FILE}" _exe_file)
+file(TO_CMAKE_PATH "${BIN_DIR}" _bin_dir)
+
+if(NOT EXISTS "${_archive_file}")
+  message(FATAL_ERROR "Archive does not exist: ${_archive_file}")
+endif()
+if(NOT EXISTS "${_exe_file}")
+  message(FATAL_ERROR "Executable does not exist: ${_exe_file}")
+endif()
+
+get_filename_component(_archive_dir "${_archive_file}" DIRECTORY)
+get_filename_component(_exe_dir "${_exe_file}" DIRECTORY)
+
+if(NOT _archive_dir STREQUAL "${_bin_dir}/${CONFIG}")
+  message(FATAL_ERROR
+    "Static archive is not in a per-configuration directory.\n"
+    "  expected dir: ${_bin_dir}/${CONFIG}\n"
+    "  actual dir:   ${_archive_dir}\n"
+    "Sharing one archive path across configurations lets one configuration "
+    "overwrite another's .lib, which breaks the next link with LNK2038 "
+    "runtime-library mismatches (issue #528).")
+endif()
+
+if(NOT _exe_dir STREQUAL "${_bin_dir}")
+  message(FATAL_ERROR
+    "Executable is not in the flat runtime directory.\n"
+    "  expected dir: ${_bin_dir}\n"
+    "  actual dir:   ${_exe_dir}\n"
+    "Tests and the module loader resolve binaries at bin/ regardless of "
+    "configuration.")
+endif()
+
+message(STATUS
+  "Per-config archive layout OK: ${_archive_dir} (archive), ${_exe_dir} (exe)")

--- a/context-runtime/util/CMakeLists.txt
+++ b/context-runtime/util/CMakeLists.txt
@@ -32,6 +32,21 @@ target_link_libraries(clio_run
   PUBLIC clio_run_commands
 )
 
+# Regression test for issue #528: on multi-config generators, static
+# archives must land in per-configuration directories (bin/<CONFIG>) so a
+# Release build cannot clobber the Debug archive and poison the next Debug
+# link, while executables stay in the flat bin/ layout tests depend on.
+if(CLIO_CORE_ENABLE_TESTS AND CMAKE_CONFIGURATION_TYPES)
+  add_test(NAME build_layout_per_config_archives
+    COMMAND ${CMAKE_COMMAND}
+      -DARCHIVE_FILE=$<TARGET_FILE:clio_run_commands>
+      -DEXE_FILE=$<TARGET_FILE:clio_run>
+      -DBIN_DIR=${CMAKE_BINARY_DIR}/bin
+      -DCONFIG=$<CONFIG>
+      -P ${CMAKE_SOURCE_DIR}/cmake/CheckPerConfigArchiveLayout.cmake
+  )
+endif()
+
 # Install the binary under its canonical name `clio_run`. The legacy name
 # `chimaera` (predates the CLIO rebrand) is installed as a symlink in the
 # same bin/ dir so existing pipelines and scripts keep working. The binary


### PR DESCRIPTION
## Summary
- Stop forcing per-configuration archive output directories to the shared flat `bin/` on multi-config generators (Visual Studio, Xcode). Static libraries and DLL import libraries now land in `bin/<CONFIG>/` (e.g. `bin/Debug/`), so building one configuration can no longer overwrite another configuration's archives.
- Runtime artifacts (`.exe`/`.dll`) keep the flat `bin/` layout for every configuration — tests and the module loader resolve binaries there regardless of config. Single-config generators (Linux CI) are unaffected.
- Add a `build_layout_per_config_archives` regression test (multi-config only) that asserts archives are per-config and executables are flat.

## Motivation
Fixes #528

On Windows, Debug and Release both emitted `bin/<name>.lib`. After a Release build in the same tree, the next Debug build considered its `Lib` step up to date (the shared output was newer than the Debug objects) and fed the stale Release archive to the Debug link, failing with 13 errors: 12x `LNK2038` (`RuntimeLibrary` / `_ITERATOR_DEBUG_LEVEL` mismatch) + `LNK1319` on `clio_run.exe`. Archives are link-time-only inputs, so splitting them per config removes the collision without changing where tests find binaries.

## Test plan
- [x] Full `run_vol.bat` (VS 18 2026, vcpkg, Debug, VOL enabled): **0 compiler errors**, the 13 link errors are gone
- [x] New regression test passes: `ctest -C Debug -R build_layout_per_config_archives`
- [x] All existing tests pass: 188/188 (`100% tests passed, 0 tests failed out of 188`)
- [x] Verified on-disk layout: all `.lib`/`.exp` in `bin/Debug/`, executables/DLLs flat in `bin/`
- [x] No new compiler warnings

## Breaking changes
None. Install rules (`ARCHIVE DESTINATION lib`) and single-config builds are unaffected; only the build-tree location of `.lib` files on multi-config generators changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
