### PR TITLE
fix(cuda): keep ProcessAffiner out of nvcc front-end to avoid cudafe++ ICE

### DIFF
--- a/context-transport-primitives/include/clio_ctp/util/affinity.h
+++ b/context-transport-primitives/include/clio_ctp/util/affinity.h
@@ -39,7 +39,16 @@
 // macOS exposes no equivalent in libpthread; Windows uses a different
 // API entirely. Both compile this class out — no current call site
 // needs it on those platforms.
-#ifdef __linux__
+//
+// It is also excluded from NVCC's device front-end (cudafe++): the class
+// is pure host code with no device call site, and cudafe++ in the CUDA
+// 12.x toolchain hits an internal error ("find_allocated_name_reference"
+// in lexical.c) when instantiating std::vector<cpu_set_t>'s destructor
+// (the ~cpu_set_t() pseudo-destructor). __CUDACC__ is defined for both
+// the host and device passes of nvcc, so this keeps the header out of
+// every CUDA translation unit that pulls it in transitively via
+// clio_ctp.h, while leaving it intact for ordinary host compilers.
+#if defined(__linux__) && !defined(__CUDACC__)
 
 // Reference:
 // https://stackoverflow.com/questions/63372288/getting-list-of-pids-from-proc-in-linux
@@ -196,6 +205,6 @@ class ProcessAffiner {
 
 }  // namespace ctp
 
-#endif  // __linux__
+#endif  // __linux__ && !__CUDACC__
 
 #endif  // CTP_SHM_AFFINITY_H


### PR DESCRIPTION
## Problem

The GPU build (`build_gpu`, CUDA 12.9 / nvcc) fails while compiling `context-runtime/src/gpu/gpu2cpu_init_hip.cc` with an **nvcc front-end (`cudafe++`) internal compiler error**:

```
/usr/include/c++/12/bits/stl_construct.h(88): internal error:
  assertion failed at: "lexical.c", line 22310 in find_allocated_name_reference
   __location->~_Tp();
nvcc error : 'cudafe++' died due to signal 6
nvcc error : 'cudafe++' core dumped
```

This is a compiler bug, not a code bug.

## Root cause

The CUDA translation unit transitively includes `clio_ctp.h` → `clio_ctp/util/affinity.h`, whose `ProcessAffiner` class holds a `std::vector<cpu_set_t>` member. `cudafe++` crashes when instantiating that vector's `~cpu_set_t()` pseudo-destructor.

Bisection confirmed `affinity.h` alone reproduces the crash, and `ProcessAffiner` is **not referenced anywhere** in the tree — it is pure host-only Linux code (`sched_setaffinity`, `cpu_set_t`, `/proc` walking).

## Fix

Change the guard from `#ifdef __linux__` to `#if defined(__linux__) && !defined(__CUDACC__)`. `__CUDACC__` is defined for both the host and device passes of nvcc, so the class is excluded from every CUDA translation unit while remaining fully available to ordinary host compilers.

## Testing

A full clean `build_gpu` run (CUDA on, GPU runtime, BAM) completes with **exit code 0** with this change; the previously-failing `clio_run_cxx_gpu` target now compiles. Host (non-nvcc) builds are unaffected since the guard is a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
