### PR TITLE
ci: add Windows 2025 / VS 2026 icx build+test action (#555)

### DIFF
--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -174,7 +174,10 @@ jobs:
             -DCLIO_CORE_ENABLE_BENCHMARKS=OFF ^
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
             -DCLIO_CTP_LOG_LEVEL=0 || exit /b 1
-          cmake --build build --config Debug -j %NUMBER_OF_PROCESSORS% || exit /b 1
+          rem --verbose (temporary): print the exact ninja-invoked compile
+          rem command, including dep flags (-QMD/-QMT/-QMF) that ninja injects
+          rem but compile_commands.json omits -- to see why icx-cl drops /Fo.
+          cmake --build build --config Debug --verbose -j %NUMBER_OF_PROCESSORS% || exit /b 1
 
       - name: Diagnose export-def failure
         if: failure()

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -10,10 +10,12 @@ name: Windows ICX Test
 # windows-2025 runner -- which now ships Visual Studio 2026 -- to catch
 # compiler-specific regressions.
 #
-# NOTE: on Windows, icx.exe is the MSVC-compatible unified driver (accepts
-# cl-style "/" flags) and compiles both C and C++. icpx.exe uses a GNU/clang
-# command line and rejects the MSVC-style flags CMake emits for the Ninja
-# generator, so both CMAKE_C_COMPILER and CMAKE_CXX_COMPILER are set to icx.
+# NOTE: oneAPI ships three Windows C++ drivers. icpx.exe and icx.exe both use a
+# clang/GNU-style command line: icpx rejects the MSVC flags CMake emits for the
+# Ninja generator outright, and icx accepts some "/" flags but quietly ignores
+# /Fo<obj>, writing <base>.o into the build root (which breaks the DLL link via
+# bindexplib). icx-cl.exe is the cl.exe-compatible driver that honors /Fo, /Zi,
+# etc., so CMAKE_C_COMPILER and CMAKE_CXX_COMPILER are both set to icx-cl.
 #
 #   * oneAPI is installed via the oneapi-src/oneapi-ci helper scripts
 #     (template: actions/.github/workflows/win-25_vs-26_icx-2025.3.1.yml).
@@ -114,8 +116,8 @@ jobs:
           call "%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" x64 || exit /b 1
           call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat" || exit /b 1
           cmake -B build -G Ninja ^
-            -DCMAKE_C_COMPILER=icx ^
-            -DCMAKE_CXX_COMPILER=icx ^
+            -DCMAKE_C_COMPILER=icx-cl ^
+            -DCMAKE_CXX_COMPILER=icx-cl ^
             -DCMAKE_TOOLCHAIN_FILE="%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake" ^
             -DVCPKG_TARGET_TRIPLET=x64-windows ^
             -DVCPKG_MANIFEST_DIR="%GITHUB_WORKSPACE%\installers\vcpkg" ^

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -108,24 +108,33 @@ jobs:
         shell: cmd
         run: |
           @echo on
+          setlocal enabledelayedexpansion
           call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat" >nul || exit /b 1
           if exist probe rmdir /s /q probe
-          mkdir probe & cd probe & mkdir out
-          echo int foo(){return 0;} > t.cpp
-          echo ===== case A: cl-style "/c /Fo" =====
-          icx-cl /nologo /c /Foout\a.obj t.cpp
-          if exist out\a.obj (echo A_RESULT: obj at out\a.obj) else (echo A_RESULT: MISSING)
-          if exist t.o (echo A_RESULT: stray t.o present)
-          del /q t.o out\a.obj 2>nul
-          echo ===== case B: dash "-c /Fo" =====
-          icx-cl /nologo -c /Foout\b.obj t.cpp
-          if exist out\b.obj (echo B_RESULT: obj at out\b.obj) else (echo B_RESULT: MISSING)
-          if exist t.o (echo B_RESULT: stray t.o present)
-          del /q t.o out\b.obj 2>nul
-          echo ===== case C: dash "-c -o" =====
-          icx-cl /nologo -c -oout\c.obj t.cpp
-          if exist out\c.obj (echo C_RESULT: obj at out\c.obj) else (echo C_RESULT: MISSING)
-          if exist t.o (echo C_RESULT: stray t.o present)
+          mkdir probe & cd probe & mkdir out & mkdir inc
+          echo int foo(){return 0;} > system_info.cc
+          set SRC=%CD%\system_info.cc
+          rem Flag groups mirroring CMake's real icx-cl command line.
+          set BASE=/nologo /TP /DWIN32 /D_WINDOWS /EHsc /Zi /Od /Ob0 /RTC1 -MDd /FS
+          set QSTD=-Qstd:c++20
+          set EXT=-external:I"%CD%\inc" -external:W0
+          call :run D  "%BASE% %QSTD% %EXT%"          "%SRC%"
+          call :run E  "%BASE% %EXT%"                  "%SRC%"
+          call :run F  "%BASE% %QSTD%"                 "%SRC%"
+          call :run G  "%BASE%"                        "%SRC%"
+          call :run H  "%BASE% %QSTD% %EXT%"           "system_info.cc"
+          goto :eof
+          :run
+          set TAG=%~1
+          set FLAGS=%~2
+          set THESRC=%~3
+          del /q out\!TAG!.obj system_info.o 2>nul
+          echo ===== case !TAG!: icx-cl !FLAGS! /Foout\!TAG!.obj -c !THESRC! =====
+          icx-cl !FLAGS! /Foout\!TAG!.obj /Fdout\ -c "!THESRC!"
+          if exist out\!TAG!.obj (echo !TAG!_RESULT: OK obj-at-/Fo) else (echo !TAG!_RESULT: MISSING)
+          if exist system_info.o (echo !TAG!_RESULT: STRAY system_info.o in cwd)
+          del /q out\!TAG!.obj system_info.o 2>nul
+          goto :eof
 
       - name: Configure and build (icx)
         shell: cmd

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -40,6 +40,10 @@ env:
   # Intel oneAPI Base Toolkit ships the DPC++/C++ compiler (icx/icpx).
   WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/076e961b-2c29-48a8-9203-c96f00e7051b/intel-oneapi-base-toolkit-2025.3.1.35_offline.exe
   WINDOWS_CPP_COMPONENTS: intel.oneapi.win.cpp-dpcpp-common
+  # Bump CACHE_NUMBER to force a fresh oneAPI install; the cache key also
+  # includes the toolkit URL, so a version change invalidates it automatically.
+  CACHE_NUMBER: "0"
+  ONEAPI_ROOT_DIR: "C:\\Program Files (x86)\\Intel\\oneAPI"
   VCPKG_DEFAULT_TRIPLET: x64-windows
   CAE_LABEL_TEST_SKIP: "1"
 
@@ -62,7 +66,18 @@ jobs:
           git pull
           .\bootstrap-vcpkg.bat
 
-      - name: Install oneAPI (icx/icpx)
+      # Cache the installed oneAPI tree so the ~6 min component install is
+      # skipped while the base-toolkit version (encoded in WINDOWS_BASEKIT_URL)
+      # is unchanged. A URL or CACHE_NUMBER change invalidates the key.
+      - name: Cache oneAPI install
+        id: cache-oneapi
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.ONEAPI_ROOT_DIR }}
+          key: oneapi-${{ runner.os }}-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}
+
+      - name: Install oneAPI (icx)
+        if: steps.cache-oneapi.outputs.cache-hit != 'true'
         shell: cmd
         run: |
           git clone --depth=1 https://github.com/oneapi-src/oneapi-ci.git oneapi-ci
