### PR TITLE
fix(ctp/lightbeam): suppress SIGPIPE on socket writes to a dead peer

### DIFF
--- a/context-transport-primitives/include/clio_ctp/lightbeam/posix_socket.h
+++ b/context-transport-primitives/include/clio_ctp/lightbeam/posix_socket.h
@@ -91,6 +91,14 @@ CTP_DLL void SetReuseAddr(socket_t fd);
 CTP_DLL void SetSendBuf(socket_t fd, int size);
 CTP_DLL void SetRecvBuf(socket_t fd, int size);
 
+/** Prevent writes to this socket from raising SIGPIPE when the peer has
+ *  closed the connection. On macOS/BSD this sets the SO_NOSIGPIPE socket
+ *  option; on Linux SendV() passes MSG_NOSIGNAL per write instead, so this is
+ *  a no-op there (and on Windows, which has no SIGPIPE). Without it, writing
+ *  to a dead peer terminates the process via SIGPIPE's default disposition on
+ *  macOS. */
+CTP_DLL void SetNoSigPipe(socket_t fd);
+
 /** Initialize platform socket library (WSAStartup on Windows, no-op on POSIX) */
 CTP_DLL void InitSocketLib();
 

--- a/context-transport-primitives/src/socket_posix.cc
+++ b/context-transport-primitives/src/socket_posix.cc
@@ -38,6 +38,13 @@
 #include <cerrno>
 #include <cstring>
 
+// Linux suppresses SIGPIPE per-write via this send() flag; macOS/BSD lack it
+// and use the SO_NOSIGPIPE socket option (see SetNoSigPipe) instead, so define
+// it to 0 there to keep SendV() portable.
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
 namespace ctp::lbm::sock {
 
 void InitSocketLib() {
@@ -89,6 +96,19 @@ void SetRecvBuf(socket_t fd, int size) {
   ::setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
 }
 
+void SetNoSigPipe(socket_t fd) {
+#ifdef SO_NOSIGPIPE
+  // macOS / *BSD: make writes on this fd fail with EPIPE rather than raise
+  // SIGPIPE (whose default disposition terminates the process) when the peer
+  // has closed. Linux has no SO_NOSIGPIPE and relies on MSG_NOSIGNAL in
+  // SendV() instead.
+  int on = 1;
+  ::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
+#else
+  (void)fd;
+#endif
+}
+
 void UnlinkPath(const char* path) {
   ::unlink(path);
 }
@@ -111,7 +131,14 @@ ssize_t SendV(socket_t fd, const IoBuffer* iov, int count) {
   int iov_idx = 0;
 
   while (sent < total) {
-    ssize_t n = ::writev(fd, local_iov + iov_idx, local_count - iov_idx);
+    // sendmsg (vs writev) lets us pass MSG_NOSIGNAL so a write to a peer that
+    // has closed returns EPIPE instead of raising SIGPIPE on Linux; macOS/BSD
+    // get the same guarantee from SO_NOSIGPIPE set in SetNoSigPipe().
+    struct msghdr msg;
+    std::memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = local_iov + iov_idx;
+    msg.msg_iovlen = local_count - iov_idx;
+    ssize_t n = ::sendmsg(fd, &msg, MSG_NOSIGNAL);
     if (n < 0) {
       if (errno == EINTR) continue;
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -231,12 +258,14 @@ socket_t Connect(const std::string& addr, int port,
       Close(fd);
       return kInvalidSocket;
     }
+    SetNoSigPipe(fd);
     return fd;
   }
   socket_t fd = ::socket(AF_INET, SOCK_STREAM, 0);
   if (fd == kInvalidSocket) return kInvalidSocket;
   SetTcpNoDelay(fd);
   SetSendBuf(fd, 4 * 1024 * 1024);
+  SetNoSigPipe(fd);
   struct sockaddr_in sin;
   std::memset(&sin, 0, sizeof(sin));
   sin.sin_family = AF_INET;
@@ -291,7 +320,11 @@ socket_t Listen(const std::string& addr, int port,
 }
 
 socket_t Accept(socket_t listen_fd) {
-  return ::accept(listen_fd, nullptr, nullptr);
+  socket_t fd = ::accept(listen_fd, nullptr, nullptr);
+  if (fd != kInvalidSocket) {
+    SetNoSigPipe(fd);
+  }
+  return fd;
 }
 
 uint32_t HostToNet32(uint32_t host) { return htonl(host); }

--- a/context-transport-primitives/src/socket_win.cc
+++ b/context-transport-primitives/src/socket_win.cc
@@ -146,6 +146,11 @@ void SetRecvBuf(socket_t fd, int size) {
                reinterpret_cast<const char*>(&size), sizeof(size));
 }
 
+void SetNoSigPipe(socket_t fd) {
+  // Windows has no SIGPIPE; failed sends surface as WSAECONNRESET return codes.
+  (void)fd;
+}
+
 void UnlinkPath(const char* path) {
   DeleteFileA(path);
 }


### PR DESCRIPTION
## Summary
- The lightbeam socket transport sent with `writev()` and never suppressed `SIGPIPE`, so writing to a socket whose peer had died raised `SIGPIPE` and killed the process.
- Add platform-correct suppression: `SO_NOSIGPIPE` on macOS/BSD fds and `MSG_NOSIGNAL` via `sendmsg()` on Linux. Writes to a dead peer now return `EPIPE` (already handled).

## Motivation
Fixes #531. CDash build `cl-22/cnd/d/vol` on `macos-12` (id 3602539) reported `cr_client_retry_client_death_ipc` as `FAILED` with `Completed (SIGPIPE)`. The test forks a child client that submits a task and exits immediately; the in-process server then writes to the dead peer and the process is terminated by SIGPIPE.

## Changes
| File | Change |
|------|--------|
| `posix_socket.h` | Declare `SetNoSigPipe(socket_t)`. |
| `socket_posix.cc` | Implement `SetNoSigPipe` (`SO_NOSIGPIPE` on macOS/BSD, no-op elsewhere); apply it to `Connect` (IPC+TCP) and `Accept` fds; `SendV` now uses `sendmsg(..., MSG_NOSIGNAL)` (defined to `0` on macOS) instead of `writev`. |
| `socket_win.cc` | No-op `SetNoSigPipe` (Windows has no SIGPIPE). |

## Test plan
- [x] Build on macOS (Homebrew LLVM 22): **0 errors, 0 warnings**.
- [x] `cr_client_retry_client_death_ipc` run 10×: **0 SIGPIPE failures** (was the CDash failure mode).
- [x] Socket/transport unit tests: **10/10 pass** (no `writev`→`sendmsg` regression).
- [ ] Linux CI `build-and-test` + cpplint + sanitizers (run on this PR).

## Out of scope / known issue
A residual ~10% flake in the same test (parent task returns non-zero, `test_client_retry.cc:196`) is a **separate** server-side orphan-task reaping race tracked in **#486**, which CI already absorbs with `ctest --repeat until-pass:3`. This PR turns an unconditional SIGPIPE crash into, at worst, that retryable flake.

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)