### PR TITLE
build: disable context-visualizer gracefully when Python is absent

### DIFF
--- a/context-visualizer/CMakeLists.txt
+++ b/context-visualizer/CMakeLists.txt
@@ -18,7 +18,11 @@ endif()
 # otherwise find just the Interpreter component, which is lightweight and does
 # NOT pull in nanobind / Development.Module.
 if(NOT Python_EXECUTABLE)
-    find_package(Python COMPONENTS Interpreter REQUIRED)
+    find_package(Python COMPONENTS Interpreter QUIET)
+    if(NOT Python_FOUND)
+        message(STATUS "Context-visualizer component disabled (requires Python)")
+        return()
+    endif()
 endif()
 
 # Resolve the interpreter's site-packages directory *relative to its prefix*


### PR DESCRIPTION
find_package was called with REQUIRED, causing a hard CMake error when CLIO_CORE_ENABLE_PYTHON=OFF and no Python interpreter is installed. Switch to QUIET and return() early with a STATUS message so the build proceeds without the visualizer instead of failing.

Closes #564