### PR TITLE
Fix/cte getblob bytes

### DIFF
--- a/context-transfer-engine/wrapper/python/CMakeLists.txt
+++ b/context-transfer-engine/wrapper/python/CMakeLists.txt
@@ -147,4 +147,21 @@ if(BUILD_TESTING)
         ENVIRONMENT "CHI_WITH_RUNTIME=1;CLIO_BIND_ADDR=127.0.0.1"
         DEPENDS clio_cte_core_ext
     )
+
+    # GetBlob binary round-trip — regression guard for the nb::bytes return
+    # type (a std::string return decoded non-UTF-8 blob data and raised
+    # UnicodeDecodeError).
+    add_test(
+        NAME python_getblob_bytes_test
+        COMMAND ${Python_EXECUTABLE} -I ${CMAKE_CURRENT_SOURCE_DIR}/test_cte_getblob_bytes.py
+        WORKING_DIRECTORY $<TARGET_FILE_DIR:clio_cte_core_ext>
+    )
+    set_tests_properties(
+        python_getblob_bytes_test
+        PROPERTIES
+        LABELS "python;bindings;getblob"
+        TIMEOUT 120
+        ENVIRONMENT "CHI_WITH_RUNTIME=1;CLIO_BIND_ADDR=127.0.0.1"
+        DEPENDS clio_cte_core_ext
+    )
 endif()

