### PR TITLE
Add Mofka streaming benchmark (Jarvis packages + single/2-node TCP pipelines)

### DIFF
--- a/jarvis_clio_core/jarvis_clio_core/mofka_bench/__init__.py
+++ b/jarvis_clio_core/jarvis_clio_core/mofka_bench/__init__.py
@@ -1,0 +1,4 @@
+"""
+Mofka Benchmark Application Package — runs producer/consumer benchmarks
+against a running Mofka server and collects performance metrics.
+"""

--- a/jarvis_clio_core/jarvis_clio_core/mofka_bench/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/mofka_bench/pkg.py
@@ -1,0 +1,630 @@
+"""
+Mofka Benchmark Application — runs producer and/or consumer benchmarks
+against a running Mofka server and collects performance metrics.
+
+Ported from the archived ``jarvis_iowarp.mofka_bench`` (branch
+``claude/mofka-multinode``) into ``jarvis_clio_core``. Deltas from the
+archived file, both required to run under the Slurm ``scheduler:`` block
+(jarvis ``dev``), which seeds the hostfile with *all* allocated nodes:
+
+  1. Multi-node dispatch keys on ``self.hostfile`` and requires
+     ``len(hosts) > 1`` — so a 1-node Slurm allocation (one real, non-
+     ``localhost`` host) runs producer/consumer locally, co-located with
+     bedrock, exactly like the archived single-node flow.
+  2. ``_client_hostfile()`` drops the bedrock head node
+     (``MOFKA_SERVER_HOST``, set by mofka_server) from the PSSH target
+     set so only the N-1 client nodes run producers/consumers. Idempotent
+     — a no-op when the head is already absent (e.g. Pattern-A bash-
+     stripped hostfile). See pipelines/mofka/architecture_decisions.md.
+"""
+from jarvis_cd.core.pkg import Application
+from jarvis_cd.shell import Exec, LocalExecInfo, PsshExecInfo
+from jarvis_cd.util.hostfile import Hostfile
+import glob
+import os
+import re
+import time as time_mod
+
+
+class MofkaBench(Application):
+    """
+    Runs Mofka producer/consumer benchmarks and collects throughput,
+    event-rate, and latency statistics.
+    """
+
+    _FOLD_SUM = {
+        'throughput_mbps',
+        'events_per_sec',
+        'total_data_mb',
+        'events_count',
+    }
+    _FOLD_MAX = {
+        'elapsed_ms',
+    }
+
+    def _init(self):
+        self.start_time = None
+
+    def _configure_menu(self):
+        return [
+            {
+                'name': 'mode',
+                'msg': 'Benchmark mode',
+                'type': str,
+                'default': 'both',
+                'choices': ['producer', 'consumer', 'both'],
+            },
+            {
+                'name': 'num_events',
+                'msg': 'Number of events to produce/consume',
+                'type': int,
+                'default': 1000,
+            },
+            {
+                'name': 'data_size',
+                'msg': 'Data payload size in bytes',
+                'type': int,
+                'default': 1024,
+            },
+            {
+                'name': 'metadata_size',
+                'msg': 'Metadata size in bytes',
+                'type': int,
+                'default': 64,
+            },
+            {
+                'name': 'batch_size',
+                'msg': 'Producer/consumer batch size',
+                'type': int,
+                'default': 16,
+            },
+            {
+                'name': 'num_threads',
+                'msg': 'Number of threads',
+                'type': int,
+                'default': 1,
+            },
+            {
+                'name': 'data_selectivity',
+                'msg': 'Consumer data selectivity (0.0-1.0)',
+                'type': float,
+                'default': 1.0,
+            },
+            {
+                'name': 'use_progress_thread',
+                'msg': 'Use Mercury progress thread',
+                'type': bool,
+                'default': True,
+            },
+            {
+                'name': 'nprocs',
+                'msg': 'Number of MPI/SSH processes (1 = single-node local)',
+                'type': int,
+                'default': 1,
+            },
+            {
+                'name': 'ppn',
+                'msg': 'Processes per node',
+                'type': int,
+                'default': 1,
+            },
+        ]
+
+    def _configure(self, **kwargs):
+        # Resolve group file and topic from upstream mofka_server env
+        group_file = self.env.get(
+            'MOFKA_GROUP_FILE', '/tmp/mofka-bench/mofka.json'
+        )
+        topic = self.env.get('MOFKA_TOPIC', 'benchmark_topic')
+
+        self.setenv('MOFKA_GROUP_FILE', group_file)
+        self.setenv('MOFKA_TOPIC', topic)
+        self.setenv('MOFKA_NUM_EVENTS', str(self.config['num_events']))
+        self.setenv('MOFKA_DATA_SIZE', str(self.config['data_size']))
+        self.setenv('MOFKA_METADATA_SIZE', str(self.config['metadata_size']))
+        self.setenv('MOFKA_BATCH_SIZE', str(self.config['batch_size']))
+        self.setenv('MOFKA_NUM_THREADS', str(self.config['num_threads']))
+        self.setenv('MOFKA_DATA_SELECTIVITY',
+                     str(self.config['data_selectivity']))
+
+        self.log('Mofka benchmark configured')
+
+    def start(self):
+        t0 = time_mod.time()
+
+        group_file = self.env.get(
+            'MOFKA_GROUP_FILE', '/tmp/mofka-bench/mofka.json'
+        )
+        topic = self.env.get('MOFKA_TOPIC', 'benchmark_topic')
+        scripts_dir = os.path.join(self.pkg_dir, 'scripts')
+
+        # Clear previous output files (and any per-host siblings from a
+        # prior multi-node run) so _parse_output can't match stale data.
+        for fname in ('producer_output.txt', 'consumer_output.txt'):
+            path = os.path.join(self.shared_dir, fname)
+            if os.path.exists(path):
+                os.remove(path)
+            for stale in glob.glob(path + '.*'):
+                os.remove(stale)
+
+        progress_flag = ('--use-progress-thread'
+                         if self.config['use_progress_thread'] else '')
+
+        # --- Producer ---
+        if self.config['mode'] in ('producer', 'both'):
+            cmd = (
+                f'python3 {scripts_dir}/producer.py'
+                f' --group-file {group_file}'
+                f' --topic {topic}'
+                f' --num-events {self.config["num_events"]}'
+                f' --data-size {self.config["data_size"]}'
+                f' --metadata-size {self.config["metadata_size"]}'
+                f' --batch-size {self.config["batch_size"]}'
+                f' --num-threads {self.config["num_threads"]}'
+                f' {progress_flag}'
+            )
+            producer_out = os.path.join(self.shared_dir, 'producer_output.txt')
+            self.log('Running producer benchmark')
+            self._run_role(cmd, producer_out, 'producer')
+            self._check_output_freshness(producer_out, 'producer')
+
+        # --- Consumer ---
+        if self.config['mode'] in ('consumer', 'both'):
+            cmd = (
+                f'python3 {scripts_dir}/consumer.py'
+                f' --group-file {group_file}'
+                f' --topic {topic}'
+                f' --num-events {self.config["num_events"]}'
+                f' --data-size {self.config["data_size"]}'
+                f' --data-selectivity {self.config["data_selectivity"]}'
+                f' --batch-size {self.config["batch_size"]}'
+                f' --num-threads {self.config["num_threads"]}'
+                f' {progress_flag}'
+            )
+            consumer_out = os.path.join(
+                self.shared_dir, 'consumer_output.txt'
+            )
+            self.log('Running consumer benchmark')
+            self._run_role(cmd, consumer_out, 'consumer')
+            self._check_output_freshness(consumer_out, 'consumer')
+
+        self.start_time = time_mod.time() - t0
+        self.log(f'Benchmark completed in {self.start_time:.2f}s')
+
+    def _is_multinode(self):
+        """Decide whether producer/consumer dispatch via PSSH (multi-node)
+        or locally (single-node).
+
+        Returns True only for a genuine multi-host allocation
+        (``len(hosts) > 1``). Three cases:
+          - default localhost hostfile (no allocation) -> False (local)
+          - 1-node Slurm allocation: the scheduler writes one real host
+            (e.g. ``ares-comp-14``, not ``localhost``) -> is_local() is
+            False, but ``len(hosts) == 1`` -> False (local; bedrock and
+            the producer/consumer share the one node, matching the
+            archived single-node flow)
+          - 2+ node allocation -> True (PSSH to the N-1 client nodes)
+
+        The ``len(hosts) > 1`` gate (vs the archived ``len(hf) > 0``) is
+        what keeps single-node Slurm runs on the local branch now that the
+        scheduler always materialises a non-localhost hostfile.
+        """
+        hf = self.hostfile
+        if hf is None:
+            return False
+        try:
+            if hf.is_local():
+                return False
+            return len(hf.hosts) > 1
+        except (AttributeError, TypeError):
+            return False
+
+    def _client_hostfile(self):
+        """Hostfile of client-only nodes for PSSH (bedrock head removed).
+
+        The Slurm scheduler block seeds jarvis's hostfile with every
+        allocated node, head included. Bedrock runs on the head node (the
+        batch node, published as ``MOFKA_SERVER_HOST`` by mofka_server);
+        producers/consumers must run only on the remaining N-1 client
+        nodes. Compared on short hostnames so a domain suffix
+        (``ares-comp-14.localdomain`` vs ``ares-comp-14``) still matches.
+
+        Idempotent: if ``MOFKA_SERVER_HOST`` is unset or already absent
+        from the hostfile (e.g. a Pattern-A bash-pre-stripped client
+        hostfile), the original hostfile is returned unchanged. If the
+        server is somehow the only host, fall back to the original so
+        PSSH still has a target (``_is_multinode`` gates this off anyway).
+        """
+        hf = self.hostfile
+        server_host = (self.env.get('MOFKA_SERVER_HOST', '') or '').split(
+            '.')[0]
+        if not server_host:
+            return hf
+        has_ip = len(hf.hosts_ip) == len(hf.hosts)
+        keep, keep_ip = [], []
+        for i, host in enumerate(hf.hosts):
+            if host.split('.')[0] == server_host:
+                continue
+            keep.append(host)
+            if has_ip:
+                keep_ip.append(hf.hosts_ip[i])
+        if not keep:
+            return hf
+        return Hostfile(hosts=keep, hosts_ip=keep_ip if keep_ip else None)
+
+    def _run_role(self, cmd, output_path, role):
+        """Dispatch a producer/consumer command either locally or across
+        client hosts via PsshExecInfo. The dispatch signal is
+        ``_is_multinode()`` (a >1-host allocation), not nprocs.
+
+        Multi-node uses a client-only hostfile (``_client_hostfile``) so
+        the bedrock head node never runs a producer/consumer. PsshExecInfo
+        doesn't accept pipe_stdout, so the redirect is embedded with
+        double-quoted bash -c and an escaped \\$(hostname) so each node
+        writes to a unique file.
+
+        Local branch captures both stdout and stderr into the output file
+        so a Python traceback from producer.py/consumer.py reaches the
+        log instead of vanishing. Non-zero exit codes raise RuntimeError
+        so jarvis flips the iteration's status to failed.
+        """
+        if self._is_multinode():
+            wrapped = (
+                f'bash -c "{cmd} > {output_path}.\\$(hostname) 2>&1"'
+            )
+            exec_info = PsshExecInfo(
+                env=self.mod_env,
+                hostfile=self._client_hostfile(),
+                nprocs=self.config['nprocs'],
+                ppn=self.config['ppn'],
+            )
+            result = Exec(wrapped, exec_info).run()
+        else:
+            result = Exec(cmd, LocalExecInfo(
+                env=self.mod_env,
+                pipe_stdout=output_path,
+                pipe_stderr=output_path,
+            )).run()
+
+        exit_codes = getattr(result, 'exit_code', {}) or {}
+        nonzero = {h: c for h, c in exit_codes.items() if c != 0}
+        if nonzero:
+            self._log_output_tail(output_path)
+            raise RuntimeError(
+                f'{role} benchmark exited with non-zero code(s): {nonzero}')
+
+    def stop(self):
+        pass
+
+    def clean(self):
+        for fname in ('producer_output.txt', 'consumer_output.txt'):
+            path = os.path.join(self.shared_dir, fname)
+            if os.path.exists(path):
+                os.remove(path)
+            for per_host in glob.glob(path + '.*'):
+                os.remove(per_host)
+
+    # ------------------------------------------------------------------
+    # Statistics collection
+    # ------------------------------------------------------------------
+
+    def _resolve_output_path(self, path):
+        """Return the canonical {role}_output.txt if it exists (single-node),
+        else any one of the per-host files written in multi-node mode.
+        Returns None if neither shape is on disk. Single-node runs always
+        hit the first branch; the glob branch handles the multi-node case
+        where each host writes its own file."""
+        if os.path.exists(path):
+            return path
+        per_host = sorted(glob.glob(path + '.*'))
+        return per_host[0] if per_host else None
+
+    def _log_output_tail(self, path, n_lines=100):
+        """Emit the tail of {role}_output.txt into the Jarvis log. Falls back
+        to a per-host file (multi-node) if the canonical path is absent."""
+        resolved = self._resolve_output_path(path)
+        if resolved is None:
+            self.log(f'(no output file at {path} or {path}.*)')
+            return
+        try:
+            with open(resolved, 'r') as f:
+                lines = f.readlines()
+        except Exception as e:
+            self.log(f'failed to read {resolved}: {e}')
+            return
+        tail = lines[-n_lines:] if len(lines) > n_lines else lines
+        self.log(
+            f'--- {os.path.basename(resolved)} tail ({len(tail)} lines) ---')
+        for line in tail:
+            self.log(line.rstrip())
+        self.log(f'--- end {os.path.basename(resolved)} tail ---')
+
+    def _check_output_freshness(self, path, role):
+        """Raise if output is missing, empty, or lacks the RESULTS header.
+
+        Both producer.py and consumer.py print a `RESULTS` block on the
+        success path; a crash inside the push/flush/pull loop leaves an
+        output file with the early config banner but no RESULTS, which is
+        the silent-failure mode that produced empty CSV columns on the
+        original Ares sweep.
+        """
+        resolved = self._resolve_output_path(path)
+        if resolved is None:
+            raise RuntimeError(
+                f'{role} benchmark produced no output file at '
+                f'{path} (or {path}.*)')
+        with open(resolved, 'r') as f:
+            content = f.read()
+        if not content.strip():
+            raise RuntimeError(
+                f'{role} benchmark output file is empty: {resolved}')
+        content_stripped = re.sub(r'\033\[[0-9;]*m', '', content)
+        if not re.search(r'\bRESULTS\b', content_stripped):
+            self._log_output_tail(path)
+            raise RuntimeError(
+                f'{role} benchmark output lacks RESULTS header: {resolved}')
+
+    def _fold_host_stats(self, per_host_stats, stat_dict):
+        """Aggregate per-host stat dicts into stat_dict.
+
+        SUM for cumulative metrics (throughput, events, data volume);
+        MAX for wall-clock (the run is only over when the slowest
+        host finishes). Unknown metrics fall back to mean — a safe
+        default if a new metric is added without updating the fold
+        rules, though anything load-bearing should be explicitly
+        classified in _FOLD_SUM / _FOLD_MAX.
+        """
+        from collections import defaultdict
+        buckets = defaultdict(list)
+        for host_stat in per_host_stats:
+            for key, value in host_stat.items():
+                buckets[key].append(value)
+        for key, values in buckets.items():
+            metric = key.rsplit('.', 1)[-1]
+            if metric in self._FOLD_SUM:
+                stat_dict[key] = sum(values)
+            elif metric in self._FOLD_MAX:
+                stat_dict[key] = max(values)
+            else:
+                stat_dict[key] = sum(values) / len(values)
+
+    def _get_stat(self, stat_dict):
+        """Parse benchmark output files and populate stat_dict.
+
+        Single-node: one canonical {role}_output.txt is parsed via
+        _resolve_output_path (same code path as before this change).
+        Multi-node: glob all per-host {role}_output.txt.<hostname>
+        files, parse each into its own dict, then fold via
+        _fold_host_stats.
+        """
+        for role in ('producer', 'consumer'):
+            canonical = os.path.join(
+                self.shared_dir, f'{role}_output.txt'
+            )
+            if self._is_multinode():
+                files = sorted(glob.glob(canonical + '.*'))
+            else:
+                resolved = self._resolve_output_path(canonical)
+                files = [resolved] if resolved else []
+            if not files:
+                continue
+            per_host_stats = []
+            for fpath in files:
+                with open(fpath, 'r') as f:
+                    output = f.read()
+                host_stat = {}
+                self._parse_output(output, role, host_stat)
+                if host_stat:
+                    per_host_stats.append(host_stat)
+            if not per_host_stats:
+                continue
+            if len(per_host_stats) == 1:
+                stat_dict.update(per_host_stats[0])
+            else:
+                self._fold_host_stats(per_host_stats, stat_dict)
+
+    def _parse_output(self, output, role, stat_dict):
+        """Extract metrics from producer or consumer stdout.
+
+        Uses findall and takes the last match to be resilient against
+        output files that contain data from multiple appended runs.
+        """
+        patterns = {
+            'throughput_mbps': r'Throughput:\s+([\d.]+)\s+MB/s',
+            'events_per_sec': r'Events/sec:\s+([\d.]+)',
+            'elapsed_ms': r'Elapsed time:\s+([\d.]+)\s+ms',
+            'total_data_mb': r'Total data:\s+([\d.]+)\s+MB',
+            'events_count': r'Events (?:produced|consumed):\s+(\d+)',
+        }
+        for metric, pattern in patterns.items():
+            matches = re.findall(pattern, output)
+            if matches:
+                value = float(matches[-1])
+                if metric == 'events_count':
+                    value = int(value)
+                stat_dict[f'{self.pkg_id}.{role}.{metric}'] = value
+
+    # ------------------------------------------------------------------
+    # Plotting
+    # ------------------------------------------------------------------
+
+    def _plot(self, results_dir):
+        """
+        Generate performance visualisation plots from pipeline test
+        results stored in *results_dir*/results.csv.
+
+        Produces four PNG figures:
+          1. Throughput (MB/s) vs Data Size
+          2. Events/sec vs Data Size
+          3. Throughput (MB/s) vs Num Threads
+          4. Events/sec vs Num Threads
+        """
+        import csv
+        try:
+            import matplotlib
+            matplotlib.use('Agg')
+            import matplotlib.pyplot as plt
+        except ImportError:
+            self.log('matplotlib not available — skipping plots')
+            return
+
+        csv_path = os.path.join(results_dir, 'results.csv')
+        if not os.path.exists(csv_path):
+            self.log(f'No results.csv found at {csv_path}')
+            return
+
+        rows = []
+        with open(csv_path, 'r') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                rows.append(row)
+
+        if not rows:
+            self.log('results.csv is empty')
+            return
+
+        # Identify the stat column names (they use the pkg_name prefix)
+        # Try to find any column matching *.producer.throughput_mbps
+        pkg_prefix = None
+        for key in rows[0]:
+            if key.endswith('.producer.throughput_mbps'):
+                pkg_prefix = key.rsplit('.producer.throughput_mbps', 1)[0]
+                break
+        if pkg_prefix is None:
+            # Fall back: try consumer
+            for key in rows[0]:
+                if key.endswith('.consumer.throughput_mbps'):
+                    pkg_prefix = key.rsplit('.consumer.throughput_mbps', 1)[0]
+                    break
+        if pkg_prefix is None:
+            self.log('Could not identify stat columns in results.csv')
+            return
+
+        def _col(role, metric):
+            return f'{pkg_prefix}.{role}.{metric}'
+
+        def _safe_float(row, col):
+            val = row.get(col, '')
+            if val == '':
+                return None
+            try:
+                return float(val)
+            except (ValueError, TypeError):
+                return None
+
+        # Detect which sweep variable columns exist
+        data_size_col = None
+        threads_col = None
+        for key in rows[0]:
+            if key.endswith('.data_size'):
+                data_size_col = key
+            if key.endswith('.num_threads'):
+                threads_col = key
+
+        # --- Helper: aggregate rows by a sweep variable ---
+        def _aggregate(rows, sweep_col, role, metric_col):
+            """Return sorted (x_values, y_means) averaging over repeats."""
+            from collections import defaultdict
+            buckets = defaultdict(list)
+            for row in rows:
+                x = _safe_float(row, sweep_col)
+                y = _safe_float(row, _col(role, metric_col))
+                if x is not None and y is not None:
+                    buckets[x].append(y)
+            xs = sorted(buckets.keys())
+            ys = [sum(buckets[x]) / len(buckets[x]) for x in xs]
+            return xs, ys
+
+        # --- Figure 1: Throughput vs Data Size ---
+        if data_size_col:
+            fig, ax = plt.subplots(figsize=(8, 5))
+            for role, colour, label in [
+                ('producer', '#2196F3', 'Producer'),
+                ('consumer', '#FF9800', 'Consumer'),
+            ]:
+                xs, ys = _aggregate(rows, data_size_col, role,
+                                    'throughput_mbps')
+                if xs:
+                    ax.bar(
+                        [str(int(x)) for x in xs], ys,
+                        alpha=0.7, color=colour, label=label,
+                        width=0.35,
+                    )
+            ax.set_xlabel('Data Size (bytes)')
+            ax.set_ylabel('Throughput (MB/s)')
+            ax.set_title('Mofka Throughput vs Data Size')
+            ax.legend()
+            fig.tight_layout()
+            fig.savefig(os.path.join(results_dir,
+                                     'throughput_vs_data_size.png'),
+                        dpi=150)
+            plt.close(fig)
+
+        # --- Figure 2: Events/sec vs Data Size ---
+        if data_size_col:
+            fig, ax = plt.subplots(figsize=(8, 5))
+            for role, colour, label in [
+                ('producer', '#2196F3', 'Producer'),
+                ('consumer', '#FF9800', 'Consumer'),
+            ]:
+                xs, ys = _aggregate(rows, data_size_col, role,
+                                    'events_per_sec')
+                if xs:
+                    ax.bar(
+                        [str(int(x)) for x in xs], ys,
+                        alpha=0.7, color=colour, label=label,
+                        width=0.35,
+                    )
+            ax.set_xlabel('Data Size (bytes)')
+            ax.set_ylabel('Events / sec')
+            ax.set_title('Mofka Event Rate vs Data Size')
+            ax.legend()
+            fig.tight_layout()
+            fig.savefig(os.path.join(results_dir,
+                                     'events_vs_data_size.png'),
+                        dpi=150)
+            plt.close(fig)
+
+        # --- Figure 3: Throughput vs Num Threads ---
+        if threads_col:
+            fig, ax = plt.subplots(figsize=(8, 5))
+            for role, marker, label in [
+                ('producer', 'o', 'Producer'),
+                ('consumer', 's', 'Consumer'),
+            ]:
+                xs, ys = _aggregate(rows, threads_col, role,
+                                    'throughput_mbps')
+                if xs:
+                    ax.plot(xs, ys, marker=marker, label=label, linewidth=2)
+            ax.set_xlabel('Number of Threads')
+            ax.set_ylabel('Throughput (MB/s)')
+            ax.set_title('Mofka Throughput vs Thread Count')
+            ax.legend()
+            fig.tight_layout()
+            fig.savefig(os.path.join(results_dir,
+                                     'throughput_vs_threads.png'),
+                        dpi=150)
+            plt.close(fig)
+
+        # --- Figure 4: Events/sec vs Num Threads ---
+        if threads_col:
+            fig, ax = plt.subplots(figsize=(8, 5))
+            for role, marker, label in [
+                ('producer', 'o', 'Producer'),
+                ('consumer', 's', 'Consumer'),
+            ]:
+                xs, ys = _aggregate(rows, threads_col, role,
+                                    'events_per_sec')
+                if xs:
+                    ax.plot(xs, ys, marker=marker, label=label, linewidth=2)
+            ax.set_xlabel('Number of Threads')
+            ax.set_ylabel('Events / sec')
+            ax.set_title('Mofka Event Rate vs Thread Count')
+            ax.legend()
+            fig.tight_layout()
+            fig.savefig(os.path.join(results_dir,
+                                     'events_vs_threads.png'),
+                        dpi=150)
+            plt.close(fig)
+
+        self.log(f'Plots saved to {results_dir}')

