### PR TITLE
fix(runtime): free server-side FutureShm on TCP/IPC reply path (#560)

### DIFF
--- a/context-runtime/src/ipc/ipc_cpu2cpu_zmq.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu_zmq.cc
@@ -290,6 +290,16 @@ bool IpcCpu2CpuZmq::RuntimeSend(
         }
       }
 
+      // Free the server-side FutureShm allocated for this inbound request in
+      // RuntimeRecv (NewObj<FutureShm>()). The queued Future here is never
+      // consumed_, so ~Future() never runs its FutureShm-free path; without
+      // this every cross-process RPC leaks one FutureShm. CleanupResponseArchive
+      // is intentionally not called — that map is client-side only (see
+      // ipc_cpu2cpu_zmq_impl.h RuntimeRecv); on the server it would be a no-op.
+      if (!future_shm.IsNull()) {
+        ipc->FreeBuffer(future_shm.Cast<char>());
+      }
+
       did_work = true;
       tasks_sent++;
       size_t total = send_counter.fetch_add(1, std::memory_order_relaxed) + 1;


### PR DESCRIPTION
## Summary

Fixes #560. Every inbound cross-process request allocated a server-side `FutureShm` in `IpcCpu2CpuZmq::RuntimeRecv` (`ipc_cpu2cpu_zmq.cc:106`, `NewObj<FutureShm>()`) that was never freed. The reply path `RuntimeSend` freed only the **task** via `DelTask` (`:289`), and the queued `Future` is never `consumed_`, so `~Future()`'s `FutureShm`-free path (`ipc_manager.h:1704-1717`) never ran — leaking one `FutureShm` per cross-process RPC.

## Fix

Free the `FutureShm` alongside the existing `DelTask`, after a successful send:

```cpp
if (!future_shm.IsNull()) {
  ipc->FreeBuffer(future_shm.Cast<char>());
}
```

- Placed **after** the failure `continue` (which re-queues the future), so it never runs on the retry path.
- `CleanupResponseArchive` is intentionally skipped: `pending_response_archives_` is populated only on the client side (`ipc_cpu2cpu_zmq_impl.h` RuntimeRecv), so on the server it would be a no-op.

## Verification

- Confirmed the leak by tracing the alloc site, the reply path, and the `consumed_`-gated `~Future()` free path.
- Compiled the translation unit with the project's exact build flags (`-fsyntax-only`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)