@@ -96,6 +111,7 @@ jobs:
             -DCLIO_CORE_ENABLE_CEE=OFF ^
             -DCLIO_CORE_ENABLE_TESTS=ON ^
             -DCLIO_CORE_ENABLE_PYTHON=OFF ^
+            -DCLIO_CORE_ENABLE_PCH=OFF ^
             -DCLIO_CORE_ENABLE_ZMQ=ON ^
             -DCLIO_CORE_ENABLE_CEREAL=ON ^
             -DCLIO_CORE_ENABLE_CONDA=OFF ^

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -1,0 +1,141 @@
+name: Windows ICX Test
+
+# Windows oneAPI (icx/icpx) build + test workflow for
+# https://github.com/iowarp/clio-core/issues/555
+# ("ci: add a windows 2025 vs 2026 icx action").
+#
+# The regular "Windows Build and Test" workflow builds clio-core with MSVC
+# (the Visual Studio generator) on windows-2022/2025/11-arm. This workflow
+# instead builds with the Intel oneAPI DPC++/C++ compilers (icx/icpx) on a
+# windows-2025 runner -- which now ships Visual Studio 2026 -- to catch
+# compiler-specific regressions.
+#
+#   * oneAPI is installed via the oneapi-src/oneapi-ci helper scripts
+#     (template: actions/.github/workflows/win-25_vs-26_icx-2025.3.1.yml).
+#   * The CMake options mirror .github/workflows/windows-build-and-test.yml.
+#   * Results are reported to my.cdash.org (HERMES "core" dashboard) the same
+#     way .github/workflows/mac-test.yml does: -DSITE / -DBUILDNAME cache vars
+#     plus `ctest -T Test` / `ctest -T Submit` against CTestConfig.cmake.
+
+on:
+  push:
+    branches:
+      - main
+      - issue-555-windows-icx
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Intel oneAPI Base Toolkit ships the DPC++/C++ compiler (icx/icpx).
+  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/076e961b-2c29-48a8-9203-c96f00e7051b/intel-oneapi-base-toolkit-2025.3.1.35_offline.exe
+  WINDOWS_CPP_COMPONENTS: intel.oneapi.win.cpp-dpcpp-common
+  VCPKG_DEFAULT_TRIPLET: x64-windows
+  CAE_LABEL_TEST_SKIP: "1"
+
+jobs:
+  win-icx-test:
+    name: windows-2025 (icx)
+    runs-on: windows-2025
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Bootstrap vcpkg
+        shell: pwsh
+        run: |
+          cd $env:VCPKG_INSTALLATION_ROOT
+          git pull
+          .\bootstrap-vcpkg.bat
+
+      - name: Install oneAPI (icx/icpx)
+        shell: cmd
+        run: |
+          git clone --depth=1 https://github.com/oneapi-src/oneapi-ci.git oneapi-ci
+          cd oneapi-ci
+          scripts\install_windows.bat %WINDOWS_BASEKIT_URL% %WINDOWS_CPP_COMPONENTS%
+
+      - name: Configure and build (icx)
+        shell: cmd
+        run: |
+          @echo on
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat"
+          cmake -B build -G Ninja ^
+            -DCMAKE_C_COMPILER=icx ^
+            -DCMAKE_CXX_COMPILER=icpx ^
+            -DCMAKE_TOOLCHAIN_FILE="%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake" ^
+            -DVCPKG_TARGET_TRIPLET=x64-windows ^
+            -DVCPKG_MANIFEST_DIR="%GITHUB_WORKSPACE%\installers\vcpkg" ^
+            -DVCPKG_OVERLAY_PORTS="%GITHUB_WORKSPACE%\installers\vcpkg\overlay-ports" ^
+            -DCMAKE_BUILD_TYPE=Debug ^
+            -DSITE=windows-2025 ^
+            -DBUILDNAME=vs2026/ninja/icx-2025.3 ^
+            -DCLIO_CORE_ENABLE_RUNTIME=ON ^
+            -DCLIO_CORE_ENABLE_CTE=ON ^
+            -DCLIO_CORE_ENABLE_CAE=ON ^
+            -DCLIO_CORE_ENABLE_CEE=OFF ^
+            -DCLIO_CORE_ENABLE_TESTS=ON ^
+            -DCLIO_CORE_ENABLE_PYTHON=OFF ^
+            -DCLIO_CORE_ENABLE_ZMQ=ON ^
+            -DCLIO_CORE_ENABLE_CEREAL=ON ^
+            -DCLIO_CORE_ENABLE_CONDA=OFF ^
+            -DCLIO_CORE_ENABLE_ELF=OFF ^
+            -DCLIO_CORE_ENABLE_RPATH=OFF ^
+            -DCLIO_CTE_ENABLE_VFD=OFF ^
+            -DCLIO_CTE_ENABLE_HDF5_VOL=OFF ^
+            -DCLIO_CORE_ENABLE_BENCHMARKS=OFF ^
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
+            -DCLIO_CTP_LOG_LEVEL=0 || exit /b 1
+          cmake --build build --config Debug -j %NUMBER_OF_PROCESSORS% || exit /b 1
+
+      - name: Run ctest
+        shell: cmd
+        run: |
+          @echo on
+          call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat"
+          cd build
+          ctest -T Test --build-config Debug --output-on-failure --timeout 120 -LE ollama
+
+      - name: Submit results to CDash
+        if: always()
+        continue-on-error: true
+        shell: cmd
+        run: |
+          cd build
+          ctest -T Submit
+
+      - name: Summarize failed tests
+        if: always()
+        shell: bash
+        run: |
+          LOG="build/Testing/Temporary/LastTest.log"
+          echo "## Windows ICX test summary (windows-2025)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$LOG" ]; then
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -E "Test #|\*\*\*Failed|\*\*\*Exception|Passed|Failed" "$LOG" \
+              | grep -E "Failed|Exception" >> "$GITHUB_STEP_SUMMARY" || \
+              echo "(no failures parsed from LastTest.log)" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "(LastTest.log not found)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: win-icx-test-logs
+          path: |
+            build/Testing/Temporary/LastTest.log
+            build/Testing/Temporary/CTestCostData.txt
+          if-no-files-found: warn

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -104,38 +104,6 @@ jobs:
           path: ${{ env.ONEAPI_ROOT_DIR }}
           key: oneapi-${{ runner.os }}-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}
 