--- a/jarvis_clio_core/jarvis_clio_core/mofka_bench/scripts/consumer.py
+++ b/jarvis_clio_core/jarvis_clio_core/mofka_bench/scripts/consumer.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Mofka Consumer Benchmark
+Consumes N events from a topic and measures throughput.
+
+Usage:
+    source env.sh
+    python3 consumer.py [options]
+"""
+import argparse
+import os
+import sys
+import time
+
+def main():
+    parser = argparse.ArgumentParser(description="Mofka Consumer Benchmark")
+    parser.add_argument("--group-file", default=os.environ.get("MOFKA_GROUP_FILE", "/tmp/mofka-bench/mofka.json"))
+    parser.add_argument("--topic", default=os.environ.get("MOFKA_TOPIC", "benchmark_topic"))
+    parser.add_argument("--num-events", type=int, default=int(os.environ.get("MOFKA_NUM_EVENTS", "1000")))
+    parser.add_argument("--data-size", type=int, default=int(os.environ.get("MOFKA_DATA_SIZE", "1024")))
+    parser.add_argument("--num-threads", type=int, default=int(os.environ.get("MOFKA_NUM_THREADS", "1")))
+    parser.add_argument("--data-selectivity", type=float, default=float(os.environ.get("MOFKA_DATA_SELECTIVITY", "1.0")))
+    parser.add_argument("--batch-size", type=int, default=int(os.environ.get("MOFKA_BATCH_SIZE", "16")))
+    parser.add_argument("--use-progress-thread", action="store_true", default=True)
+    args = parser.parse_args()
+
+    print("=" * 50)
+    print("  Mofka Consumer Benchmark (Python)")
+    print("=" * 50)
+    print(f"  Group file:        {args.group_file}")
+    print(f"  Topic:             {args.topic}")
+    print(f"  Events to consume: {args.num_events}")
+    print(f"  Data size:         {args.data_size} bytes")
+    print(f"  Data selectivity:  {args.data_selectivity}")
+    print(f"  Batch size:        {args.batch_size}")
+    print(f"  Threads:           {args.num_threads}")
+    print("=" * 50)
+
+    if not os.path.exists(args.group_file):
+        print(f"ERROR: Group file not found: {args.group_file}")
+        print("  Did you start the server first? (./server.sh)")
+        sys.exit(1)
+
+    from mochi.mofka.client import MofkaDriver
+
+    # Connect to Mofka
+    driver = MofkaDriver(args.group_file, use_progress_thread=args.use_progress_thread)
+
+    # Open topic
+    topic = driver.open_topic(args.topic)
+
+    # Create consumer without Python data_selector/data_broker callbacks.
+    # Using Python callbacks with use_progress_thread=True causes a GIL
+    # deadlock: the C++ progress thread tries to acquire the GIL for the
+    # callback while the main thread holds it inside future.wait().
+    # The default C++ consumer retrieves all event data without callbacks.
+    consumer = topic.consumer(
+        name="bench-consumer",
+        batch_size=args.batch_size,
+    )
+
+    # Run benchmark
+    # event.data returns a DataDescriptor (not raw bytes), so we track
+    # transferred bytes as data_size * selectivity per event consumed.
+    events_consumed = 0
+    bytes_per_event = int(args.data_size * args.data_selectivity)
+
+    print(f"\nConsuming {args.num_events} events...")
+    t_start = time.time()
+
+    while events_consumed < args.num_events:
+        future = consumer.pull()
+        event = future.wait()
+        event.acknowledge()
+        events_consumed += 1
+
+    total_data_bytes = events_consumed * bytes_per_event
+
+    t_end = time.time()
+
+    elapsed_ms = (t_end - t_start) * 1000.0
+    total_mb = total_data_bytes / (1024 * 1024)
+    throughput_mbs = total_mb / (elapsed_ms / 1000.0) if elapsed_ms > 0 else 0
+    events_per_sec = events_consumed / (elapsed_ms / 1000.0) if elapsed_ms > 0 else 0
+
+    print(f"\n{'=' * 50}")
+    print(f"  RESULTS")
+    print(f"{'=' * 50}")
+    print(f"  Events consumed:   {events_consumed}")
+    print(f"  Total data:        {total_mb:.2f} MB")
+    print(f"  Elapsed time:      {elapsed_ms:.2f} ms")
+    print(f"  Throughput:        {throughput_mbs:.2f} MB/s")
+    print(f"  Events/sec:        {events_per_sec:.0f}")
+    print(f"{'=' * 50}")
+
+    del consumer
+    del topic
+    del driver
+
+if __name__ == "__main__":
+    main()

--- a/jarvis_clio_core/jarvis_clio_core/mofka_bench/scripts/producer.py
+++ b/jarvis_clio_core/jarvis_clio_core/mofka_bench/scripts/producer.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Mofka Producer Benchmark
+Sends N events to a topic and measures throughput.
+
+Usage:
+    source env.sh
+    python3 producer.py [options]
+"""
+import argparse
+import os
+import sys
+import time
+import json
+
+def main():
+    parser = argparse.ArgumentParser(description="Mofka Producer Benchmark")
+    parser.add_argument("--group-file", default=os.environ.get("MOFKA_GROUP_FILE", "/tmp/mofka-bench/mofka.json"))
+    parser.add_argument("--topic", default=os.environ.get("MOFKA_TOPIC", "benchmark_topic"))
+    parser.add_argument("--num-events", type=int, default=int(os.environ.get("MOFKA_NUM_EVENTS", "1000")))
+    parser.add_argument("--data-size", type=int, default=int(os.environ.get("MOFKA_DATA_SIZE", "1024")))
+    parser.add_argument("--metadata-size", type=int, default=int(os.environ.get("MOFKA_METADATA_SIZE", "64")))
+    parser.add_argument("--batch-size", type=int, default=int(os.environ.get("MOFKA_BATCH_SIZE", "16")))
+    parser.add_argument("--num-threads", type=int, default=int(os.environ.get("MOFKA_NUM_THREADS", "1")))
+    parser.add_argument("--use-progress-thread", action="store_true", default=True)
+    args = parser.parse_args()
+
+    print("=" * 50)
+    print("  Mofka Producer Benchmark (Python)")
+    print("=" * 50)
+    print(f"  Group file:     {args.group_file}")
+    print(f"  Topic:          {args.topic}")
+    print(f"  Events:         {args.num_events}")
+    print(f"  Data size:      {args.data_size} bytes")
+    print(f"  Metadata size:  {args.metadata_size} bytes")
+    print(f"  Batch size:     {args.batch_size}")
+    print(f"  Threads:        {args.num_threads}")
+    print("=" * 50)
+
+    if not os.path.exists(args.group_file):
+        print(f"ERROR: Group file not found: {args.group_file}")
+        print("  Did you start the server first? (./server.sh)")
+        sys.exit(1)
+
+    from mochi.mofka.client import MofkaDriver
+
+    # Connect to Mofka.
+    # use_progress_thread=False is a deliberate workaround for a producer
+    # SIGSEGV (exit 139) at small payloads: with the progress thread on,
+    # the C++ mofka::Data destructor calls _Py_Dealloc on the wrapped
+    # Python bytes payload from an Argobots worker thread *without holding
+    # the GIL*, racing the main thread's push loop. Moving RPC progress to
+    # the main thread (which already holds the GIL) eliminates the race.
+    # The upstream binding bug remains; see
+    # pipelines/mofka/architecture_decisions.md.
+    driver = MofkaDriver(args.group_file, use_progress_thread=False)
+
+    # Open topic
+    topic = driver.open_topic(args.topic)
+
+    # Create producer with batch size
+    # batch_size is an int parameter (not AdaptiveBatchSize class)
+    producer = topic.producer(name="bench-producer", batch_size=args.batch_size)
+
+    # Prepare data payload
+    data_payload = b'\x42' * args.data_size
+
+    # Prepare metadata template (padded to requested size)
+    meta_base = {"id": 0}
+    meta_str = json.dumps(meta_base)
+    if len(meta_str) < args.metadata_size:
+        meta_base["pad"] = "x" * max(0, args.metadata_size - len(meta_str) - 10)
+
+    # Run benchmark
+    print(f"\nProducing {args.num_events} events...")
+    t_start = time.time()
+
+    for i in range(args.num_events):
+        meta_base["id"] = i
+        metadata = json.dumps(meta_base)
+        producer.push(metadata=metadata, data=data_payload)
+
+    producer.flush()
+    t_end = time.time()
+
+    elapsed_ms = (t_end - t_start) * 1000.0
+    total_bytes = args.num_events * (args.data_size + args.metadata_size)
+    throughput_mbs = (total_bytes / (1024 * 1024)) / (elapsed_ms / 1000.0) if elapsed_ms > 0 else 0
+    events_per_sec = args.num_events / (elapsed_ms / 1000.0) if elapsed_ms > 0 else 0
+
+    print(f"\n{'=' * 50}")
+    print(f"  RESULTS")
+    print(f"{'=' * 50}")
+    print(f"  Events produced:   {args.num_events}")
+    print(f"  Total data:        {total_bytes / (1024*1024):.2f} MB")
+    print(f"  Elapsed time:      {elapsed_ms:.2f} ms")
+    print(f"  Throughput:        {throughput_mbs:.2f} MB/s")
+    print(f"  Events/sec:        {events_per_sec:.0f}")
+    print(f"{'=' * 50}")
+
+    del producer
+    del topic
+    del driver
+
+if __name__ == "__main__":
+    main()

