### PR TITLE
Reimplement rich statistic metrics to CTE benchmark output and Jarvis parser

### DIFF
--- a/context-transfer-engine/benchmark/bench_common.h
+++ b/context-transfer-engine/benchmark/bench_common.h
@@ -63,6 +63,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <string>
@@ -244,13 +245,26 @@ inline BenchArgs ParseBenchArgs(int argc, char **argv) {
 }
 
 /**
- * Print per-thread + aggregate timing/bandwidth. ops[i] is the number of
- * ops thread i actually completed (matters for --time-limit, where it is
- * not io_count); times[i] is its elapsed microseconds.
+ * Print the full per-thread + aggregate timing/bandwidth/latency report.
+ *
+ * Emits one labelled metric per line so the Jarvis package's _get_stat()
+ * regex can scrape each value into a results.csv column. The exact wording
+ * and units below are part of that contract -- changing them breaks the
+ * parser in jarvis_clio_core/clio_cte_bench/pkg.py.
+ *
+ * @param label   Operation name (Put | Get | PutGet); becomes the CSV
+ *                "operation" namespace.
+ * @param a       Parsed benchmark parameters (uses a.threads, a.io_size).
+ * @param times   Per-thread elapsed time in microseconds. ops[i]/times[i]
+ *                are paired per worker thread.
+ * @param ops     Per-thread completed-op counts (== io_count unless
+ *                --time-limit was used, where each thread does as many ops
+ *                as fit in the wall-clock window).
  */
 inline void PrintResults(const std::string &label, const BenchArgs &a,
                          const std::vector<long long> &times,
                          const std::vector<u64> &ops) {
+  double num_threads = static_cast<double>(a.threads ? a.threads : 1);
   long long min_t = *std::min_element(times.begin(), times.end());
   long long max_t = *std::max_element(times.begin(), times.end());
   long long sum_t = 0;
@@ -259,21 +273,53 @@ inline void PrintResults(const std::string &label, const BenchArgs &a,
     sum_t += times[i];
     total_ops += ops[i];
   }
-  double avg_t = static_cast<double>(sum_t) / static_cast<double>(a.threads);
-  u64 avg_ops = total_ops / a.threads;
+  double avg_t = static_cast<double>(sum_t) / num_threads;        // us
+  double avg_ops = static_cast<double>(total_ops) / num_threads;  // ops/thread
 
-  u64 per_thread_bytes = avg_ops * a.io_size;
+  // Working set: avg per-thread bytes vs. all-threads bytes.
+  u64 per_thread_bytes =
+      static_cast<u64>(a.io_size * avg_ops);
   u64 aggregate_bytes = total_ops * a.io_size;
+
+  // Bandwidth from the min/max/avg thread time; min time -> max bandwidth.
+  double min_bw = CalcBandwidth(per_thread_bytes, static_cast<double>(min_t));
+  double max_bw = CalcBandwidth(per_thread_bytes, static_cast<double>(max_t));
+  double avg_bw = CalcBandwidth(per_thread_bytes, avg_t);
+  double agg_bw = CalcBandwidth(aggregate_bytes, avg_t);
+
+  double avg_t_sec = avg_t / 1000000.0;
+  double agg_ops_per_sec = avg_t_sec > 0.0 ? total_ops / avg_t_sec : 0.0;
+  double ops_per_thread_avg_per_sec =
+      avg_t_sec > 0.0 ? avg_ops / avg_t_sec : 0.0;
+  double avg_latency_per_op = avg_ops > 0.0 ? avg_t / avg_ops : 0.0;  // us
+  double total_data_mb =
+      static_cast<double>(aggregate_bytes) / (1024.0 * 1024.0);
+
+  // Spread of per-thread completion times (us) about their mean.
+  double sum_sq_diff = 0.0;
+  for (long long t : times) {
+    double diff = static_cast<double>(t) - avg_t;
+    sum_sq_diff += diff * diff;
+  }
+  double latency_stddev = std::sqrt(sum_sq_diff / num_threads);
 
   HLOG(kInfo, "");
   HLOG(kInfo, "=== {} Benchmark Results ===", label);
-  HLOG(kInfo, "Ops (total / avg per thread): {} / {}", total_ops, avg_ops);
-  HLOG(kInfo, "Time (min/max/avg): {} / {} / {} ms", min_t / 1000.0,
-       max_t / 1000.0, avg_t / 1000.0);
-  HLOG(kInfo, "Bandwidth per thread (avg): {} MB/s",
-       CalcBandwidth(per_thread_bytes, avg_t));
-  HLOG(kInfo, "Aggregate bandwidth: {} MB/s",
-       CalcBandwidth(aggregate_bytes, avg_t));
+  HLOG(kInfo, "Time (min): {} us ({} ms)", static_cast<double>(min_t),
+       min_t / 1000.0);
+  HLOG(kInfo, "Time (max): {} us ({} ms)", static_cast<double>(max_t),
+       max_t / 1000.0);
+  HLOG(kInfo, "Time (avg): {} us ({} ms)", avg_t, avg_t / 1000.0);
+  HLOG(kInfo, "Bandwidth per thread (min): {} MB/s", min_bw);
+  HLOG(kInfo, "Bandwidth per thread (max): {} MB/s", max_bw);
+  HLOG(kInfo, "Bandwidth per thread (avg): {} MB/s", avg_bw);
+  HLOG(kInfo, "Aggregate bandwidth: {} MB/s", agg_bw);
+  HLOG(kInfo, "Aggregate IOPS: {}", agg_ops_per_sec);
+  HLOG(kInfo, "IOPS per thread (avg): {}", ops_per_thread_avg_per_sec);
+  HLOG(kInfo, "Avg latency per op: {} us", avg_latency_per_op);
+  HLOG(kInfo, "Latency stddev: {} us", latency_stddev);
+  HLOG(kInfo, "Total data: {} MB", total_data_mb);
+  HLOG(kInfo, "Total ops: {}", total_ops);
   HLOG(kInfo, "===========================");
 }
 

