### PR TITLE
ci: run win-icx-test across windows-2022 and windows-2025-vs2026 matrix

### DIFF
--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -130,7 +130,7 @@ jobs:
             -DVCPKG_OVERLAY_PORTS="%GITHUB_WORKSPACE%\installers\vcpkg\overlay-ports" ^
             -DCMAKE_BUILD_TYPE=Debug ^
             -DSITE=${{ matrix.os }} ^
-            -DBUILDNAME=vs2026/ninja/icx-2025.3 ^
+            -DBUILDNAME=ninja/icx-2025.3 ^
             -DCLIO_CORE_ENABLE_RUNTIME=ON ^
             -DCLIO_CORE_ENABLE_CTE=ON ^
             -DCLIO_CORE_ENABLE_CAE=ON ^

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -59,6 +59,7 @@ jobs:
       matrix:
         os:
           - windows-2022
+          - windows-2025
           - windows-2025-vs2026
 
     steps:

--- a/.github/workflows/win-icx-test.yml
+++ b/.github/workflows/win-icx-test.yml
@@ -51,9 +51,15 @@ env:
 
 jobs:
   win-icx-test:
-    name: windows-2025 (icx)
-    runs-on: windows-2025
+    name: ${{ matrix.os }} (icx)
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2022
+          - windows-2025-vs2026
 
     steps:
       - name: Checkout repository
@@ -123,7 +129,7 @@ jobs:
             -DVCPKG_MANIFEST_DIR="%GITHUB_WORKSPACE%\installers\vcpkg" ^
             -DVCPKG_OVERLAY_PORTS="%GITHUB_WORKSPACE%\installers\vcpkg\overlay-ports" ^
             -DCMAKE_BUILD_TYPE=Debug ^
-            -DSITE=windows-2025 ^
+            -DSITE=${{ matrix.os }} ^
             -DBUILDNAME=vs2026/ninja/icx-2025.3 ^
             -DCLIO_CORE_ENABLE_RUNTIME=ON ^
             -DCLIO_CORE_ENABLE_CTE=ON ^
@@ -165,7 +171,7 @@ jobs:
         shell: bash
         run: |
           LOG="build/Testing/Temporary/LastTest.log"
-          echo "## Windows ICX test summary (windows-2025)" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Windows ICX test summary (${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
           if [ -f "$LOG" ]; then
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             grep -E "Test #|\*\*\*Failed|\*\*\*Exception|Passed|Failed" "$LOG" \
@@ -180,7 +186,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: win-icx-test-logs
+          name: win-icx-test-logs-${{ matrix.os }}
           path: |
             build/Testing/Temporary/LastTest.log
             build/Testing/Temporary/CTestCostData.txt


### PR DESCRIPTION
## Summary
Converts the single `windows-2025` icx job in `win-icx-test.yml` into a `strategy.matrix` over `runs-on` platforms:
- `windows-2022`
- `windows-2025-vs2026`

`runs-on`, the job `name`, the `-DSITE=` CTest cache var, the step-summary heading, and the uploaded artifact name now derive from `matrix.os`, so each runner reports distinctly to CDash and uploads its own logs without name collisions. `fail-fast: false` lets one platform's failure not cancel the other.

Relates to #555.

## Test plan
- [x] YAML validated with `yaml.safe_load`
- [ ] CI runs the matrix on both runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)