--- a/jarvis_clio_core/jarvis_clio_core/mofka_server/__init__.py
+++ b/jarvis_clio_core/jarvis_clio_core/mofka_server/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mofka Server Service Package — manages the Mofka/Bedrock daemon lifecycle.
+"""

--- a/jarvis_clio_core/jarvis_clio_core/mofka_server/config/config.json
+++ b/jarvis_clio_core/jarvis_clio_core/mofka_server/config/config.json
@@ -1,0 +1,55 @@
+{
+    "libraries": [
+        "libflock-bedrock-module.so",
+        "libyokan-bedrock-module.so",
+        "libwarabi-bedrock-module.so",
+        "libmofka-bedrock-module.so"
+    ],
+    "providers": [
+        {
+            "name" : "group_manager",
+            "type" : "flock",
+            "provider_id" : 1,
+            "config": {
+                "bootstrap": "self",
+                "file": "mofka.json",
+                "group": {
+                    "type": "static"
+                }
+            }
+        },
+        {
+            "name": "master",
+            "provider_id": 2,
+            "type": "yokan",
+            "tags" : [ "mofka:master" ],
+            "config" : {
+                "database" : {
+                    "type": "map"
+                }
+            }
+        },
+        {
+            "name": "metadata",
+            "provider_id": 3,
+            "type": "yokan",
+            "tags" : [ "mofka:metadata" ],
+            "config" : {
+                "database" : {
+                    "type": "map"
+                }
+            }
+        },
+        {
+            "name": "data",
+            "provider_id": 4,
+            "type": "warabi",
+            "tags" : [ "mofka:data" ],
+            "config" : {
+                "target" : {
+                    "type": "memory"
+                }
+            }
+        }
+    ]
+}

--- a/jarvis_clio_core/jarvis_clio_core/mofka_server/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/mofka_server/pkg.py
@@ -1,0 +1,223 @@
+"""
+Mofka Server Service — starts and stops the Bedrock/Mofka daemon,
+creates a topic and partition so that downstream benchmark packages
+can produce and consume events.
+
+Ported from the archived ``jarvis_iowarp.mofka_server`` (branch
+``claude/mofka-multinode``) into the ``jarvis_clio_core`` repo. The only
+behavioural addition is publishing ``MOFKA_SERVER_HOST`` (the node that
+actually runs bedrock) so ``mofka_bench`` can exclude it from the PSSH
+client hostfile under the Slurm scheduler (which seeds the hostfile with
+*all* allocated nodes, head included). See
+``jarvis_clio_core/pipelines/mofka/architecture_decisions.md``.
+"""
+from jarvis_cd.core.pkg import Service
+from jarvis_cd.shell import Exec, LocalExecInfo
+from jarvis_cd.shell.process import Kill
+import os
+import json
+import socket
+import time
+import shutil
+
+
+class MofkaServer(Service):
+    """Manages the Mofka/Bedrock daemon lifecycle."""
+
+    def _init(self):
+        self.bedrock_pid_file = None
+
+    def _configure_menu(self):
+        return [
+            {
+                'name': 'protocol',
+                'msg': 'Mercury transport protocol',
+                'type': str,
+                'default': 'tcp',
+                'choices': ['tcp', 'na+sm', 'ofi+tcp', 'ofi+verbs', 'ofi+cxi'],
+            },
+            {
+                'name': 'workdir',
+                'msg': 'Working directory for Mofka runtime files',
+                'type': str,
+                'default': '/tmp/mofka-bench',
+            },
+            {
+                'name': 'topic',
+                'msg': 'Mofka topic name to create',
+                'type': str,
+                'default': 'benchmark_topic',
+            },
+            {
+                'name': 'partition_type',
+                'msg': 'Partition storage type',
+                'type': str,
+                'default': 'memory',
+                'choices': ['memory'],
+            },
+        ]
+
+    def _configure(self, **kwargs):
+        # Expand $USER / ~ in workdir so per-user paths like
+        # /mnt/nvme/$USER/mofka-bench resolve before any FS op uses them.
+        # Without this, the literal '$USER' would become a directory name
+        # and shutil.rmtree() in start()/clean() would either no-op or
+        # operate on the wrong path.
+        workdir = os.path.expandvars(
+            os.path.expanduser(self.config['workdir']))
+        self.config['workdir'] = workdir
+        group_file = os.path.join(workdir, 'mofka.json')
+        driver_config = os.path.join(workdir, 'driver_config.json')
+        self.bedrock_pid_file = os.path.join(workdir, 'mofka.pid')
+
+        self.setenv('MOFKA_PROTOCOL', self.config['protocol'])
+        self.setenv('MOFKA_WORKDIR', workdir)
+        self.setenv('MOFKA_GROUP_FILE', group_file)
+        self.setenv('MOFKA_TOPIC', self.config['topic'])
+        self.setenv('MOFKA_DRIVER_CONFIG', driver_config)
+
+        # Publish the host that will run bedrock. Under the Slurm scheduler
+        # block, configure + start both execute on the first allocated node
+        # (the batch node), which is also where bedrock binds via
+        # LocalExecInfo below. mofka_bench reads this to drop the server
+        # node from its PSSH client hostfile. Stored as the short hostname;
+        # mofka_bench compares on short names too. Harmless single-node /
+        # Pattern-A (the value simply won't appear in a client-only
+        # hostfile, so the filter is a no-op).
+        self.setenv('MOFKA_SERVER_HOST', socket.gethostname().split('.')[0])
+
+        # Locate an active Spack environment view. $SPACK_ENV is set by
+        # `spack env activate <name>` and points at a user-owned spack env
+        # (e.g. ~/mofka-spack-env on Ares). Fall back to the system-spack
+        # path so existing /opt/spack-env installs keep working.
+        spack_env_view = None
+        spack_env_root = os.environ.get('SPACK_ENV')
+        if spack_env_root:
+            candidate = os.path.join(spack_env_root, '.spack-env', 'view')
+            if os.path.isdir(candidate):
+                spack_env_view = candidate
+        if spack_env_view is None and os.path.isdir(
+                '/opt/spack-env/.spack-env/view'):
+            spack_env_view = '/opt/spack-env/.spack-env/view'
+
+        if spack_env_view:
+            self.prepend_env('PATH', os.path.join(spack_env_view, 'bin'))
+            self.prepend_env(
+                'LD_LIBRARY_PATH',
+                os.path.join(spack_env_view, 'lib'),
+            )
+            self.prepend_env(
+                'LD_LIBRARY_PATH',
+                os.path.join(spack_env_view, 'lib64'),
+            )
+            # Auto-detect Python version for site-packages
+            lib_dir = os.path.join(spack_env_view, 'lib')
+            if os.path.isdir(lib_dir):
+                for entry in os.listdir(lib_dir):
+                    if entry.startswith('python3.'):
+                        python_site = os.path.join(
+                            lib_dir, entry, 'site-packages'
+                        )
+                        if os.path.isdir(python_site):
+                            self.prepend_env('PYTHONPATH', python_site)
+                            break
+
+        self.log('Mofka server configured')
+
+    def start(self):
+        workdir = self.config['workdir']
+        group_file = os.path.join(workdir, 'mofka.json')
+        config_path = os.path.join(self.pkg_dir, 'config', 'config.json')
+
+        # Step 1: Prepare working directory
+        if os.path.exists(workdir):
+            shutil.rmtree(workdir)
+        os.makedirs(workdir, exist_ok=True)
+
+        # Step 2: Start bedrock daemon
+        self.log(f'Starting bedrock: protocol={self.config["protocol"]}')
+        cmd = f'bedrock {self.config["protocol"]} -c {config_path}'
+        Exec(cmd, LocalExecInfo(
+            env=self.mod_env,
+            cwd=workdir,
+            exec_async=True,
+        )).run()
+
+        # Wait for group file
+        self.log('Waiting for mofka.json...')
+        for i in range(30):
+            if os.path.exists(group_file):
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError(
+                f'mofka.json did not appear after 30s in {workdir}'
+            )
+        self.log('Bedrock is ready')
+
+        # Read and log the actual bound address from group_file. Bedrock
+        # writes mofka.json as {"members":[{"address":"<scheme>://...", ...}]}.
+        # Asserting against the scheme catches the silent TCP fallback failure
+        # mode for RDMA: bedrock accepts `ofi+verbs` on the CLI but libfabric
+        # returns a TCP-backed domain when verbs hardware init quietly fails,
+        # producing a structurally-clean run with bogus comparison numbers.
+        try:
+            with open(group_file, 'r') as f:
+                group_data = json.load(f)
+            members = group_data.get('members', [])
+            bound_addr = members[0].get('address', '') if members else ''
+        except Exception as e:
+            bound_addr = f'<failed to read mofka.json: {e}>'
+        self.log(f'Bedrock bound address: {bound_addr}')
+        if 'verbs' in self.config['protocol'] and 'verbs' not in bound_addr:
+            raise RuntimeError(
+                f'Protocol mismatch: requested protocol='
+                f'{self.config["protocol"]} but bedrock bound address='
+                f'{bound_addr} (silent fallback?)'
+            )
+
+        # Step 3+4: Create topic + add partition via the MofkaDriver Python
+        # API (scripts/setup_topic.py). We do NOT use `mofkactl` here: on
+        # current mochi builds its typer/Click CLI crashes — Click 8.2 changed
+        # Parameter.make_metavar() to require a `ctx` arg and the bundled typer
+        # calls it the old way, so any mofkactl invocation that renders options
+        # raises "make_metavar() missing 1 required positional argument: 'ctx'".
+        # The bindings themselves are fine, so we drive MofkaDriver directly.
+        # See pipelines/mofka/architecture_decisions.md.
+        topic = self.config['topic']
+        setup_script = os.path.join(self.pkg_dir, 'scripts', 'setup_topic.py')
+        self.log(f'Creating topic + partition via MofkaDriver API: {topic}')
+        Exec(
+            f'python3 {setup_script}'
+            f' --group-file {group_file}'
+            f' --topic {topic}'
+            f' --partition-type {self.config["partition_type"]}',
+            LocalExecInfo(env=self.mod_env),
+        ).run()
+
+        # Step 5: Write driver config
+        driver_config_path = os.path.join(workdir, 'driver_config.json')
+        driver_cfg = {
+            'group_file': group_file,
+            'margo': {'use_progress_thread': True},
+        }
+        with open(driver_config_path, 'w') as f:
+            json.dump(driver_cfg, f, indent=4)
+        self.log(f'Driver config written to {driver_config_path}')
+
+        self.log('Mofka server is ready for benchmarks')
+
+    def stop(self):
+        self.log('Stopping bedrock daemon')
+        Kill('bedrock', LocalExecInfo(env=self.mod_env), partial=True).run()
+        time.sleep(1)
+
+    def clean(self):
+        # Expand here too: clean() can be called without a prior _configure()
+        # in the same Python process, so we can't rely on the in-memory
+        # config having already been rewritten.
+        workdir = os.path.expandvars(os.path.expanduser(
+            self.config.get('workdir', '/tmp/mofka-bench')))
+        if os.path.exists(workdir):
+            shutil.rmtree(workdir)
+            self.log(f'Removed working directory: {workdir}')

--- a/jarvis_clio_core/jarvis_clio_core/mofka_server/scripts/setup_topic.py
+++ b/jarvis_clio_core/jarvis_clio_core/mofka_server/scripts/setup_topic.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Create the Mofka topic + partition via the MofkaDriver Python API.
+
+This replaces the `mofkactl` CLI calls that the server used to make
+(`mofkactl topic create` / `mofkactl partition add`). On current mochi
+builds mofkactl is broken by a typer/Click version conflict — Click 8.2.0
+changed `Parameter.make_metavar()` to require a `ctx` argument, and the
+bundled typer calls it the old way, so any mofkactl invocation that renders
+options crashes with:
+
+    TypeError: Parameter.make_metavar() missing 1 required positional argument: 'ctx'
+
+The `mochi.mofka.client` bindings themselves are fine, so we drive topic and
+partition creation directly through MofkaDriver. Idempotent: a no-op if the
+topic already exists. Prints a RESULTS line on success so the caller can
+assert on it (same convention as producer.py / consumer.py).
+
+Usage:
+    python3 setup_topic.py --group-file <mofka.json> --topic <name> \
+        [--partition-type memory] [--server-rank 0]
+"""
+import argparse
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mofka topic/partition setup")
+    parser.add_argument(
+        "--group-file",
+        default=os.environ.get("MOFKA_GROUP_FILE", "/tmp/mofka-bench/mofka.json"))
+    parser.add_argument(
+        "--topic", default=os.environ.get("MOFKA_TOPIC", "benchmark_topic"))
+    parser.add_argument("--partition-type", default="memory")
+    parser.add_argument("--server-rank", type=int, default=0)
+    args = parser.parse_args()
+
+    print("=" * 50)
+    print("  Mofka Topic/Partition Setup (MofkaDriver API)")
+    print("=" * 50)
+    print(f"  Group file:     {args.group_file}")
+    print(f"  Topic:          {args.topic}")
+    print(f"  Partition type: {args.partition_type}")
+    print(f"  Server rank:    {args.server_rank}")
+    print("=" * 50)
+
+    if not os.path.exists(args.group_file):
+        print(f"ERROR: Group file not found: {args.group_file}")
+        print("  Did bedrock start and write mofka.json?")
+        sys.exit(1)
+
+    if args.partition_type != "memory":
+        # The benchmark only exercises in-memory partitions; other targets
+        # (disk-backed warabi) would use add_custom_partition with a config.
+        print(f"ERROR: unsupported partition type '{args.partition_type}' "
+              f"(only 'memory' is wired up)")
+        sys.exit(1)
+
+    from mochi.mofka.client import MofkaDriver
+
+    # Admin-only operations (no bytes payloads), so the producer's
+    # use_progress_thread=False workaround is unnecessary here.
+    driver = MofkaDriver(args.group_file)
+
+    if driver.topic_exists(args.topic):
+        print(f"Topic '{args.topic}' already exists — skipping create")
+    else:
+        driver.create_topic(args.topic)
+        print(f"Created topic '{args.topic}'")
+        driver.add_memory_partition(args.topic, args.server_rank)
+        print(f"Added memory partition on rank {args.server_rank}")
+
+    print("RESULTS: mofka topic+partition ready")
+
+    del driver
+
+
+if __name__ == "__main__":
+    main()