-      - name: Probe icx-cl /Fo behavior
-        shell: cmd
-        run: |
-          @echo on
-          setlocal enabledelayedexpansion
-          call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat" >nul || exit /b 1
-          if exist probe rmdir /s /q probe
-          mkdir probe & cd probe & mkdir out & mkdir inc
-          echo int foo(){return 0;} > system_info.cc
-          set SRC=%CD%\system_info.cc
-          rem Flag groups mirroring CMake's real icx-cl command line.
-          set BASE=/nologo /TP /DWIN32 /D_WINDOWS /EHsc /Zi /Od /Ob0 /RTC1 -MDd /FS
-          set QSTD=-Qstd:c++20
-          set EXT=-external:I"%CD%\inc" -external:W0
-          call :run D  "%BASE% %QSTD% %EXT%"          "%SRC%"
-          call :run E  "%BASE% %EXT%"                  "%SRC%"
-          call :run F  "%BASE% %QSTD%"                 "%SRC%"
-          call :run G  "%BASE%"                        "%SRC%"
-          call :run H  "%BASE% %QSTD% %EXT%"           "system_info.cc"
-          goto :eof
-          :run
-          set TAG=%~1
-          set FLAGS=%~2
-          set THESRC=%~3
-          del /q out\!TAG!.obj system_info.o 2>nul
-          echo ===== case !TAG!: icx-cl !FLAGS! /Foout\!TAG!.obj -c !THESRC! =====
-          icx-cl !FLAGS! /Foout\!TAG!.obj /Fdout\ -c "!THESRC!"
-          if exist out\!TAG!.obj (echo !TAG!_RESULT: OK obj-at-/Fo) else (echo !TAG!_RESULT: MISSING)
-          if exist system_info.o (echo !TAG!_RESULT: STRAY system_info.o in cwd)
-          del /q out\!TAG!.obj system_info.o 2>nul
-          goto :eof
-
       - name: Configure and build (icx)
         shell: cmd
         run: |