--- a/context-transfer-engine/wrapper/python/core_bindings.cc
+++ b/context-transfer-engine/wrapper/python/core_bindings.cc
@@ -301,16 +301,20 @@ NB_MODULE(clio_cte_core_ext, m) {
            "Args: blob_name (str), data (bytes), off (int, optional)")
       .def("GetBlob",
            [](clio::cte::core::Tag &self, const std::string &blob_name,
-              size_t data_size, size_t off) -> std::string {
-             // Allocate buffer and retrieve blob data
+              size_t data_size, size_t off) -> nb::bytes {
+             // Retrieve blob data into a buffer, return it as raw bytes.
+             // Must return nb::bytes (not std::string): blobs are arbitrary
+             // binary, and nanobind decodes a returned std::string as UTF-8,
+             // which raises UnicodeDecodeError on any non-text payload. This
+             // also mirrors PutBlob, which already accepts nb::bytes.
              std::string result(data_size, '\0');
              self.GetBlob(blob_name, result.data(), data_size, off);
-             return result;
+             return nb::bytes(result.data(), result.size());
            },
            "blob_name"_a, "data_size"_a, "off"_a = 0,
            "Get blob data. Automatically allocates shared memory and copies data. "
            "Args: blob_name (str), data_size (int), off (int, optional). "
-           "Returns: str/bytes containing blob data")
+           "Returns: bytes containing the raw blob data")
       .def("GetBlobScore", &clio::cte::core::Tag::GetBlobScore,
            "blob_name"_a,
            "Get blob placement score (0.0-1.0). "

--- a/context-transfer-engine/wrapper/python/test_cte_getblob_bytes.py
+++ b/context-transfer-engine/wrapper/python/test_cte_getblob_bytes.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Regression test for Tag.GetBlob returning raw bytes.
+
+The Python binding once returned std::string, which nanobind decodes as UTF-8 —
+raising UnicodeDecodeError on any non-text blob. This puts a deliberately
+non-UTF-8 payload via PutBlob and verifies GetBlob returns it as `bytes`,
+byte-exact. Against the old binding this test errors out (UnicodeDecodeError);
+against the fix it passes.
+
+Usage:
+    python3 test_cte_getblob_bytes.py
+    CLIO_WITH_RUNTIME=0 python3 test_cte_getblob_bytes.py   # external runtime
+"""
+import os
+import socket
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.getcwd())  # prefer the freshly-built module next to us
+
+
+def should_initialize_runtime() -> bool:
+    val = os.getenv("CLIO_WITH_RUNTIME")
+    return val is None or str(val).lower() not in ("0", "false", "no", "off")
+
+
+def setup_environment_paths(cte) -> None:
+    module_file = getattr(cte, "__file__", None)
+    if not module_file:
+        return
+    bin_dir = os.path.dirname(os.path.abspath(module_file))
+    os.environ["CLIO_REPO_PATH"] = bin_dir
+    existing = os.getenv("LD_LIBRARY_PATH", "")
+    os.environ["LD_LIBRARY_PATH"] = f"{bin_dir}:{existing}" if existing else bin_dir
+
+
+def find_available_port(start: int = 9209, end: int = 9280) -> int:
+    for port in range(start, end):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"No available ports in {start}-{end}")
+
+
+def initialize_runtime(cte) -> bool:
+    import yaml
+    config = {
+        "networking": {"port": find_available_port()},
+        "runtime": {"num_threads": 4, "queue_depth": 1024},
+        "compose": [
+            {"mod_name": "clio_bdev", "pool_name": "ram::chi_default_bdev",
+             "pool_query": "local", "pool_id": "301.0",
+             "bdev_type": "ram", "capacity": "128MB"},
+            {"mod_name": "clio_cte_core", "pool_name": "clio_cte_core",
+             "pool_query": "local", "pool_id": "512.0",
+             "storage": [{"path": "ram::cte_ram_tier1", "bdev_type": "ram",
+                          "capacity_limit": "128MB", "score": 1.0}],
+             "dpe": {"dpe_type": "max_bw"}},
+        ],
+    }
+    cfg_path = os.path.join(tempfile.gettempdir(), "clio_getblob_bytes_conf.yaml")
+    with open(cfg_path, "w") as f:
+        yaml.dump(config, f)
+    os.environ["CLIO_SERVER_CONF"] = cfg_path
+    if not cte.chimaera_init(cte.ChimaeraMode.kClient, True):
+        return False
+    time.sleep(0.5)
+    return cte.initialize_cte(cfg_path, cte.PoolQuery.Dynamic())
+
+
+def run_test(cte) -> int:
+    tag = cte.Tag("getblob_bytes_roundtrip")
+    payload = bytes(range(256)) * 64  # 16 KiB, deliberately NOT valid UTF-8
+    tag.PutBlob("blob", payload, 0)
+
+    size = tag.GetBlobSize("blob")
+    assert size == len(payload), f"GetBlobSize {size} != {len(payload)}"
+
+    got = tag.GetBlob("blob", size, 0)
+    assert isinstance(got, bytes), f"GetBlob must return bytes, got {type(got).__name__}"
+    assert got == payload, "binary round-trip mismatch"
+    print(f"OK GetBlob returned {len(got)} bytes (byte-exact, non-UTF-8 round-trip)")
+    return 0
+
+
+def main() -> int:
+    try:
+        import clio_cte_core_ext as cte
+    except ImportError as e:
+        print(f"FAIL: cannot import clio_cte_core_ext: {e}")
+        return 1
+    if should_initialize_runtime():
+        setup_environment_paths(cte)
+        if not initialize_runtime(cte):
+            print("FAIL: runtime initialization")
+            return 1
+    return run_test(cte)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssertionError as e:
+        print(f"FAIL: {e}")
+        sys.exit(1)
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"FAIL: {e}")
+        sys.exit(1)


### PR DESCRIPTION
The nanobind binding for Tag.GetBlob returned std::string, which nanobind converts to a Python str by decoding as UTF-8. Blobs are arbitrary binary data, so any non-text payload (e.g. HDF5 float arrays) raised UnicodeDecodeError on the way back to Python. The binary read path was effectively unusable even though the C++ data plane stored and returned the bytes correctly -- the corruption was purely in the binding's return-type choice.

This was also internally inconsistent. PutBlob already accepts nb::bytes, so binary data could be written but never read back. And the one in-tree consumer (iowarp-cei-mcp/server.py) already branches on isinstance(blob_data, bytes) with a base64 fallback for binary payloads. This path was dead code, because the str binding threw before the server ever received the data.

Returning nb::bytes makes read symmetric with write, activates the MCP server's existing binary path, and lets callers .decode() when they want text. Existing CTE tests assert isinstance(result, (str, bytes)) and are unaffected.

This PR also includes a regression test to verify the new behavior.