--- a/jarvis_clio_core/pipelines/mofka/microbench_mofka_ares.yaml
+++ b/jarvis_clio_core/pipelines/mofka/microbench_mofka_ares.yaml
@@ -1,0 +1,51 @@
+# Mofka Benchmark — Ares Single-Node FULL SWEEP (Pattern A: manual sbatch, in-process)
+#
+# 45-run producer/consumer sweep on one Ares compute node, TCP transport,
+# memory partition. Run the smoke variant first to confirm the env is healthy.
+#
+# Sweep: 5 data sizes x 3 thread counts x 3 repeats = 45 runs.
+#
+# Pattern A: one allocation, sweep runs in-process via `jarvis ppl run yaml`
+# (no jarvis scheduler block — that would submit one job per iteration, which
+# fails on Ares). See pipelines/mofka/architecture_decisions.md.
+#
+# Submit with:  sbatch jarvis_clio_core/pipelines/mofka/run_ares_mofka.sbatch
+# Monitor with: squeue -u $USER     Output: mofka_bench_<jobid>.log
+#
+# Time budget: 45 runs x ~30s + per-iteration bedrock startup ≈ 30 min.
+# 2 h ceiling leaves slack for startup variance and outliers.
+
+config:
+  name: mofka_bench_ares
+  pkgs:
+    - pkg_type: jarvis_clio_core.mofka_server
+      pkg_name: mofka_srv
+      protocol: "tcp"
+      workdir: "/mnt/nvme/$USER/mofka-bench"
+      topic: "benchmark_topic"
+      partition_type: "memory"
+
+    - pkg_type: jarvis_clio_core.mofka_bench
+      pkg_name: mofka_bench
+      mode: "both"
+      num_events: 1000
+      data_size: 1024
+      metadata_size: 64
+      batch_size: 16
+      num_threads: 1
+      data_selectivity: 1.0
+      use_progress_thread: true
+      nprocs: 1
+      ppn: 1
+
+vars:
+  mofka_bench.data_size: [256, 1024, 4096, 16384, 65536]
+  mofka_bench.num_threads: [1, 2, 4]
+
+loop:
+  - [mofka_bench.data_size]
+  - [mofka_bench.num_threads]
+
+repeat: 3
+
+output: "${HOME}/mofka_bench_ares_results"