--- a/jarvis_clio_core/jarvis_clio_core/clio_cte_bench/pkg.py
+++ b/jarvis_clio_core/jarvis_clio_core/clio_cte_bench/pkg.py
@@ -1,6 +1,7 @@
 from jarvis_cd.core.pkg import Application
-from jarvis_cd.shell import Exec, PsshExecInfo
+from jarvis_cd.shell import Exec, PsshExecInfo, LocalExecInfo
 import os
+import re
 
 class ClioCteBench(Application):
     """
@@ -193,7 +194,13 @@ class ClioCteBench(Application):
         """
         Run the CTE benchmark application.
 
-        This method executes the benchmark with MPI support and configured parameters.
+        This method executes the benchmark with MPI support and configured
+        parameters. The benchmark's stdout+stderr (the HLOG results report)
+        is always captured to ``<shared_dir>/bench_output.txt`` so that
+        ``_get_stat`` can parse the metrics afterwards. The sweep runner
+        (jarvis_cd pipeline_test) re-loads a *fresh* package instance before
+        calling ``_get_stat``, so an in-memory buffer would be lost -- the
+        on-disk file is the contract between start() and _get_stat().
         """
         self.log(f"Starting CTE benchmark: {self.config['test_case']}")
 
@@ -216,31 +223,36 @@ class ClioCteBench(Application):
             cmd += ['--max-total-blobs', str(self.config['max_total_blobs'])]
         cmd += ['--query-type', str(self.config['query_type'])]
 
-        self.log(
-            f"Running benchmark via Pssh: {self.config['nprocs']} procs, "
-            f"{self.config['ppn']} per node"
-        )
-        exec_info = PsshExecInfo(
-            env=self.mod_env,
-            hostfile=self.hostfile,
-            nprocs=self.config['nprocs'],
-            ppn=self.config['ppn'],
-        )
-
-        # Execute the benchmark
         cmd_str = ' '.join(cmd)
+        output_path = os.path.join(self.shared_dir, 'bench_output.txt')
 
-        if self.output_file:
-            # Redirect output to file
-            cmd_str += f' > {self.output_file} 2>&1'
-            self.log(f"Executing: {cmd_str}")
-            Exec(cmd_str, exec_info).run()
-            self.log(f"Benchmark completed. Results saved to: {self.output_file}")
+        if self.config['nprocs'] > 1:
+            # Multi-rank: redirect in the shell so every rank's output lands
+            # in the shared file (shared_dir is on a shared FS on Ares).
+            self.log(
+                f"Running benchmark via Pssh: {self.config['nprocs']} procs, "
+                f"{self.config['ppn']} per node"
+            )
+            exec_info = PsshExecInfo(
+                env=self.mod_env,
+                hostfile=self.hostfile,
+                nprocs=self.config['nprocs'],
+                ppn=self.config['ppn'],
+            )
+            cmd_str += f' > {output_path} 2>&1'
         else:
-            # Print to stdout
-            self.log(f"Executing: {cmd_str}")
-            Exec(cmd_str, exec_info).run()
-            self.log("Benchmark completed")
+            # Single-rank: pipe both streams to the file via LocalExecInfo
+            # (matches the proven archived capture path; HLOG -> stderr).
+            self.log("Running benchmark locally (single rank)")
+            exec_info = LocalExecInfo(
+                env=self.mod_env,
+                pipe_stdout=output_path,
+                pipe_stderr=output_path,
+            )
+
+        self.log(f"Executing: {cmd_str}")
+        Exec(cmd_str, exec_info).run()
+        self.log(f"Benchmark completed. Output captured to: {output_path}")
 
     def stop(self):
         """
