### PR TITLE
test: re-enable last 2 disabled tests (ctp_mp_allocator_multiprocess #483, cee_python_retrieve_roundtrip)

### DIFF
--- a/context-exploration-engine/api/test/CMakeLists.txt
+++ b/context-exploration-engine/api/test/CMakeLists.txt
@@ -158,10 +158,12 @@ if(TARGET clio_cee)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
+  # Self-contained: the test starts an in-process runtime via
+  # clio_cte_core_ext.chimaera_init(kClient, True), so it no longer needs an
+  # externally running IOWarp daemon and is enabled by default.
   set_tests_properties(cee_python_retrieve_roundtrip PROPERTIES
-    LABELS "cee;api;python;retrieve;regression;manual"
+    LABELS "cee;api;python;retrieve;regression;msan_skip"
     TIMEOUT 120
-    DISABLED TRUE  # Requires externally running IOWarp runtime
   )
 
   install(FILES test_context_retrieve_roundtrip.py

--- a/context-exploration-engine/api/test/test_context_retrieve_roundtrip.py
+++ b/context-exploration-engine/api/test/test_context_retrieve_roundtrip.py
@@ -6,16 +6,89 @@ Tests full data round-trip: bundle -> query -> retrieve -> verify -> destroy.
 On main this test crashes with SIGABRT (double-free in ContextRetrieve).
 With the fix (removing manual DelTask loop), it passes.
 
-Requires a running IOWarp runtime with clio_cte_core and clio_cae_core modules.
+Self-contained: starts an in-process IOWarp runtime (clio_cte_core +
+clio_cae_core modules are loaded from the build's bin directory) via
+clio_cte_core_ext.chimaera_init(kClient, True), so it no longer needs an
+externally running daemon.
 """
 
-import sys
 import os
+import socket
+import sys
 import tempfile
+import time
 
 # Add build directory to path for module import
 sys.path.insert(0, os.path.join(os.getcwd(), "bin"))
-sys.path.insert(0, "/usr/local/lib/python3.13/site-packages")
+
+
+def _setup_environment_paths():
+    """Point ChiMod discovery at the directory holding the python extensions."""
+    import clio_cte_core_ext as cte
+
+    bin_dir = os.path.dirname(os.path.abspath(cte.__file__))
+    os.environ["CLIO_REPO_PATH"] = bin_dir
+    # Linux uses LD_LIBRARY_PATH, macOS uses DYLD_LIBRARY_PATH.
+    for var in ("LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"):
+        existing = os.getenv(var, "")
+        os.environ[var] = f"{bin_dir}:{existing}" if existing else bin_dir
+    return bin_dir
+
+
+def _generate_config():
+    """Write a minimal single-node runtime config and export CLIO_SERVER_CONF."""
+    import yaml
+
+    tmp = tempfile.gettempdir()
+    hostfile = os.path.join(tmp, "cee_roundtrip_hostfile")
+    with open(hostfile, "w") as f:
+        f.write("localhost\n")
+
+    port = None
+    for candidate in range(9229, 9300):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", candidate))
+                port = candidate
+                break
+            except OSError:
+                continue
+    if port is None:
+        raise RuntimeError("no available port for runtime in 9229-9300")
+
+    storage = os.path.join(tmp, "cee_roundtrip_storage")
+    os.makedirs(storage, exist_ok=True)
+
+    config = {
+        "networking": {"protocol": "zmq", "hostfile": hostfile, "port": port},
+        "workers": {"num_workers": 4},
+        "memory": {
+            "main_segment_size": "1G",
+            "client_data_segment_size": "512M",
+            "runtime_data_segment_size": "512M",
+        },
+        "devices": [{"mount_point": storage, "capacity": "1G"}],
+    }
+    config_path = os.path.join(tmp, "cee_roundtrip_conf.yaml")
+    with open(config_path, "w") as f:
+        yaml.dump(config, f)
+    os.environ["CLIO_SERVER_CONF"] = config_path
+    return config_path
+
+
+def start_runtime():
+    """Start an in-process IOWarp runtime. Returns True if ready."""
+    _setup_environment_paths()
+    config_path = _generate_config()
+
+    import clio_cte_core_ext as cte
+
+    if not cte.chimaera_init(cte.ChimaeraMode.kClient, True):
+        return False
+    time.sleep(0.5)  # let the runtime finish coming up
+    if hasattr(cte, "initialize_cte"):
+        cte.initialize_cte(config_path, cte.PoolQuery.Dynamic())
+    return True
 
 
 def test_retrieve_roundtrip():
@@ -25,8 +98,7 @@ def test_retrieve_roundtrip():
     ctx_interface = cee.ContextInterface()
     tag_name = "test_retrieve_roundtrip"
 
-    # Use /dev/shm so the runtime container can also access the file
-    tmpdir = tempfile.mkdtemp(prefix="iowarp_test_", dir="/dev/shm")
+    tmpdir = tempfile.mkdtemp(prefix="iowarp_test_")
     test_file = os.path.join(tmpdir, "test_data.bin")
 
     # Create test file with known pattern
@@ -87,6 +159,9 @@ def main():
     print("=" * 60)
 
     try:
+        if not start_runtime():
+            print("\nFAIL: could not start in-process IOWarp runtime")
+            return 1
         success = test_retrieve_roundtrip()
         if success:
             print("\nPASS: Data round-trip verified successfully")

--- a/context-exploration-engine/api/test/test_context_retrieve_roundtrip.py
+++ b/context-exploration-engine/api/test/test_context_retrieve_roundtrip.py
@@ -77,7 +77,7 @@ def _generate_config():
 
 
 def start_runtime():
-    """Start an in-process IOWarp runtime. Returns True if ready."""
+    """Start an in-process IOWarp runtime with a storage target. Returns True."""
     _setup_environment_paths()
     config_path = _generate_config()
 
@@ -88,6 +88,21 @@ def start_runtime():
     time.sleep(0.5)  # let the runtime finish coming up
     if hasattr(cte, "initialize_cte"):
         cte.initialize_cte(config_path, cte.PoolQuery.Dynamic())
+
+    # Register a storage target so context_bundle's PutBlob has somewhere to
+    # land. The in-process runtime starts with no devices, so without this the
+    # assimilator fails with "Failed to store description" (return_code 11).
+    client = cte.get_cte_client()
+    storage_dir = tempfile.mkdtemp(prefix="iowarp_store_")
+    target_path = os.path.join(storage_dir, "cee_roundtrip_target")
+    try:
+        client.RegisterTarget(target_path, cte.BdevType.kFile,
+                              1024 * 1024 * 1024, cte.PoolQuery.Local(),
+                              cte.PoolId(700, 0))
+    except TypeError:
+        # RegisterTarget's binding returns a std::atomic nanobind can't convert
+        # to a Python type; the registration side-effect still completes.
+        pass
     return True
 
 

--- a/context-transport-primitives/test/unit/allocator/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/allocator/CMakeLists.txt
@@ -127,7 +127,11 @@ set_tests_properties(
   ctp_mp_allocator_multiprocess
   ctp_buddy_allocator_multiprocess
   PROPERTIES
-    TIMEOUT 15
+    # 3 ranks x 2 threads each run a 5s contended alloc/free workload (rank 0
+    # leads by a 2s stagger), so a healthy run is ~11-12s on macOS once the
+    # ticket lock's backoff serializes the global allocator. 15s left almost no
+    # CI headroom; 60s keeps it comfortably non-flaky.
+    TIMEOUT 60
     ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH}"
 )
 
@@ -144,14 +148,14 @@ set_tests_properties(
   PROPERTIES LABELS "msan_skip"
 )
 
-# macOS: ctp_mp_allocator_multiprocess deadlocks (15s timeout) inside the
-# shared-memory ProducerConsumerAllocator under cross-process contention --
-# a lock-free/atomics-on-shm issue specific to macOS (the per-thread workload
-# has a hard steady_clock deadline so it cannot itself overrun). Disabled on
-# macOS pending the real fix; tracked in issue #483. Linux is unaffected.
-if(APPLE)
-  set_tests_properties(ctp_mp_allocator_multiprocess PROPERTIES DISABLED TRUE)
-endif()
+# macOS (issue #483, fixed): ctp_mp_allocator_multiprocess used to livelock
+# under cross-process contention on the shared-memory ProducerConsumerAllocator.
+# Its global ticket lock (ctp::Mutex) busy-spun with only a PAUSE hint, and the
+# macOS scheduler would not preempt a spinning waiter to run the descheduled
+# lock holder -- starving the holder for the full 15s timeout. The ticket lock's
+# Backoff now additionally deschedules the OS thread (std::this_thread::sleep_for)
+# once contention is sustained, so the holder makes progress. The test passes on
+# macOS again and is enabled (it keeps the bumped timeout above for headroom).
 endif()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Re-enables the final 2 of the 12 disabled tests. Both root causes were already addressed in the codebase; the tests just needed to be turned back on (one needed a small self-contained-runtime change).

## 1. `ctp_mp_allocator_multiprocess` (issue #483)

**Was:** `DISABLED TRUE` on macOS — livelocked (15s timeout) under cross-process contention on the `ProducerConsumerAllocator`'s global ticket lock (`ctp::Mutex`). A far-back waiter busy-spun with only a PAUSE hint, and the macOS scheduler wouldn't preempt it to run the descheduled lock holder.

**Now:** The ticket lock's `Backoff` already deschedules the OS thread (`std::this_thread::sleep_for`) once contention is sustained, so the holder makes progress. Re-enabled on macOS and bumped the timeout **15 → 60s**: a healthy run is ~10-12s (3 ranks × 2 threads, 5s contended workload + 2s stagger), which left almost no headroom at 15s.

## 2. `cee_python_retrieve_roundtrip` (regression test for #192)

**Was:** `DISABLED TRUE` with a `manual` label — "Requires externally running IOWarp runtime".

**Now:** Self-contained. The test starts an **in-process** runtime via `clio_cte_core_ext.chimaera_init(kClient, True)` + `initialize_cte` (the same pattern the CTE Python tests use), generates its own single-node config, and uses a portable temp dir instead of the hardcoded `/dev/shm` (which doesn't exist on macOS). Dropped the `manual` label, added `msan_skip` (it now starts an uninstrumented runtime).

## Testing (local, macos-12, debug build)

- `ctp_mp_allocator_multiprocess`: **3/3** pass (~10-11s each) under `ctest --repeat until-fail:3`.
- `cee_python_retrieve_roundtrip`: passes (~8.5s) — full `context_bundle → query → retrieve → destroy` round-trip verified (65564 bytes), exercising the #192 double-free fix cleanly.

Both show as enabled (no longer in ctest's "Disabled" list).

Completes the disabled-test cleanup alongside #574 (the 10 macOS ZMQ tests). Relates to #483.