--- a/jarvis_clio_core/pipelines/mofka/microbench_mofka_ares_multinode_2n.yaml
+++ b/jarvis_clio_core/pipelines/mofka/microbench_mofka_ares_multinode_2n.yaml
@@ -1,0 +1,55 @@
+# Mofka Benchmark — Ares Multi-Node FULL SWEEP, 2 nodes, TCP (Pattern A: manual sbatch)
+#
+# Topology: 1 bedrock server (batch/head node, LocalExecInfo) + 1 client node
+# (PSSH). The .sbatch sets the jarvis hostfile to both nodes; mofka_bench drops
+# the server host so producer/consumer run only on the client node. Per-host
+# stat fold (mofka_bench._fold_host_stats) SUMs throughput/events/data and
+# MAXes wall time across client hosts (degenerate single client here).
+#
+# Sweep: 5 data sizes x 3 thread counts x 3 repeats = 45 runs.
+# Run the 2n smoke variant first.
+#
+# Pattern A: one 2-node allocation, sweep runs in-process via `jarvis ppl run
+# yaml` (no jarvis scheduler block). See pipelines/mofka/architecture_decisions.md.
+#
+# Submit with: sbatch jarvis_clio_core/pipelines/mofka/run_ares_mofka_multinode_2n.sbatch
+# Output: mofka_bench_2n_<jobid>.log
+#
+# Time budget: 45 runs x ~30s + bedrock startup + PSSH startup variance.
+# 3 h ceiling leaves slack.
+
+config:
+  name: mofka_bench_ares_multinode_2n
+  ssh_cmd: "env -u LD_LIBRARY_PATH ssh"
+  pkgs:
+    - pkg_type: jarvis_clio_core.mofka_server
+      pkg_name: mofka_srv
+      protocol: "tcp"
+      workdir: "${HOME}/mofka-bench-tmp"
+      topic: "benchmark_topic"
+      partition_type: "memory"
+
+    - pkg_type: jarvis_clio_core.mofka_bench
+      pkg_name: mofka_bench
+      mode: "both"
+      num_events: 1000
+      data_size: 1024
+      metadata_size: 64
+      batch_size: 16
+      num_threads: 1
+      data_selectivity: 1.0
+      use_progress_thread: true
+      nprocs: 1
+      ppn: 1
+
+vars:
+  mofka_bench.data_size: [256, 1024, 4096, 16384, 65536]
+  mofka_bench.num_threads: [1, 2, 4]
+
+loop:
+  - [mofka_bench.data_size]
+  - [mofka_bench.num_threads]
+
+repeat: 3
+
+output: "${HOME}/mofka_bench_ares_multinode_2n_results"