@@ -258,12 +270,100 @@ class ClioCteBench(Application):
         """
         self.log("Cleaning up CTE benchmark output files...")
 
-        # Clean output file if it exists
-        if self.output_file and os.path.exists(self.output_file):
-            try:
-                os.remove(self.output_file)
-                self.log(f"Removed benchmark output file: {self.output_file}")
-            except Exception as e:
-                self.log(f"Error removing output file: {e}")
+        # The canonical results file parsed by _get_stat.
+        paths = [os.path.join(self.shared_dir, 'bench_output.txt')]
+        # Plus the optional user-facing copy, if one was configured.
+        if self.output_file:
+            paths.append(self.output_file)
+
+        for path in paths:
+            if path and os.path.exists(path):
+                try:
+                    os.remove(path)
+                    self.log(f"Removed benchmark output file: {path}")
+                except Exception as e:
+                    self.log(f"Error removing output file {path}: {e}")
 
         self.log("CTE benchmark cleanup completed")
+
+    # ------------------------------------------------------------------
+    # Statistics collection
+    # ------------------------------------------------------------------
+
+    def _get_stat(self, stat_dict):
+        """
+        Parse the captured benchmark output and populate ``stat_dict``.
+
+        Called by the jarvis_cd sweep runner after each pipeline run (on a
+        freshly-loaded package instance), which is why the metrics are read
+        back from ``<shared_dir>/bench_output.txt`` rather than from an
+        in-memory buffer. Each extracted metric becomes a results.csv column.
+
+        :param stat_dict: Dict the framework serialises into results.csv;
+                          keys are ``<pkg_id>.<operation>.<metric>``.
+        """
+        output_path = os.path.join(self.shared_dir, 'bench_output.txt')
+        if not os.path.exists(output_path):
+            self.log(f'No output file found at {output_path}')
+            return
+
+        with open(output_path, 'r') as f:
+            output = f.read()
+
+        if not output.strip():
+            self.log(f'Output file is empty: {output_path}')
+            return
+
+        before_count = len(stat_dict)
+        self._parse_output(output, stat_dict)
+        after_count = len(stat_dict)
+        if after_count == before_count:
+            self.log(f'Warning: No metrics extracted from {output_path} '
+                     f'({len(output)} bytes). '
+                     f'Check if benchmark results are present in output.')
+
+    def _parse_output(self, output, stat_dict):
+        """
+        Extract metrics from clio_cte_bench stdout into ``stat_dict``.
+
+        The C++ binary emits its results via HLOG (bench_common.h
+        ``PrintResults``), one labelled metric per line. This regex table is
+        the parsing half of that contract -- the patterns must match the
+        wording/units printed by PrintResults exactly.
+
+        :param output: Raw captured benchmark output (stdout+stderr).
+        :param stat_dict: Dict to populate with ``<pkg_id>.<op>.<metric>``.
+        """
+        # Strip ANSI escape codes from HLOG output.
+        output = re.sub(r'\033\[[0-9;]*m', '', output)
+
+        # Detect which test case header appeared (Put, Get, or PutGet).
+        header_match = re.search(r'=== (\w+) Benchmark Results ===', output)
+        operation = header_match.group(1).lower() if header_match else 'unknown'
+
+        patterns = {
+            'time_min_us': r'Time \(min\):\s+([\d.e+\-]+)\s+us',
+            'time_max_us': r'Time \(max\):\s+([\d.e+\-]+)\s+us',
+            'time_avg_us': r'Time \(avg\):\s+([\d.e+\-]+)\s+us',
+            'bw_per_thread_min_mbps':
+                r'Bandwidth per thread \(min\):\s+([\d.e+\-]+)\s+MB/s',
+            'bw_per_thread_max_mbps':
+                r'Bandwidth per thread \(max\):\s+([\d.e+\-]+)\s+MB/s',
+            'bw_per_thread_avg_mbps':
+                r'Bandwidth per thread \(avg\):\s+([\d.e+\-]+)\s+MB/s',
+            'agg_bw_mbps': r'Aggregate bandwidth:\s+([\d.e+\-]+)\s+MB/s',
+            'agg_ops_per_sec': r'Aggregate IOPS:\s+([\d.e+\-]+)',
+            'ops_per_thread_avg_per_sec':
+                r'IOPS per thread \(avg\):\s+([\d.e+\-]+)',
+            'avg_latency_per_op_us':
+                r'Avg latency per op:\s+([\d.e+\-]+)\s+us',
+            'latency_stddev_us': r'Latency stddev:\s+([\d.e+\-]+)\s+us',
+            'total_data_mb': r'Total data:\s+([\d.e+\-]+)\s+MB',
+            'total_ops': r'Total ops:\s+(\d+)',
+        }
+
+        for metric, pattern in patterns.items():
+            match = re.search(pattern, output)
+            if match:
+                stat_dict[f'{self.pkg_id}.{operation}.{metric}'] = float(
+                    match.group(1))


### PR DESCRIPTION
## Summary

Enriches the CTE benchmark (`clio_cte_bench`) results so that a full set of throughput and latency statistics is both **printed** by the benchmark and **captured** by the Jarvis `clio_cte_bench` package into its per-run stat columns. Previously the printed output and the parsed stat dictionary covered only a subset of metrics, leaving sweep result CSVs sparsely populated.

Two files change:

### `context-transfer-engine/benchmark/bench_common.h`
`PrintResults()` now emits the complete metric set, with units, for every run:
- Time min/max/avg (in **us and ms**)
- Per-thread bandwidth min/max/avg
- Aggregate bandwidth
- Aggregate IOPS and IOPS per thread
- Average latency per op and **latency stddev**
- Total data moved and total ops

This printer is the single source of truth for the math (including stddev), and is shared by `clio_cte_bench` and `clio_redis_bench`.

### `jarvis_clio_core/jarvis_clio_core/clio_cte_bench/pkg.py`
- `start()` captures the benchmark's **stdout + stderr** to `<shared_dir>/bench_output.txt` (HLOG writes to stderr, so both streams are needed).
- `_get_stat` / `_parse_output` re-read that file and populate `{pkg_id}.{op}.{metric}` columns from the printer's wording.

The on-disk file is deliberately the contract between `start()` and `_get_stat`: the sweep runner reloads a **fresh** package instance before calling `_get_stat`, so an in-memory buffer (`self.exec.stdout`) would be lost.

## Why

So that CTE benchmark sweeps produce fully-populated result CSVs (bandwidth, IOPS, latency, latency stddev, totals) suitable for comparison and analysis, instead of rows with empty metric cells.

## Testing

Validated on the Ares cluster with a PutGet smoke sweep (multiple io sizes × thread counts × repeats). Runs complete with `status=success` and every metric column populated with internally-consistent values (e.g. `agg_bw = total_data / time`, `avg_latency = time / total_ops` reconcile; `latency_stddev = 0` for single-thread runs).
