### PR TITLE
fix(runtime): source RestartContainers from RestartLog WAL (#567)

### DIFF
--- a/context-runtime/modules/admin/include/clio_runtime/admin/admin_runtime.h
+++ b/context-runtime/modules/admin/include/clio_runtime/admin/admin_runtime.h
@@ -248,8 +248,10 @@ public:
   chi::TaskResume RegisterMemory(ctp::ipc::FullPtr<RegisterMemoryTask> task, chi::RunContext &rctx);
 
   /**
-   * Handle RestartContainers - Re-create pools from saved restart configs
-   * Reads conf_dir/restart/ directory and re-creates pools from saved YAML
+   * Handle RestartContainers - Re-create pools from the restart registry.
+   * Reads the RestartLog write-ahead log (~/.clio/restart_log.bin), the same
+   * persistent registry replayed at startup, and re-composes each registered
+   * compose file.
    */
   chi::TaskResume RestartContainers(ctp::ipc::FullPtr<RestartContainersTask> task, chi::RunContext &rctx);
 

--- a/context-runtime/modules/admin/src/admin_runtime.cc
+++ b/context-runtime/modules/admin/src/admin_runtime.cc
@@ -43,6 +43,7 @@
 #include <clio_runtime/manager.h>
 #include <clio_runtime/module_manager.h>
 #include <clio_runtime/pool_manager.h>
+#include <clio_runtime/restart_log.h>
 #include <clio_runtime/task_archives.h>
 #include <clio_runtime/worker.h>
 #include <clio_ctp/lightbeam/transport_factory_impl.h>
@@ -1249,29 +1250,40 @@ chi::TaskResume Runtime::RestartContainers(
   task->error_message_ = "";
 
   try {
-    auto *config_manager = CLIO_CONFIG_MANAGER;
-    std::string restart_dir = config_manager->GetConfDir() + "/restart";
-
+    // The restart registry is the RestartLog write-ahead log
+    // (~/.clio/restart_log.bin), the same persistent registry that
+    // manager.cc replays at startup. Each live entry is the absolute path of
+    // a compose file registered via `clio_run compose start`. Re-compose each
+    // pool found there; pools already live (e.g. recovered at server-init
+    // time) come back as the existing pool with rc=0 and are still counted.
     namespace fs = std::filesystem;
-    if (!fs::exists(restart_dir) || !fs::is_directory(restart_dir)) {
-      HLOG(kDebug, "Admin: No restart directory found at {}", restart_dir);
+    clio::run::RestartLog restart_log;
+    std::vector<std::string> containers = restart_log.LiveSet();
+    if (containers.empty()) {
+      HLOG(kDebug, "Admin: No restartable containers registered in {}",
+           restart_log.path());
       task->SetReturnCode(0);
       CLIO_CO_RETURN;
     }
 
-    for (const auto &entry : fs::directory_iterator(restart_dir)) {
-      if (entry.path().extension() != ".yaml") continue;
-
-      // Load pool config from YAML file
-      chi::ConfigManager temp_config;
-      if (!temp_config.LoadYaml(entry.path().string())) {
-        HLOG(kError, "Admin: Failed to load restart config: {}",
-             entry.path().string());
+    for (const auto &container_path : containers) {
+      std::error_code ec;
+      if (!fs::exists(container_path, ec) || ec) {
+        HLOG(kWarning, "Admin: registered container '{}' no longer exists, "
+             "skipping", container_path);
         continue;
       }
 
-      const auto &compose_config = temp_config.GetComposeConfig();
-      for (const auto &pool_config : compose_config.pools_) {
+      // Load pool config from the registered compose file
+      chi::ConfigManager file_config;
+      if (!file_config.LoadYaml(container_path)) {
+        HLOG(kError, "Admin: Failed to load restart config: {}",
+             container_path);
+        continue;
+      }
+
+      for (auto pool_config : file_config.GetComposeConfig().pools_) {
+        pool_config.restart_ = true;
         HLOG(kInfo, "Admin: Restarting pool {} (module: {})",
              pool_config.pool_name_, pool_config.mod_name_);
 


### PR DESCRIPTION
## Summary

Fixes #567 — the `cte_restart_integration` ctest failed in Phase 2 with `containers_restarted=0`.

`Runtime::RestartContainers` re-composed pools by scanning `${conf_dir}/restart/*.yaml`, but **nothing writes to that directory anymore**. The restart registry was migrated to the `RestartLog` write-ahead log (`~/.clio/restart_log.bin`, PRs #549 / #562), which `manager.cc` replays on every startup. So `RestartContainers` always found an absent/empty `restart/` directory and reported zero restarts — even though the pool was correctly recovered at server-init time.

## Change

- `RestartContainers` now reads its live set from the `RestartLog` WAL (the same source `manager.cc` uses) and re-composes each registered compose file, counting every pool it (re-)composes. Pools already live come back as the existing pool with `rc=0` and are still counted.
- Guards against compose files that have since disappeared (warn + skip), mirroring the startup replay path.
- Updated the doc comment in `admin_runtime.h`.

## Testing

Built the full tree with the fix and ran the targeted integration test locally (Ubuntu 24 / WSL2, conda `cnd/vfd/vol`):

```
ctest -R cte_restart_integration --output-on-failure
100% tests passed, 0 tests failed out of 3
```

Phase 2 now logs `RestartContainers complete, rc=0, containers_restarted=1` and `=== RESTART TEST PASSED ===`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)