### PR DESCRIPTION
## What

Adds a Jarvis-based microbenchmark for **Mofka** (the Mochi/Margo streaming
service) to `jarvis_clio_core`, plus single-node and 2-node TCP sweep pipelines.

### New packages (`jarvis_clio_core/jarvis_clio_core/`)
- **`mofka_server/`** — Jarvis `Service` that launches a `bedrock` daemon
  (flock group + yokan metadata + warabi memory data providers) and creates the
  topic/partition. Topic/partition setup goes through the `MofkaDriver` Python
  API (`scripts/setup_topic.py`) rather than `mofkactl`.
- **`mofka_bench/`** — Jarvis `Application` running a producer→consumer workload
  (`scripts/{producer,consumer}.py`), parsing throughput / events-per-sec /
  latency into the sweep results CSV. Multi-node runs split the bedrock server
  host from the producer/consumer client hosts.

### Pipelines (`jarvis_clio_core/pipelines/mofka/`)
- `microbench_mofka_ares.yaml` — single-node full sweep
- `microbench_mofka_ares_multinode_2n.yaml` — 2-node full sweep

Sweep grid: data_size {256, 1024, 4096, 16384, 65536} × num_threads {1, 2, 4}
× 3 repeats = 45 runs.

## Validation

Both sweeps validated on Ares (TCP): **45/45 rows `status=success`, no empty
stat cells**, with logical scaling (producer ~17.7k evt/s @256 B tapering to
~4.4k @64 KB; throughput rising monotonically with payload).

## Scope / notes

- **TCP only**, single-node + 2-node. 4-node is a known deficiency (single
  bedrock broker saturates under fan-in → `NA_TIMEOUT`) and is intentionally
  not included.
- Producer uses `use_progress_thread=False` — a benchmark workaround for a
  GIL-less `mofka::Data` destructor segfault on small payloads (upstream binding
  bug, not fixed here).
- Pipeline YAMLs assume an Ares-style environment (Slurm `compute` partition,
  `/mnt/nvme/$USER` scratch, NFS `$HOME`). Paths/partition may need adjusting
  for other sites.