@@ -174,10 +142,7 @@ jobs:
             -DCLIO_CORE_ENABLE_BENCHMARKS=OFF ^
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
             -DCLIO_CTP_LOG_LEVEL=0 || exit /b 1
-          rem --verbose (temporary): print the exact ninja-invoked compile
-          rem command, including dep flags (-QMD/-QMT/-QMF) that ninja injects
-          rem but compile_commands.json omits -- to see why icx-cl drops /Fo.
-          cmake --build build --config Debug --verbose -j %NUMBER_OF_PROCESSORS% || exit /b 1
+          cmake --build build --config Debug -j %NUMBER_OF_PROCESSORS% || exit /b 1
 
       - name: Diagnose export-def failure
         if: failure()

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -10,6 +10,11 @@ name: Windows ICX Test
 # windows-2025 runner -- which now ships Visual Studio 2026 -- to catch
 # compiler-specific regressions.
 #
+# NOTE: on Windows, icx.exe is the MSVC-compatible unified driver (accepts
+# cl-style "/" flags) and compiles both C and C++. icpx.exe uses a GNU/clang
+# command line and rejects the MSVC-style flags CMake emits for the Ninja
+# generator, so both CMAKE_C_COMPILER and CMAKE_CXX_COMPILER are set to icx.
+#
 #   * oneAPI is installed via the oneapi-src/oneapi-ci helper scripts
 #     (template: actions/.github/workflows/win-25_vs-26_icx-2025.3.1.yml).
 #   * The CMake options mirror .github/workflows/windows-build-and-test.yml.
@@ -77,7 +82,7 @@ jobs:
           call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat" || exit /b 1
           cmake -B build -G Ninja ^
             -DCMAKE_C_COMPILER=icx ^
-            -DCMAKE_CXX_COMPILER=icpx ^
+            -DCMAKE_CXX_COMPILER=icx ^
             -DCMAKE_TOOLCHAIN_FILE="%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake" ^
             -DVCPKG_TARGET_TRIPLET=x64-windows ^
             -DVCPKG_MANIFEST_DIR="%GITHUB_WORKSPACE%\installers\vcpkg" ^

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -144,43 +144,6 @@ jobs:
             -DCLIO_CTP_LOG_LEVEL=0 || exit /b 1
           cmake --build build --config Debug -j %NUMBER_OF_PROCESSORS% || exit /b 1
 
-      - name: Diagnose export-def failure
-        if: failure()
-        shell: cmd
-        run: |
-          @echo on
-          cd build
-          echo CWD=%CD%
-          cmake --version
-          set DEFDIR=context-transport-primitives\src\CMakeFiles\clio_ctp_host.dir
-          echo ===== exports.def.objs contents =====
-          type "%DEFDIR%\exports.def.objs"
-          echo ===== dir of %DEFDIR% =====
-          dir "%DEFDIR%"
-          echo ===== does system_info.cc.obj exist? =====
-          if exist "%DEFDIR%\system_info.cc.obj" (echo YES exists) else (echo NO missing)
-          echo ===== try __create_def from build root =====
-          cmake -E __create_def diag_exports.def "%DEFDIR%\exports.def.objs"
-          echo create_def-from-buildroot exit=%ERRORLEVEL%
-          echo ===== search whole build tree for system_info objects =====
-          dir /s /b system_info*.obj system_info*.o 2>nul
-          echo ----- total .obj count in build tree -----
-          dir /s /b *.obj 2>nul | find /c ".obj"
-          echo ===== compile command for system_info.cc (compile_commands.json) =====
-          findstr /i "system_info.cc" compile_commands.json
-
-      - name: Diagnose compile command (pwsh)
-        if: failure()
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Continue"
-          Write-Host "===== CMAKE_CXX_COMPILER_FRONTEND_VARIANT / flags / CLIO_CORE_MSVC_LIKE in cache ====="
-          Select-String -Path build/CMakeCache.txt -Pattern "FRONTEND_VARIANT|CLIO_CORE_MSVC_LIKE|CMAKE_CXX_FLAGS" -SimpleMatch | ForEach-Object { $_.Line }
-          Write-Host "===== exact compile command for context-transport-primitives/src/system_info.cc ====="
-          $cc = Get-Content build/compile_commands.json -Raw | ConvertFrom-Json
-          $e = $cc | Where-Object { $_.file -like '*context-transport-primitives*system_info.cc' -and $_.output -like '*clio_ctp_host*' }
-          $e | ForEach-Object { Write-Host "OUTPUT:" $_.output; Write-Host "COMMAND:" $_.command }
-
       - name: Run ctest
         shell: cmd
         run: |

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -104,6 +104,29 @@ jobs:
           path: ${{ env.ONEAPI_ROOT_DIR }}
           key: oneapi-${{ runner.os }}-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}
 
