### PR TITLE
fix(runtime): guard PoolManager::pool_metadata_ against concurrent rehash (#572)

### DIFF
--- a/context-runtime/include/clio_runtime/pool_manager.h
+++ b/context-runtime/include/clio_runtime/pool_manager.h
@@ -38,6 +38,7 @@
 #include <string>
 #include <vector>
 #include <atomic>
+#include <shared_mutex>
 #include "clio_runtime/types.h"
 
 namespace clio::run {
@@ -304,11 +305,30 @@ class PoolManager {
    */
   Container* GetContainerRaw(PoolId pool_id, ContainerId container_id) const;
 
+  /**
+   * Internal: erase a pool's metadata entry under the write lock. Used by the
+   * CreatePool error paths and DestroyPool so they don't touch pool_metadata_
+   * without holding pool_metadata_mutex_.
+   * @param pool_id Pool identifier
+   */
+  void ErasePoolMetadata(PoolId pool_id);
+
   bool is_initialized_ = false;
 
   // Map PoolId to pool metadata (contains containers, address map, etc.)
   std::unordered_map<PoolId, PoolInfo> pool_metadata_;
-  
+
+  // Guards pool_metadata_ (and the PoolInfo contents reachable through it)
+  // against concurrent access by worker threads. Lookups on the hot task-
+  // routing path (GetStaticContainer/GetContainer via IpcManager::RouteTask)
+  // run on workers while CreatePool/UpdatePoolMetadata insert (and rehash) the
+  // map from another worker; without this lock a concurrent rehash tears the
+  // bucket array and find() dereferences null (issue #572). Readers take a
+  // shared lock, structural/PoolInfo mutators take an exclusive lock. Locks are
+  // always scoped to a single map operation so the lock is never held across
+  // CreatePool's co_await.
+  mutable std::shared_mutex pool_metadata_mutex_;
+
   // Pool ID counter for generating unique IDs (used as minor number)
   std::atomic<u32> next_pool_minor_{5}; // Start at 5 for safety, 1 reserved for admin
 

--- a/context-runtime/src/pool_manager.cc
+++ b/context-runtime/src/pool_manager.cc
@@ -46,11 +46,19 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <mutex>
+#include <shared_mutex>
 
 // Global pointer variable definition for Pool manager singleton
 CLIO_RUN_DEFINE_GLOBAL_PTR_VAR_CC(chi::PoolManager, g_pool_manager);
 
 namespace clio::run {
+
+// Convenience aliases for the pool_metadata_ reader/writer lock (issue #572).
+// Readers (lookups) take the shared lock; structural and PoolInfo mutators take
+// the exclusive lock.
+using PoolMetaReadLock = std::shared_lock<std::shared_mutex>;
+using PoolMetaWriteLock = std::unique_lock<std::shared_mutex>;
 
 // Constructor and destructor removed - handled by CTP singleton pattern
 
@@ -60,7 +68,10 @@ bool PoolManager::ServerInit() {
   }
 
   // Initialize pool metadata
-  pool_metadata_.clear();
+  {
+    PoolMetaWriteLock lock(pool_metadata_mutex_);
+    pool_metadata_.clear();
+  }
 
   is_initialized_ = true;
 
@@ -128,12 +139,15 @@ void PoolManager::Finalize() {
   }
 
   // Clear all containers in each PoolInfo, then clear metadata
-  for (auto &pair : pool_metadata_) {
-    pair.second.containers_.clear();
-    pair.second.static_container_ = nullptr;
-    pair.second.local_container_ = nullptr;
+  {
+    PoolMetaWriteLock lock(pool_metadata_mutex_);
+    for (auto &pair : pool_metadata_) {
+      pair.second.containers_.clear();
+      pair.second.static_container_ = nullptr;
+      pair.second.local_container_ = nullptr;
+    }
+    pool_metadata_.clear();
   }
-  pool_metadata_.clear();
 
   is_initialized_ = false;
 }
@@ -144,6 +158,7 @@ bool PoolManager::RegisterContainer(PoolId pool_id, ContainerId container_id,
     return false;
   }
 
+  PoolMetaWriteLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     return false;
@@ -167,6 +182,7 @@ bool PoolManager::UnregisterContainer(PoolId pool_id, ContainerId container_id) 
     return false;
   }
 
+  PoolMetaWriteLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     return false;
@@ -195,6 +211,7 @@ void PoolManager::UnregisterAllContainers(PoolId pool_id) {
     return;
   }
 
+  PoolMetaWriteLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     return;
@@ -213,6 +230,7 @@ Container* PoolManager::GetContainer(PoolId pool_id, ContainerId container_id,
     return nullptr;
   }
 
+  PoolMetaReadLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     return nullptr;
@@ -240,6 +258,7 @@ Container* PoolManager::GetContainerRaw(PoolId pool_id, ContainerId container_id
     return nullptr;
   }
 
+  PoolMetaReadLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     return nullptr;
@@ -255,6 +274,7 @@ Container* PoolManager::GetStaticContainer(PoolId pool_id) const {
     return nullptr;
   }
 
+  PoolMetaReadLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     return nullptr;
@@ -279,6 +299,7 @@ bool PoolManager::HasPool(PoolId pool_id) const {
     return false;
   }
 
+  PoolMetaReadLock lock(pool_metadata_mutex_);
   return pool_metadata_.find(pool_id) != pool_metadata_.end();
 }
 
@@ -287,6 +308,7 @@ bool PoolManager::HasContainer(PoolId pool_id, ContainerId container_id) const {
     return false;
   }
 
+  PoolMetaReadLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     return false;
@@ -300,6 +322,7 @@ PoolId PoolManager::FindPoolByName(const std::string& pool_name) const {
     return PoolId::GetNull();
   }
 
+  PoolMetaReadLock lock(pool_metadata_mutex_);
   // Iterate through pool metadata to find matching pool_name (globally unique)
   for (const auto& pair : pool_metadata_) {
     const PoolInfo& pool_info = pair.second;
@@ -312,7 +335,11 @@ PoolId PoolManager::FindPoolByName(const std::string& pool_name) const {
 }
 
 size_t PoolManager::GetPoolCount() const {
-  return is_initialized_ ? pool_metadata_.size() : 0;
+  if (!is_initialized_) {
+    return 0;
+  }
+  PoolMetaReadLock lock(pool_metadata_mutex_);
+  return pool_metadata_.size();
 }
 
 std::vector<PoolId> PoolManager::GetAllPoolIds() const {
@@ -321,6 +348,7 @@ std::vector<PoolId> PoolManager::GetAllPoolIds() const {
     return pool_ids;
   }
 
+  PoolMetaReadLock lock(pool_metadata_mutex_);
   pool_ids.reserve(pool_metadata_.size());
   for (const auto& pair : pool_metadata_) {
     pool_ids.push_back(pair.first);
@@ -401,6 +429,7 @@ void PoolManager::InitAddressMap(PoolId pool_id, u32 num_containers) {
     return;
   }
 
+  PoolMetaWriteLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     return;
@@ -515,7 +544,7 @@ TaskResume PoolManager::CreatePool(FullPtr<Task> task, RunContext* run_ctx) {
   auto* module_manager = CLIO_MODULE_MANAGER;
   if (!module_manager) {
     HLOG(kError, "PoolManager: Module manager not available");
-    pool_metadata_.erase(target_pool_id);
+    ErasePoolMetadata(target_pool_id);
     CLIO_CO_RETURN;
   }
 
@@ -529,7 +558,7 @@ TaskResume PoolManager::CreatePool(FullPtr<Task> task, RunContext* run_ctx) {
     if (!container) {
       HLOG(kError, "PoolManager: Failed to create container for ChiMod: {}",
            chimod_name);
-      pool_metadata_.erase(target_pool_id);
+      ErasePoolMetadata(target_pool_id);
       CLIO_CO_RETURN;
     }
 
@@ -563,7 +592,7 @@ TaskResume PoolManager::CreatePool(FullPtr<Task> task, RunContext* run_ctx) {
     if (!RegisterContainer(target_pool_id, node_id, container, /*is_static=*/true)) {
       HLOG(kError, "PoolManager: Failed to register container");
       module_manager->DestroyContainer(chimod_name, container);
-      pool_metadata_.erase(target_pool_id);
+      ErasePoolMetadata(target_pool_id);
       CLIO_CO_RETURN;
     }
 
@@ -582,7 +611,7 @@ TaskResume PoolManager::CreatePool(FullPtr<Task> task, RunContext* run_ctx) {
       // Unregister the container since Create failed
       UnregisterContainer(target_pool_id, node_id);
       module_manager->DestroyContainer(chimod_name, container);
-      pool_metadata_.erase(target_pool_id);
+      ErasePoolMetadata(target_pool_id);
       CLIO_CO_RETURN;
     }
 
@@ -598,7 +627,7 @@ TaskResume PoolManager::CreatePool(FullPtr<Task> task, RunContext* run_ctx) {
       UnregisterContainer(target_pool_id, node_id);
       module_manager->DestroyContainer(chimod_name, container);
     }
-    pool_metadata_.erase(target_pool_id);
+    ErasePoolMetadata(target_pool_id);
     CLIO_CO_RETURN;
   }
 
@@ -628,8 +657,7 @@ TaskResume PoolManager::DestroyPool(PoolId pool_id) {
   }
 
   // Check if pool exists in metadata
-  auto metadata_it = pool_metadata_.find(pool_id);
-  if (metadata_it == pool_metadata_.end()) {
+  if (!HasPool(pool_id)) {
     HLOG(kError, "PoolManager: Pool {} metadata not found", pool_id);
     CLIO_CO_RETURN;
   }
@@ -643,7 +671,7 @@ TaskResume PoolManager::DestroyPool(PoolId pool_id) {
   }
 
   // Remove pool metadata
-  pool_metadata_.erase(metadata_it);
+  ErasePoolMetadata(pool_id);
 
   HLOG(kInfo, "PoolManager: Destroyed complete pool {}", pool_id);
   CLIO_CO_RETURN;
@@ -655,6 +683,7 @@ const PoolInfo* PoolManager::GetPoolInfo(PoolId pool_id) const {
     return nullptr;
   }
 
+  PoolMetaReadLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   return (it != pool_metadata_.end()) ? &it->second : nullptr;
 }
@@ -664,7 +693,13 @@ void PoolManager::UpdatePoolMetadata(PoolId pool_id, const PoolInfo& info) {
     return;
   }
 
+  PoolMetaWriteLock lock(pool_metadata_mutex_);
   pool_metadata_[pool_id] = info;
+}
+
+void PoolManager::ErasePoolMetadata(PoolId pool_id) {
+  PoolMetaWriteLock lock(pool_metadata_mutex_);
+  pool_metadata_.erase(pool_id);
 }
 
 u32 PoolManager::GetContainerNodeId(PoolId pool_id,
@@ -677,19 +712,23 @@ u32 PoolManager::GetContainerNodeId(PoolId pool_id,
     return 0;  // Default to local node
   }
 
-  // Get pool metadata
-  const PoolInfo* pool_info = GetPoolInfo(pool_id);
-  if (!pool_info) {
+  // Hold the read lock across the address_map_ lookup. Resolving via a
+  // PoolInfo* and reading address_map_ after the lock dropped would race a
+  // concurrent UpdateContainerNodeMapping / pool insert (issue #572).
+  PoolMetaReadLock lock(pool_metadata_mutex_);
+  auto pit = pool_metadata_.find(pool_id);
+  if (pit == pool_metadata_.end()) {
     HLOG(kDebug, "GetContainerNodeId - pool not found, returning 0");
     return 0;  // Pool not found, assume local
   }
+  const PoolInfo &pool_info = pit->second;
 
   HLOG(kDebug, "GetContainerNodeId - pool has {} containers",
-       pool_info->num_containers_);
+       pool_info.num_containers_);
 
   // Look up node ID from the address map
-  auto it = pool_info->address_map_.find(container_id);
-  if (it != pool_info->address_map_.end()) {
+  auto it = pool_info.address_map_.find(container_id);
+  if (it != pool_info.address_map_.end()) {
     HLOG(kDebug,
          "GetContainerNodeId - found mapping: container_id={} -> node_id={}",
          container_id, it->second);
@@ -709,6 +748,7 @@ bool PoolManager::UpdateContainerNodeMapping(PoolId pool_id,
     return false;
   }
 
+  PoolMetaWriteLock lock(pool_metadata_mutex_);
   auto it = pool_metadata_.find(pool_id);
   if (it == pool_metadata_.end()) {
     HLOG(kError, "PoolManager: Pool {} not found for mapping update", pool_id);


### PR DESCRIPTION
## Summary

Fixes the intermittent `cte_tag_reorganize` SEGFAULT on macOS (issue #572).

`cte_tag_reorganize` (`test_tag_operations "Tag - Reorganize"`) intermittently crashed with `EXC_BAD_ACCESS (SIGSEGV) at 0x0`. The macOS crash report points at a worker thread:

```
std::unordered_map<UniqueId, PoolInfo>::find()            <-- null deref
clio::run::PoolManager::GetStaticContainer(UniqueId)
clio::run::IpcManager::RouteTask(Future<Task>&, bool)
clio::run::Worker::ProcessPeriodicQueue(...)
clio::run::Worker::ContinueBlockedTasks(bool)
clio::run::Worker::SuspendMe() / Run()
```

## Root cause

`PoolManager::pool_metadata_` (`PoolId -> PoolInfo`) was a bare `std::unordered_map` with **no synchronization**. While one worker thread inserts into it via `CreatePool` / `UpdatePoolMetadata` (creating the admin, CTE-core and bdev pools), the insert can **rehash and reallocate the bucket array**. Concurrently, another worker routing a **periodic task** (admin `Recv`/`Send`, CTE `StatTargets`, …) calls `pool_metadata_.find()` with no lock and reads a torn `__bucket_list_` → null deref.

The crash fires ~1.1s in, during fixture setup while pools are still being created — exactly when concurrent inserts overlap periodic-task routing. It passes when run standalone, which is why it only surfaced in the serialized full CTest run.

This is **distinct** from the already-patched coroutine-handle UAF (#485) — there are no coroutine frames in the backtrace.

## Fix

Guard `pool_metadata_` (and the `PoolInfo` contents reachable through it) with a `std::shared_mutex`:

- Lookups (`GetStaticContainer`, `GetContainer`, `HasPool`, `FindPoolByName`, `GetPoolInfo`, `GetContainerNodeId`, …) take a **shared** lock.
- Structural and `PoolInfo` mutations (`UpdatePoolMetadata`, `RegisterContainer`, `InitAddressMap`, `UpdateContainerNodeMapping`, erase/clear, `Finalize`) take an **exclusive** lock.
- Locks are **scoped to a single map operation** so the lock is never held across `CreatePool`'s `co_await` (which would deadlock the whole runtime). The error-path erases and `DestroyPool` go through a new `ErasePoolMetadata` helper; `DestroyPool` uses `HasPool` for its existence check; `GetContainerNodeId` now reads `address_map_` under the lock instead of through a `GetPoolInfo` pointer.

No public API changes; no recursive-locking paths (no locked method calls another locking method).

## Testing (local, macos-12, `run_vol` HDF5-VOL debug build)

- `cte_tag_reorganize`: **60/60** standalone runs clean + **5/5** ctest-harness repeats (`--repeat until-fail`). Previously SEGFAULTed.
- Full `ctest` suite (138 tests): **no regressions**. The only failure is the pre-existing, unrelated `cte_restart_integration` (restart/compose-WAL workflow — already failing before this change).

Closes #572
