### PR TITLE
chore(release): bump version to 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(iowarp-core VERSION 2.0.0 LANGUAGES C CXX)
+project(iowarp-core VERSION 2.1.0 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
 # Project Options


### PR DESCRIPTION
Bumps `project(iowarp-core VERSION ...)` in CMakeLists.txt from 2.0.0 to 2.1.0 for the v2.1.0 release.

This is the version-of-record on `main` for the release whose highlights are:
- **Semantic search** (headline) — CTE `SemanticSearch`/`TemporalSearch`
- **Native Windows support**
- **Preliminary macOS support**

The release CI's `check-version` job requires `main`/the tag to carry this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)