+      - name: Probe icx-cl /Fo behavior
+        shell: cmd
+        run: |
+          @echo on
+          call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat" >nul || exit /b 1
+          if exist probe rmdir /s /q probe
+          mkdir probe & cd probe & mkdir out
+          echo int foo(){return 0;} > t.cpp
+          echo ===== case A: cl-style "/c /Fo" =====
+          icx-cl /nologo /c /Foout\a.obj t.cpp
+          if exist out\a.obj (echo A_RESULT: obj at out\a.obj) else (echo A_RESULT: MISSING)
+          if exist t.o (echo A_RESULT: stray t.o present)
+          del /q t.o out\a.obj 2>nul
+          echo ===== case B: dash "-c /Fo" =====
+          icx-cl /nologo -c /Foout\b.obj t.cpp
+          if exist out\b.obj (echo B_RESULT: obj at out\b.obj) else (echo B_RESULT: MISSING)
+          if exist t.o (echo B_RESULT: stray t.o present)
+          del /q t.o out\b.obj 2>nul
+          echo ===== case C: dash "-c -o" =====
+          icx-cl /nologo -c -oout\c.obj t.cpp
+          if exist out\c.obj (echo C_RESULT: obj at out\c.obj) else (echo C_RESULT: MISSING)
+          if exist t.o (echo C_RESULT: stray t.o present)
+
       - name: Configure and build (icx)
         shell: cmd
         run: |

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -68,8 +68,13 @@ jobs:
         shell: cmd
         run: |
           @echo on
-          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-          call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat"
+          rem Locate the Visual Studio install on the runner (edition/version
+          rem agnostic) instead of hard-coding a path -- the hosted windows-2025
+          rem image may differ from the template's custom runner.
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -property installationPath`) do set "VSINSTALL=%%i"
+          echo Using Visual Studio at: %VSINSTALL%
+          call "%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" x64 || exit /b 1
+          call "%ProgramFiles(x86)%\Intel\oneAPI\setvars.bat" || exit /b 1
           cmake -B build -G Ninja ^
             -DCMAKE_C_COMPILER=icx ^
             -DCMAKE_CXX_COMPILER=icpx ^

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -167,6 +167,18 @@ jobs:
           echo ===== compile command for system_info.cc (compile_commands.json) =====
           findstr /i "system_info.cc" compile_commands.json
 
+      - name: Diagnose compile command (pwsh)
+        if: failure()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          Write-Host "===== CMAKE_CXX_COMPILER_FRONTEND_VARIANT / flags / CLIO_CORE_MSVC_LIKE in cache ====="
+          Select-String -Path build/CMakeCache.txt -Pattern "FRONTEND_VARIANT|CLIO_CORE_MSVC_LIKE|CMAKE_CXX_FLAGS" -SimpleMatch | ForEach-Object { $_.Line }
+          Write-Host "===== exact compile command for context-transport-primitives/src/system_info.cc ====="
+          $cc = Get-Content build/compile_commands.json -Raw | ConvertFrom-Json
+          $e = $cc | Where-Object { $_.file -like '*context-transport-primitives*system_info.cc' -and $_.output -like '*clio_ctp_host*' }
+          $e | ForEach-Object { Write-Host "OUTPUT:" $_.output; Write-Host "COMMAND:" $_.command }
+
       - name: Run ctest
         shell: cmd
         run: |

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -142,6 +142,25 @@ jobs:
             -DCLIO_CTP_LOG_LEVEL=0 || exit /b 1
           cmake --build build --config Debug -j %NUMBER_OF_PROCESSORS% || exit /b 1
 
+      - name: Diagnose export-def failure
+        if: failure()
+        shell: cmd
+        run: |
+          @echo on
+          cd build
+          echo CWD=%CD%
+          cmake --version
+          set DEFDIR=context-transport-primitives\src\CMakeFiles\clio_ctp_host.dir
+          echo ===== exports.def.objs contents =====
+          type "%DEFDIR%\exports.def.objs"
+          echo ===== dir of %DEFDIR% =====
+          dir "%DEFDIR%"
+          echo ===== does system_info.cc.obj exist? =====
+          if exist "%DEFDIR%\system_info.cc.obj" (echo YES exists) else (echo NO missing)
+          echo ===== try __create_def from build root =====
+          cmake -E __create_def diag_exports.def "%DEFDIR%\exports.def.objs"
+          echo create_def-from-buildroot exit=%ERRORLEVEL%
+
       - name: Run ctest
         shell: cmd
         run: |

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -160,6 +160,12 @@ jobs:
           echo ===== try __create_def from build root =====
           cmake -E __create_def diag_exports.def "%DEFDIR%\exports.def.objs"
           echo create_def-from-buildroot exit=%ERRORLEVEL%
+          echo ===== search whole build tree for system_info objects =====
+          dir /s /b system_info*.obj system_info*.o 2>nul
+          echo ----- total .obj count in build tree -----
+          dir /s /b *.obj 2>nul | find /c ".obj"
+          echo ===== compile command for system_info.cc (compile_commands.json) =====
+          findstr /i "system_info.cc" compile_commands.json
 
       - name: Run ctest
         shell: cmd

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -59,6 +59,15 @@ jobs:
         with:
           submodules: recursive
 
+      # Pin a stable CMake. The hosted image ships CMake 4.x, whose bindexplib
+      # (cmake -E __create_def, used by WINDOWS_EXPORT_ALL_SYMBOLS) fails to
+      # open the just-built object files under Ninja + IntelLLVM (icx),
+      # breaking the clio_ctp_host.dll link. 3.31.x links it cleanly.
+      - name: Install CMake 3.31.6
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.31.6"
+
       - name: Bootstrap vcpkg
         shell: pwsh
         run: |
@@ -69,9 +78,11 @@ jobs:
       # Cache the installed oneAPI tree so the ~6 min component install is
       # skipped while the base-toolkit version (encoded in WINDOWS_BASEKIT_URL)
       # is unchanged. A URL or CACHE_NUMBER change invalidates the key.
-      - name: Cache oneAPI install
+      # restore + explicit save (instead of actions/cache) so the cache still
+      # persists when a later build/test step fails during CI iteration.
+      - name: Restore oneAPI cache
         id: cache-oneapi
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ONEAPI_ROOT_DIR }}
           key: oneapi-${{ runner.os }}-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}
@@ -83,6 +94,13 @@ jobs:
           git clone --depth=1 https://github.com/oneapi-src/oneapi-ci.git oneapi-ci
           cd oneapi-ci
           scripts\install_windows.bat %WINDOWS_BASEKIT_URL% %WINDOWS_CPP_COMPONENTS%
+
+      - name: Save oneAPI cache
+        if: steps.cache-oneapi.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.ONEAPI_ROOT_DIR }}
+          key: oneapi-${{ runner.os }}-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}
 
       - name: Configure and build (icx)
         shell: cmd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ option(CLIO_CORE_ENABLE_TESTS "Master switch: Enable testing for all components"
 option(CLIO_CORE_ENABLE_BENCHMARKS "Master switch: Enable benchmarks for all components" ON)
 option(CLIO_CORE_ENABLE_PYTHON "Enable Python bindings for all components" OFF)
 option(CLIO_CORE_ENABLE_CMAKE_DOTENV "Enable reading environment variables from .env.cmake" OFF)
+# Precompiled headers speed up builds but conflict with WINDOWS_EXPORT_ALL_SYMBOLS
+# under the Ninja generator with non-MSVC Windows compilers (icx/clang-cl): the
+# bindexplib pass (cmake -E __create_def) fails to read the cmake_pch object.
+# Default ON (no change for existing builds); turn OFF for those toolchains.
+option(CLIO_CORE_ENABLE_PCH "Enable precompiled headers for faster builds" ON)
 option(CLIO_CORE_ENABLE_ASAN "Enable AddressSanitizer + LeakSanitizer for debugging" OFF)
 option(CLIO_CORE_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer for debugging" OFF)
 option(CLIO_CORE_ENABLE_MSAN "Enable MemorySanitizer for debugging (requires instrumented dependencies)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -841,12 +841,21 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Position Independent Code - Applied to all subdirectories
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# ccache — accelerate rebuilds by caching compiled objects
+# ccache — accelerate rebuilds by caching compiled objects.
+# NOT used for MSVC-like compilers (cl / clang-cl / icx-cl): as a compiler
+# launcher under Ninja, ccache mishandles the cl-style /Fo<obj> output flag and
+# the object is written as <base>.o into the build root instead of the expected
+# path, which breaks WINDOWS_EXPORT_ALL_SYMBOLS / the DLL link. (The Visual
+# Studio generator never applied the launcher, which is why MSVC CI was fine.)
+# See issue #555.
+option(CLIO_CORE_ENABLE_CCACHE "Use ccache as compiler launcher when available" ON)
 find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
+if(CCACHE_PROGRAM AND CLIO_CORE_ENABLE_CCACHE AND NOT CLIO_CORE_MSVC_LIKE)
     set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
     message(STATUS "ccache enabled: ${CCACHE_PROGRAM}")
+elseif(CCACHE_PROGRAM)
+    message(STATUS "ccache found but not used (CLIO_CORE_ENABLE_CCACHE=${CLIO_CORE_ENABLE_CCACHE}, CLIO_CORE_MSVC_LIKE=${CLIO_CORE_MSVC_LIKE})")
 else()
     message(STATUS "ccache not found — install ccache for faster rebuilds")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,22 @@ cmake_minimum_required(VERSION 3.20)
 project(iowarp-core VERSION 2.1.0 LANGUAGES C CXX)
 
 #------------------------------------------------------------------------------
+# MSVC-like front end detection
+#------------------------------------------------------------------------------
+# True for cl.exe (MSVC) and for compilers that drive an MSVC-compatible command
+# line: clang-cl and Intel's icx.exe on Windows. These accept "/"-style flags
+# (e.g. /Zi, /Od, /Fo<obj>) and MUST NOT be given GNU-style flags. Mixing GNU
+# flags (-g -O0 -Wfatal-errors) onto icx.exe flips it into clang driver mode,
+# where it ignores /Fo<obj> and writes <basename>.o into the build root --
+# leaving CMake/ninja's expected .obj absent and breaking the DLL link
+# (WINDOWS_EXPORT_ALL_SYMBOLS / bindexplib). See issue #555.
+if(MSVC OR (WIN32 AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
+    set(CLIO_CORE_MSVC_LIKE ON)
+else()
+    set(CLIO_CORE_MSVC_LIKE OFF)
+endif()
+
+#------------------------------------------------------------------------------
 # Project Options
 #==============================================================================
 # BUILD CONFIGURATION OPTIONS
@@ -863,7 +879,9 @@ endif()
 #------------------------------------------------------------------------------
 # Compiler Flags
 #------------------------------------------------------------------------------
-if(NOT MSVC)
+# Use CLIO_CORE_MSVC_LIKE (not just MSVC) so clang-cl / icx.exe on Windows take
+# the MSVC-style flag path; GNU flags break icx's /Fo handling (see issue #555).
+if(NOT CLIO_CORE_MSVC_LIKE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
     if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
         # Add compiler flags following Google C++ style guide

--- a/cmake/ClioCoreCommon.cmake
+++ b/cmake/ClioCoreCommon.cmake
@@ -1057,10 +1057,12 @@ function(add_clio_module_client)
   endif()
 
   # Precompiled headers for faster builds
-  target_precompile_headers(${TARGET_NAME} PRIVATE
-      <string> <vector> <memory> <unordered_map>
-      <functional> <algorithm> <cstdint> <cstring> <iostream>
-  )
+  if(CLIO_CORE_ENABLE_PCH)
+    target_precompile_headers(${TARGET_NAME} PRIVATE
+        <string> <vector> <memory> <unordered_map>
+        <functional> <algorithm> <cstdint> <cstring> <iostream>
+    )
+  endif()
 
   # Export module info to parent scope
   set(CLIO_RUN_MODULE_CLIENT_TARGET ${TARGET_NAME} PARENT_SCOPE)
@@ -1391,10 +1393,12 @@ check_required_components(${MODULE_PACKAGE_NAME})
   endif()
 
   # Precompiled headers for faster builds
-  target_precompile_headers(${TARGET_NAME} PRIVATE
-      <string> <vector> <memory> <unordered_map>
-      <functional> <algorithm> <cstdint> <cstring> <iostream>
-  )
+  if(CLIO_CORE_ENABLE_PCH)
+    target_precompile_headers(${TARGET_NAME} PRIVATE
+        <string> <vector> <memory> <unordered_map>
+        <functional> <algorithm> <cstdint> <cstring> <iostream>
+    )
+  endif()
 
   # Export module info to parent scope
   set(CLIO_RUN_MODULE_RUNTIME_TARGET ${TARGET_NAME} PARENT_SCOPE)

--- a/context-transport-primitives/CMakeLists.txt
+++ b/context-transport-primitives/CMakeLists.txt
@@ -3,6 +3,17 @@ project(clio_ctp LANGUAGES C CXX)
 include(CTest)
 # CMAKE_CXX_STANDARD is set by root CMakeLists.txt
 
+# Normally inherited from the root project; define a fallback for standalone
+# CTP configures so MSVC-frontend compilers (cl, clang-cl, icx.exe) take the
+# MSVC-style flag path below (see issue #555).
+if(NOT DEFINED CLIO_CORE_MSVC_LIKE)
+    if(MSVC OR (WIN32 AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
+        set(CLIO_CORE_MSVC_LIKE ON)
+    else()
+        set(CLIO_CORE_MSVC_LIKE OFF)
+    endif()
+endif()
+
 # ------------------------------------------------------------------------------
 # Global variables
 # ------------------------------------------------------------------------------
@@ -66,7 +77,7 @@ set(CLIO_CTP_EXPORTED_TARGETS "ClioCtp")
 # ------------------------------------------------------------------------------
 
 # CMAKE_POSITION_INDEPENDENT_CODE is set by root CMakeLists.txt
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$" OR CMAKE_CXX_COMPILER_ID STREQUAL "MinGW" OR CMAKE_CXX_COMPILER_ID MATCHES "^Intel" OR CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$" OR CMAKE_CXX_COMPILER_ID STREQUAL "MinGW" OR CMAKE_CXX_COMPILER_ID MATCHES "^Intel" OR CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC") AND NOT CLIO_CORE_MSVC_LIKE)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         message("IN DEBUG MODE")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -Wfatal-errors")
@@ -90,7 +101,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "^(Appl
     else()
         set(REAL_TIME_FLAGS "-lrt -ldl")
     endif()
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+elseif(CLIO_CORE_MSVC_LIKE)
+    # MSVC, clang-cl, or icx.exe on Windows: MSVC-style command line.
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         message("IN DEBUG MODE")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /Od")

--- a/context-transport-primitives/CMakeLists.txt
+++ b/context-transport-primitives/CMakeLists.txt
@@ -79,7 +79,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "^(Appl
 
     set(CLIO_CTP_COMPILER_GNU "ON")
 
-    if(APPLE)
+    if(WIN32)
+        # Clang/IntelLLVM (icx) targeting Windows: rt/dl are POSIX-only. Use
+        # the Winsock import library like the MSVC branch below.
+        set(REAL_TIME_FLAGS "ws2_32")
+    elseif(APPLE)
         set(REAL_TIME_FLAGS "-ldl")
     elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
         set(REAL_TIME_FLAGS "")

--- a/context-transport-primitives/src/CMakeLists.txt
+++ b/context-transport-primitives/src/CMakeLists.txt
@@ -49,10 +49,12 @@ target_include_directories(clio_ctp_host PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 hshm_target_compile_definitions(clio_ctp_host)
-target_precompile_headers(clio_ctp_host PRIVATE
-    <string> <vector> <memory> <unordered_map>
-    <functional> <algorithm> <cstdint> <cstring> <iostream>
-)
+if(CLIO_CORE_ENABLE_PCH)
+    target_precompile_headers(clio_ctp_host PRIVATE
+        <string> <vector> <memory> <unordered_map>
+        <functional> <algorithm> <cstdint> <cstring> <iostream>
+    )
+endif()
 list(APPEND CLIO_CTP_LIBS clio_ctp_host)
 add_library(cxx INTERFACE)
 target_link_libraries(cxx INTERFACE clio_ctp_host)


### PR DESCRIPTION
Closes #555.

Adds `.github/workflows/win-icx-test.yml`: a Windows oneAPI (**icx-cl**) build + test workflow on a `windows-2025` runner (Visual Studio 2026), reporting to **my.cdash.org** (HERMES `core`).

## What it does
- Builds clio-core with the Intel oneAPI cl-compatible driver (`icx-cl`) + Ninja, using the **same `CLIO_*` CMake options** as `windows-build-and-test.yml`.
- Installs oneAPI via the `oneapi-src/oneapi-ci` helper (template `win-25_vs-26_icx-2025.3.1.yml`).
- Reports to CDash like `mac-test.yml` (`-DSITE`/`-DBUILDNAME` + `ctest -T Test`/`-T Submit`).
- **Caches the oneAPI install** (keyed on the base-toolkit URL + `CACHE_NUMBER`); `restore` + explicit `save` so it persists even when a build fails, skipping the ~6 min install on later runs.
- Locates Visual Studio via `vswhere` (no hard-coded path); pins CMake 3.31.6 for determinism.

## Result
✅ Green on GitHub Actions: **100% tests passed (190/190)**.
✅ my.cdash.org: **"Submission successful"** — Site `windows-2025`, Build `vs2026/ninja/icx-2025.3`.

## clio-core source fixes (all guarded; no change for Linux/macOS/MSVC)
1. **`REAL_TIME_FLAGS`** — use `ws2_32` on Windows for the Clang/Intel branch instead of POSIX-only `-lrt -ldl`.
2. **`CLIO_CORE_ENABLE_PCH`** option (default ON) — gate precompiled headers; PCH conflicts with `WINDOWS_EXPORT_ALL_SYMBOLS` bindexplib under Ninja + non-MSVC compilers.
3. **`CLIO_CORE_MSVC_LIKE`** — new variable (true for `cl`/`clang-cl`/`icx-cl` via `CMAKE_CXX_COMPILER_FRONTEND_VARIANT`); used instead of bare `MSVC` so MSVC-frontend compilers get `/`-style flags rather than GNU flags.
4. **`CLIO_CORE_ENABLE_CCACHE`** option (default ON) — **the key fix**: skip the ccache compiler launcher for MSVC-like compilers. Under Ninja, ccache wrapped `icx-cl` and mishandled the cl-style `/Fo<obj>` flag, writing `<base>.o` into the build root; ninja trusted the exit code and linked, but the expected `.obj` was absent, so `WINDOWS_EXPORT_ALL_SYMBOLS`'s `bindexplib` pass failed (`Couldn't open file ... system_info.cc.obj`). The MSVC CI never hit this because the Visual Studio generator ignores `CMAKE_CXX_COMPILER_LAUNCHER` — only Ninja/Make apply it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)