### PR TITLE
Focused rename stress + concurrency tests; fix rename-overwrite semantics (#597)

### DIFF
--- a/.github/workflows/manytoone-test.yml
+++ b/.github/workflows/manytoone-test.yml
@@ -1,0 +1,86 @@
+name: ManyToOne Test
+
+# Docker-based CI for the PoolQuery::ManyToOne collective (batch + AggregateIn
+# + 1->N result broadcast), driven by the BatchManager on the neighborhood
+# leader. The project is compiled inside the iowarp/deps-cpu image (ABI-matched
+# to the runtime) and the ManyToOne tests are run in that same container:
+#
+#   * chimaera_bdev_chimod_tests "[manytoone]" — the focused collective test:
+#     a batch of AllocateBlocks requests sharing one (hash, key) is combined via
+#     AggregateIn, run once, and the result broadcast back to every submitter.
+#   * chimaera_cfs_test — the context-filesystem deferred-append pipeline, which
+#     routes per-tag AppendCollect tasks ManyToOne to a sequencer (exercising the
+#     single-in-flight-per-group-key serialization end to end).
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'cmake/**'
+      - 'context-runtime/**'
+      - 'context-transfer-engine/**'
+      - 'context-transport-primitives/**'
+      - 'docker/deps-cpu.Dockerfile'
+      - '.github/workflows/manytoone-test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: manytoone-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  manytoone:
+    name: ManyToOne (docker, batch+aggregate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      DEPS_IMAGE: iowarp/deps-cpu:latest
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      # Authenticated pulls avoid Docker Hub's anonymous rate limit. Skipped
+      # automatically on forked-PR runs where the secret is unavailable.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKER_HUB_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Pull dependency image
+        run: docker pull "$DEPS_IMAGE"
+
+      # Build the project AND run the ManyToOne tests inside the same deps-cpu
+      # container: these are single-node tests (RuntimeServer spawns clio_run
+      # in-container), so binaries and the runtime share one ABI/environment.
+      - name: Build + run ManyToOne tests (inside deps-cpu)
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}":/workspace -w /workspace -u 0 \
+            "$DEPS_IMAGE" bash -c '
+              set -e
+              export LD_LIBRARY_PATH=/usr/local/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+              export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
+              git config --global --add safe.directory /workspace
+              cmake --preset release -DCLIO_CORE_ENABLE_PYTHON=OFF
+              cmake --build build -j"$(nproc)"
+
+              cd build/bin
+              export CHI_REPO_PATH="$PWD"
+              export LD_LIBRARY_PATH="$PWD:$LD_LIBRARY_PATH"
+              export CLIO_BIND_ADDR=127.0.0.1
+
+              echo "==== ManyToOne collective (bdev AllocateBlocks batch) ===="
+              ./chimaera_bdev_chimod_tests "[manytoone]"
+
+              echo "==== ManyToOne via context-filesystem deferred append ===="
+              ./chimaera_cfs_test
+            '

--- a/.github/workflows/manytoone-test.yml
+++ b/.github/workflows/manytoone-test.yml
@@ -70,7 +70,13 @@ jobs:
               export LD_LIBRARY_PATH=/usr/local/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
               export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
               git config --global --add safe.directory /workspace
-              cmake --preset release -DCLIO_CORE_ENABLE_PYTHON=OFF
+              # CLIO_CTE_ENABLE_FILESYSTEM must be set on the configure command
+              # line: it is force-enabled inside context-transfer-engine, but the
+              # cfs test lives in context-runtime, which is configured first — so
+              # without this flag the option is still OFF when the test target is
+              # evaluated and chimaera_cfs_test never gets built (exit 127 below).
+              cmake --preset release -DCLIO_CORE_ENABLE_PYTHON=OFF \
+                    -DCLIO_CTE_ENABLE_FILESYSTEM=ON
               cmake --build build -j"$(nproc)"
 
               cd build/bin

--- a/context-runtime/include/clio_runtime/batch_manager.h
+++ b/context-runtime/include/clio_runtime/batch_manager.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "clio_runtime/task.h"
@@ -111,6 +112,14 @@ class BatchManager {
   IpcManager *ipc_;
   std::mutex mu_;
   std::unordered_map<GroupKey, Group, GroupKeyHash> groups_;
+  // At most one aggregate per group key may be in flight at a time. While a
+  // group's aggregate is running, new members keep accumulating in groups_ and
+  // are NOT flushed until that aggregate completes (OnAggregateComplete clears
+  // the key). This serializes collectives sharing a (pool,method,hash,key) so
+  // e.g. each runs against the fully-settled output of the previous one.
+  std::unordered_set<GroupKey, GroupKeyHash> in_flight_;
+  /** in-flight aggregate task unique id → its group key (to release on done). */
+  std::unordered_map<u64, GroupKey> agg_group_;
   /** agg task unique id → its batched originals, awaiting broadcast. */
   std::mutex pending_mu_;
   std::unordered_map<u64, std::vector<ctp::ipc::FullPtr<Task>>> pending_;

--- a/context-runtime/src/batch_manager.cc
+++ b/context-runtime/src/batch_manager.cc
@@ -57,12 +57,22 @@ bool BatchManager::FlushDue(Worker *worker) {
     u64 now = NowNs();
     for (auto it = groups_.begin(); it != groups_.end();) {
       if (now >= it->second.deadline_ns) {
+        if (in_flight_.count(it->first) != 0) {
+          // An aggregate for this key is still running. Leave the group in
+          // place so members keep accumulating; it flushes once the in-flight
+          // aggregate completes (OnAggregateComplete clears in_flight_).
+          ++it;
+          continue;
+        }
+        in_flight_.insert(it->first);  // claim: this group's aggregate is ours
         due.emplace_back(it->first, std::move(it->second));
         it = groups_.erase(it);
       } else {
         ++it;
       }
     }
+    // groups_ still holds not-yet-due groups AND in-flight-blocked groups; keep
+    // the leader polling so a blocked group flushes promptly once released.
     pending_remains = !groups_.empty();
   }
   for (auto &[key, group] : due) {
@@ -83,6 +93,8 @@ void BatchManager::BuildAndSubmit(Worker * /*worker*/, const GroupKey &key,
   if (container == nullptr) {
     HLOG(kError, "BatchManager: no container for pool {} (dropping {} tasks)",
          key.pool_id, group.members.size());
+    std::lock_guard<std::mutex> lk(mu_);
+    in_flight_.erase(key);  // release the claim so future batches can flush
     return;
   }
 
@@ -92,6 +104,8 @@ void BatchManager::BuildAndSubmit(Worker * /*worker*/, const GroupKey &key,
   if (agg.IsNull()) {
     HLOG(kError, "BatchManager: NewCopyTask failed for pool {} method {}",
          key.pool_id, key.method);
+    std::lock_guard<std::mutex> lk(mu_);
+    in_flight_.erase(key);
     return;
   }
   // Combine each remaining member's INPUTS into the aggregate (AggregateIn).
@@ -113,10 +127,16 @@ void BatchManager::BuildAndSubmit(Worker * /*worker*/, const GroupKey &key,
   agg->SetFlags(TASK_BATCH_AGGREGATE);
   agg->ClearFlags(TASK_ROUTED | TASK_STARTED | TASK_RUN_CTX_EXISTS);
 
-  // Remember the originals to broadcast to when the aggregate completes.
+  // Remember the originals to broadcast to when the aggregate completes, and
+  // map the aggregate back to its group key so OnAggregateComplete can release
+  // the in-flight claim (allowing the next batch for this key to flush).
   {
     std::lock_guard<std::mutex> lk(pending_mu_);
     pending_[agg->task_id_.unique_] = std::move(group.members);
+  }
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    agg_group_[agg->task_id_.unique_] = key;
   }
 
   ipc_->Send(agg);
@@ -129,6 +149,19 @@ bool BatchManager::IsAggregate(const ctp::ipc::FullPtr<Task> &task) const {
 void BatchManager::OnAggregateComplete(Worker *worker,
                                        const ctp::ipc::FullPtr<Task> &agg,
                                        RunContext *agg_rctx) {
+  // Release the in-flight claim for this group key first, so a fresh batch can
+  // start now that this aggregate's effects are fully settled. Done before the
+  // broadcast below (which only signals the original submitters) so the leader
+  // can begin the next batch promptly.
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto git = agg_group_.find(agg->task_id_.unique_);
+    if (git != agg_group_.end()) {
+      in_flight_.erase(git->second);
+      agg_group_.erase(git);
+    }
+  }
+
   std::vector<ctp::ipc::FullPtr<Task>> members;
   {
     std::lock_guard<std::mutex> lk(pending_mu_);

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -994,11 +994,26 @@ void Worker::ExecTask(const FullPtr<Task> &task_ptr, RunContext *run_ctx,
     if (run_ctx->yield_time_us_ > 0) {
       AddToBlockedQueue(run_ctx);
     }
+    // The worker is no longer running this coroutine; drop the current
+    // RunContext so between-task main-loop code (below) can't read it. See the
+    // note at the end of this function.
+    SetCurrentRunContext(nullptr);
     return;
   }
 
   // End task execution and cleanup (handles periodic rescheduling internally)
   EndTask(task_ptr, run_ctx, true);
+
+  // Clear the worker's current RunContext now that this task is no longer
+  // executing. Main-loop code that runs *between* tasks — notably
+  // BatchManager::FlushDue -> CreateTaskId -> Worker::GetCurrentTask — must not
+  // dereference current_run_context_ after the task it pointed at has been
+  // freed. A completed remote task's RunContext is destroyed on the network
+  // (ZMQ) thread, so leaving current_run_context_ set here is a cross-thread
+  // dangling pointer (observed as a heap-use-after-free in CreateTaskId during
+  // a ManyToOne flush). run_ctx may itself be freed by EndTask above, so only
+  // store nullptr — never read run_ctx past this point.
+  SetCurrentRunContext(nullptr);
 }
 
 

--- a/context-runtime/test/unit/cli/CMakeLists.txt
+++ b/context-runtime/test/unit/cli/CMakeLists.txt
@@ -171,6 +171,41 @@ if(CLIO_CORE_ENABLE_TESTS)
       TIMEOUT 110
       LABELS "msan_skip"
     )
+
+    # Focused rename stress + concurrency test (issue #597): POSIX
+    # rename-overwrite semantics and renames racing on shared destinations.
+    add_executable(chimaera_cfs_rename_test test_cfs_rename.cc)
+    target_include_directories(chimaera_cfs_rename_test PRIVATE
+      ${CLIO_RUN_ROOT}/include
+      ${CLIO_RUN_ROOT}/test
+    )
+    target_link_libraries(chimaera_cfs_rename_test
+      clio_cte_filesystem_client
+      clio_cte_core_client
+      clio_admin_client
+      chimaera_cxx
+      ctp::cxx
+      ${CMAKE_THREAD_LIBS_INIT}
+    )
+    target_compile_definitions(chimaera_cfs_rename_test PRIVATE
+      CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+    add_dependencies(chimaera_cfs_rename_test clio_run clio_cte_filesystem_runtime)
+    set_target_properties(chimaera_cfs_rename_test PROPERTIES
+      CXX_STANDARD 20
+      CXX_STANDARD_REQUIRED ON
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+    add_test(
+      NAME cr_cli_cfs_rename
+      COMMAND chimaera_cfs_rename_test
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+    set_tests_properties(cr_cli_cfs_rename PROPERTIES
+      ENVIRONMENT "${_cli_live_env}"
+      RESOURCE_LOCK "chimaera_runtime_port"
+      TIMEOUT 180
+      LABELS "msan_skip"
+    )
   endif()
 
   # RestartLog unit test: pure file-level WAL behavior (no daemon).

--- a/context-runtime/test/unit/cli/test_cfs.cc
+++ b/context-runtime/test/unit/cli/test_cfs.cc
@@ -18,6 +18,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <set>
 #include <thread>
 #include <vector>
 
@@ -527,10 +528,14 @@ TEST_CASE("Cfs - filesystem chimod open/write/getattr/read/truncate",
   }
 
   // ---- Deferred-append pipeline ----
-  // Append three distinguishable chunks; each is placed locally + queued, then
-  // a periodic AppendSequence -> AppendCollect (ManyToOne, sort by UTC/logical)
-  // -> AppendExecution merges them into the file pages in order. The merge is
-  // asynchronous, so poll-read until the concatenation appears.
+  // Fire many appends concurrently (without awaiting each), so they pile into
+  // the pending queue and the periodic AppendSequence drains them across
+  // SEVERAL ManyToOne AppendCollect batches. Each append is placed locally +
+  // queued; AppendCollect (sorted by UTC/logical) plans the merge against the
+  // file tail and AppendExecution writes it into the pages. Because at most one
+  // aggregate per tag runs at a time (BatchManager serialization), successive
+  // batches see a fully-settled tail, so the bytes land in submission order and
+  // span page boundaries cleanly. Verify the exact ordered concatenation.
   {
     const std::string apath = "/append_test.bin";
     auto aop = cfs.AsyncOpen(apath, O_CREAT | O_RDWR, 0644);
@@ -547,6 +552,7 @@ TEST_CASE("Cfs - filesystem chimod open/write/getattr/read/truncate",
       REQUIRE(!ab.IsNull());
       memset(ab.ptr_, marks[c], kChunk);
       expected.append(kChunk, marks[c]);
+      // Await each: sequential appends => (UTC, logical) order == this order.
       auto ap = cfs.AsyncAppend(ah, kChunk, ab.shm_.template Cast<void>());
       ap.Wait();
       REQUIRE(ap->GetReturnCode() == 0);
@@ -554,9 +560,11 @@ TEST_CASE("Cfs - filesystem chimod open/write/getattr/read/truncate",
     }
     const chi::u64 total = kChunk * 3;
 
-    // The periodic AppendSequence drains + merges asynchronously; poll-read.
+    // The periodic AppendSequence -> AppendCollect (ManyToOne) -> AppendExecution
+    // pipeline merges asynchronously; poll-read until the ordered concatenation
+    // appears.
     bool matched = false;
-    for (int attempt = 0; attempt < 200 && !matched; ++attempt) {
+    for (int attempt = 0; attempt < 400 && !matched; ++attempt) {
       ctp::ipc::FullPtr<char> rb = ipc->AllocateBuffer(total);
       REQUIRE(!rb.IsNull());
       memset(rb.ptr_, 0, total);

--- a/context-runtime/test/unit/cli/test_cfs.cc
+++ b/context-runtime/test/unit/cli/test_cfs.cc
@@ -545,24 +545,26 @@ TEST_CASE("Cfs - filesystem chimod open/write/getattr/read/truncate",
     REQUIRE(ah != 0);
 
     constexpr chi::u64 kChunk = 4096;
-    const char marks[3] = {'A', 'B', 'C'};
-    std::string expected;
-    for (int c = 0; c < 3; ++c) {
+    constexpr int kNum = 16;  // concurrent stress (probe for corruption)
+    std::vector<ctp::ipc::FullPtr<char>> abufs;
+    std::vector<chi::Future<clio::cte::filesystem::AppendTask>> afuts;
+    for (int c = 0; c < kNum; ++c) {
+      char mark = static_cast<char>('a' + c);
       ctp::ipc::FullPtr<char> ab = ipc->AllocateBuffer(kChunk);
       REQUIRE(!ab.IsNull());
-      memset(ab.ptr_, marks[c], kChunk);
-      expected.append(kChunk, marks[c]);
-      // Await each: sequential appends => (UTC, logical) order == this order.
-      auto ap = cfs.AsyncAppend(ah, kChunk, ab.shm_.template Cast<void>());
-      ap.Wait();
-      REQUIRE(ap->GetReturnCode() == 0);
-      ipc->FreeBuffer(ab);
+      memset(ab.ptr_, mark, kChunk);
+      abufs.push_back(ab);
+      afuts.push_back(cfs.AsyncAppend(ah, kChunk, ab.shm_.template Cast<void>()));
     }
-    const chi::u64 total = kChunk * 3;
+    for (auto &f : afuts) { f.Wait(); REQUIRE(f->GetReturnCode() == 0); }
+    for (auto &ab : abufs) ipc->FreeBuffer(ab);
+    const chi::u64 total = kChunk * kNum;
 
-    // The periodic AppendSequence -> AppendCollect (ManyToOne) -> AppendExecution
-    // pipeline merges asynchronously; poll-read until the ordered concatenation
-    // appears.
+    // Concurrent appends are ordered by (UTC, logical), not submission order, so
+    // we don't pin the order. The pipeline (periodic AppendSequence -> ManyToOne
+    // AppendCollect -> AppendPlan -> AppendExecution) must merge them with no
+    // overlap or corruption: poll-read until the file is exactly kNum back-to-
+    // back kChunk regions, each a single distinct marker, all present once.
     bool matched = false;
     for (int attempt = 0; attempt < 400 && !matched; ++attempt) {
       ctp::ipc::FullPtr<char> rb = ipc->AllocateBuffer(total);
@@ -570,16 +572,26 @@ TEST_CASE("Cfs - filesystem chimod open/write/getattr/read/truncate",
       memset(rb.ptr_, 0, total);
       auto r = cfs.AsyncRead(ah, 0, total, rb.shm_.template Cast<void>());
       r.Wait();
-      if (r->GetReturnCode() == 0 && r->bytes_read_ == total &&
-          memcmp(rb.ptr_, expected.data(), total) == 0) {
-        matched = true;
+      bool ok = (r->GetReturnCode() == 0 && r->bytes_read_ == total);
+      if (ok) {
+        std::set<char> seen;
+        for (int c = 0; c < kNum && ok; ++c) {
+          const char *region = rb.ptr_ + static_cast<size_t>(c) * kChunk;
+          char m = region[0];
+          for (chi::u64 i = 0; i < kChunk; ++i) {
+            if (region[i] != m) { ok = false; break; }
+          }
+          if (ok && m >= 'a' && m < 'a' + kNum) seen.insert(m);
+          else ok = false;
+        }
+        if (ok && seen.size() == static_cast<size_t>(kNum)) matched = true;
       }
       ipc->FreeBuffer(rb);
       if (!matched) {
         std::this_thread::sleep_for(std::chrono::milliseconds(25));
       }
     }
-    REQUIRE(matched);  // appends merged into the file in order
+    REQUIRE(matched);  // all appends merged intact into their own regions
 
     auto acl = cfs.AsyncClose(ah);
     acl.Wait();

--- a/context-runtime/test/unit/cli/test_cfs.cc
+++ b/context-runtime/test/unit/cli/test_cfs.cc
@@ -526,6 +526,57 @@ TEST_CASE("Cfs - filesystem chimod open/write/getattr/read/truncate",
     REQUIRE(ex == 0);  // directory gone
   }
 
+  // ---- Deferred-append pipeline ----
+  // Append three distinguishable chunks; each is placed locally + queued, then
+  // a periodic AppendSequence -> AppendCollect (ManyToOne, sort by UTC/logical)
+  // -> AppendExecution merges them into the file pages in order. The merge is
+  // asynchronous, so poll-read until the concatenation appears.
+  {
+    const std::string apath = "/append_test.bin";
+    auto aop = cfs.AsyncOpen(apath, O_CREAT | O_RDWR, 0644);
+    aop.Wait();
+    REQUIRE(aop->GetReturnCode() == 0);
+    chi::u64 ah = aop->handle_;
+    REQUIRE(ah != 0);
+
+    constexpr chi::u64 kChunk = 4096;
+    const char marks[3] = {'A', 'B', 'C'};
+    std::string expected;
+    for (int c = 0; c < 3; ++c) {
+      ctp::ipc::FullPtr<char> ab = ipc->AllocateBuffer(kChunk);
+      REQUIRE(!ab.IsNull());
+      memset(ab.ptr_, marks[c], kChunk);
+      expected.append(kChunk, marks[c]);
+      auto ap = cfs.AsyncAppend(ah, kChunk, ab.shm_.template Cast<void>());
+      ap.Wait();
+      REQUIRE(ap->GetReturnCode() == 0);
+      ipc->FreeBuffer(ab);
+    }
+    const chi::u64 total = kChunk * 3;
+
+    // The periodic AppendSequence drains + merges asynchronously; poll-read.
+    bool matched = false;
+    for (int attempt = 0; attempt < 200 && !matched; ++attempt) {
+      ctp::ipc::FullPtr<char> rb = ipc->AllocateBuffer(total);
+      REQUIRE(!rb.IsNull());
+      memset(rb.ptr_, 0, total);
+      auto r = cfs.AsyncRead(ah, 0, total, rb.shm_.template Cast<void>());
+      r.Wait();
+      if (r->GetReturnCode() == 0 && r->bytes_read_ == total &&
+          memcmp(rb.ptr_, expected.data(), total) == 0) {
+        matched = true;
+      }
+      ipc->FreeBuffer(rb);
+      if (!matched) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+      }
+    }
+    REQUIRE(matched);  // appends merged into the file in order
+
+    auto acl = cfs.AsyncClose(ah);
+    acl.Wait();
+  }
+
   RunCliTimed({"stop", "--grace-period", "2000"}, 90);
   for (int i = 0; i < 200 && server.IsRunning(); ++i) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/context-runtime/test/unit/cli/test_cfs_rename.cc
+++ b/context-runtime/test/unit/cli/test_cfs_rename.cc
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+/**
+ * Focused rename stress + concurrency tests for the filesystem chimod.
+ *
+ * Rename is the operation the xfstests surfaced as most fragile (issue #597):
+ *   * B1 generic/245 — rename-overwrite ignores destination type/emptiness
+ *     (clobbers a non-empty dir / wrong-type target instead of EEXIST/ENOTEMPTY).
+ *   * B2 generic/035 — renaming OVER an open file strands that file's handle.
+ *   * #596 — overlapping renames could orphan a tag (resolvable upward via the
+ *     name stored in its info, but not forward via the name->id binding).
+ *
+ * The cfs integration test (test_cfs.cc) covers the single-threaded happy path.
+ * This file adds (a) POSIX-semantics checks for rename-overwrite, and (b)
+ * concurrency torture: many renames racing on shared destinations, where the
+ * filesystem Rename's non-atomic "DelTag(dst) then RenameTag(src,dst)" is most
+ * likely to lose data or leave duplicate/orphan bindings.
+ */
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_cte/filesystem/filesystem_client.h>
+
+#include "runtime_server.h"
+#include "simple_test.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+int RunCliTimed(const std::vector<std::string>& args, int timeout_sec) {
+  std::vector<std::string> full;
+  full.push_back(CLIO_RUN_EXE);
+  full.insert(full.end(), args.begin(), args.end());
+  std::vector<char*> argv;
+  for (auto& a : full) argv.push_back(a.data());
+  argv.push_back(nullptr);
+  pid_t pid = fork();
+  if (pid < 0) return -1;
+  if (pid == 0) {
+    int n = open("/dev/null", O_WRONLY);
+    if (n >= 0) { dup2(n, 1); dup2(n, 2); close(n); }
+    execv(argv[0], argv.data());
+    _exit(127);
+  }
+  auto deadline = std::chrono::steady_clock::now() +
+                  std::chrono::seconds(timeout_sec);
+  int status = 0;
+  while (true) {
+    pid_t r = waitpid(pid, &status, WNOHANG);
+    if (r == pid) return WIFEXITED(status) ? WEXITSTATUS(status) : -2;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      kill(pid, SIGKILL); waitpid(pid, &status, 0); return -3;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}
+}  // namespace
+
+TEST_CASE("Cfs - rename POSIX semantics + concurrency", "[cli][cfs][rename]") {
+  constexpr unsigned kPort = 10605;
+  const fs::path work = fs::temp_directory_path() / "cfs_rename_test";
+  fs::remove_all(work);
+  fs::create_directories(work);
+
+  const fs::path yaml = work / "compose.yaml";
+  {
+    std::ofstream f(yaml);
+    f << "compose:\n"
+         "  - mod_name: clio_cte_core\n"
+         "    pool_name: \"cfs_cte\"\n"
+         "    pool_query: local\n"
+         "    pool_id: \"512.0\"\n"
+         "    storage:\n"
+         "      - path: " << (work / "ram_dev").string() << "\n"
+         "        bdev_type: ram\n"
+         "        capacity_limit: 64mb\n"
+         "    dpe:\n"
+         "      dpe_type: random\n"
+         "  - mod_name: clio_cte_filesystem\n"
+         "    pool_name: \"cfs\"\n"
+         "    pool_query: local\n"
+         "    pool_id: \"600.0\"\n"
+         "    next_pool_id: \"512.0\"\n";
+  }
+
+  setenv("CLIO_WAIT_SERVER", "15", 1);
+  setenv("CLIO_BIND_ADDR", "127.0.0.1", 1);
+
+  clio::run::test::RuntimeServer server;
+  REQUIRE(server.Start(kPort));
+  REQUIRE(server.WaitForReady());
+  REQUIRE(RunCliTimed({"compose", "start", yaml.string()}, 60) == 0);
+
+  REQUIRE(chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, false));
+  auto* ipc = CLIO_IPC;
+  REQUIRE(ipc != nullptr);
+
+  clio::cte::filesystem::Client cfs;
+  cfs.Init(chi::PoolId(600, 0));
+
+  // ---- helpers -------------------------------------------------------------
+  // Create a file and fill it with `n` bytes of marker byte `mark`.
+  auto mkfile = [&](const std::string& path, char mark, chi::u64 n) {
+    auto op = cfs.AsyncOpen(path, O_CREAT | O_RDWR, 0644);
+    op.Wait();
+    REQUIRE(op->GetReturnCode() == 0);
+    chi::u64 h = op->handle_;
+    if (n > 0) {
+      ctp::ipc::FullPtr<char> wb = ipc->AllocateBuffer(n);
+      memset(wb.ptr_, mark, n);
+      auto w = cfs.AsyncWrite(h, 0, n, wb.shm_.template Cast<void>());
+      w.Wait();
+      REQUIRE(w->GetReturnCode() == 0);
+      ipc->FreeBuffer(wb);
+    }
+    auto cl = cfs.AsyncClose(h);
+    cl.Wait();
+  };
+
+  auto exists = [&](const std::string& path) -> bool {
+    auto g = cfs.AsyncGetattr(path);
+    g.Wait();
+    return g->GetReturnCode() == 0 && g->exists_ == 1;
+  };
+  auto is_dir = [&](const std::string& path) -> bool {
+    auto g = cfs.AsyncGetattr(path);
+    g.Wait();
+    return g->GetReturnCode() == 0 && g->exists_ == 1 && g->is_dir_ == 1;
+  };
+  auto fsize = [&](const std::string& path) -> chi::u64 {
+    auto g = cfs.AsyncGetattr(path);
+    g.Wait();
+    REQUIRE(g->GetReturnCode() == 0);
+    return g->size_;
+  };
+  // Read the first byte of a file by path (its uniform marker).
+  auto first_byte = [&](const std::string& path) -> int {
+    auto op = cfs.AsyncOpen(path, O_RDWR, 0644);
+    op.Wait();
+    if (op->GetReturnCode() != 0) return -1;
+    chi::u64 h = op->handle_;
+    ctp::ipc::FullPtr<char> rb = ipc->AllocateBuffer(1);
+    rb.ptr_[0] = 0;
+    auto r = cfs.AsyncRead(h, 0, 1, rb.shm_.template Cast<void>());
+    r.Wait();
+    int b = (r->GetReturnCode() == 0 && r->bytes_read_ == 1)
+                ? (unsigned char)rb.ptr_[0] : -1;
+    ipc->FreeBuffer(rb);
+    auto cl = cfs.AsyncClose(h);
+    cl.Wait();
+    return b;
+  };
+  auto rename_rc = [&](const std::string& src, const std::string& dst) -> int {
+    auto mv = cfs.AsyncRename(src, dst);
+    mv.Wait();
+    return (int)mv->GetReturnCode();
+  };
+  // Count direct entries of `dir` whose leaf equals `leaf`, and total entries.
+  auto readdir_count = [&](const std::string& dir, const std::string& full_path)
+      -> std::pair<int, int> {
+    auto rd = cfs.AsyncReaddir(dir);
+    rd.Wait();
+    REQUIRE(rd->GetReturnCode() == 0);
+    int total = 0, matches = 0;
+    for (const auto& e : rd->entries_) {
+      std::string s = e.str();
+      if (s.find(".__clio_dir__") != std::string::npos) continue;  // marker
+      ++total;
+      if (s == full_path) ++matches;
+    }
+    return {total, matches};
+  };
+
+  constexpr chi::u64 kN = 4096;
+
+  // ======================================================================
+  // A. Basic rename correctness (sanity): move keeps data, source vanishes.
+  // ======================================================================
+  {
+    mkfile("/A/src.bin", 'a', kN);
+    REQUIRE(rename_rc("/A/src.bin", "/A/dst.bin") == 0);
+    REQUIRE_FALSE(exists("/A/src.bin"));
+    REQUIRE(exists("/A/dst.bin"));
+    REQUIRE(fsize("/A/dst.bin") == kN);
+    REQUIRE(first_byte("/A/dst.bin") == 'a');
+  }
+
+  // ======================================================================
+  // B1. rename-overwrite POSIX semantics (issue #597 B1, generic/245).
+  // ======================================================================
+  {
+    // file -> existing file: allowed; destination takes the source's content.
+    mkfile("/B/f1.bin", 'x', kN);
+    mkfile("/B/f2.bin", 'y', kN);
+    REQUIRE(rename_rc("/B/f1.bin", "/B/f2.bin") == 0);
+    REQUIRE_FALSE(exists("/B/f1.bin"));
+    REQUIRE(exists("/B/f2.bin"));
+    REQUIRE(first_byte("/B/f2.bin") == 'x');   // overwritten with source data
+
+    // file -> non-empty directory: must fail, and must NOT destroy the dir.
+    mkfile("/B/file.bin", 'm', kN);
+    mkfile("/B/dir/inner.bin", 'n', kN);
+    int rc = rename_rc("/B/file.bin", "/B/dir");
+    REQUIRE(rc != 0);                          // EISDIR / ENOTEMPTY / EEXIST
+    REQUIRE(is_dir("/B/dir"));                  // dir survives
+    REQUIRE(exists("/B/dir/inner.bin"));        // its child survives
+    REQUIRE(exists("/B/file.bin"));             // source untouched
+
+    // directory -> non-empty directory: must fail (ENOTEMPTY), both intact.
+    mkfile("/B/d1/c1.bin", 'p', kN);
+    mkfile("/B/d2/c2.bin", 'q', kN);
+    int rc2 = rename_rc("/B/d1", "/B/d2");
+    REQUIRE(rc2 != 0);
+    REQUIRE(is_dir("/B/d1"));
+    REQUIRE(exists("/B/d1/c1.bin"));
+    REQUIRE(is_dir("/B/d2"));
+    REQUIRE(exists("/B/d2/c2.bin"));
+  }
+
+  // ======================================================================
+  // B2. rename a file that is currently OPEN (move, not overwrite).
+  // The tag keeps its TagId across rename, so the open handle must stay
+  // valid and keep reading the same bytes from the new path.
+  // ======================================================================
+  {
+    mkfile("/C/open.bin", 'o', kN);
+    auto op = cfs.AsyncOpen("/C/open.bin", O_RDWR, 0644);
+    op.Wait();
+    REQUIRE(op->GetReturnCode() == 0);
+    chi::u64 h = op->handle_;
+
+    REQUIRE(rename_rc("/C/open.bin", "/C/moved.bin") == 0);
+    REQUIRE_FALSE(exists("/C/open.bin"));
+    REQUIRE(exists("/C/moved.bin"));
+
+    // The still-open handle must read the original content.
+    ctp::ipc::FullPtr<char> rb = ipc->AllocateBuffer(kN);
+    memset(rb.ptr_, 0, kN);
+    auto r = cfs.AsyncRead(h, 0, kN, rb.shm_.template Cast<void>());
+    r.Wait();
+    REQUIRE(r->GetReturnCode() == 0);
+    REQUIRE(r->bytes_read_ == kN);
+    REQUIRE((unsigned char)rb.ptr_[0] == 'o');
+    ipc->FreeBuffer(rb);
+    auto cl = cfs.AsyncClose(h);
+    cl.Wait();
+  }
+
+  // ======================================================================
+  // D1. Concurrent INDEPENDENT renames: N files each moved to its own
+  // destination at once. All must land intact; no source may remain.
+  // ======================================================================
+  {
+    constexpr int kFiles = 16;
+    for (int i = 0; i < kFiles; ++i) {
+      mkfile("/D1/s" + std::to_string(i) + ".bin",
+             (char)('A' + i), kN);
+    }
+    std::vector<chi::Future<clio::cte::filesystem::RenameTask>> futs;
+    futs.reserve(kFiles);
+    for (int i = 0; i < kFiles; ++i) {
+      futs.push_back(cfs.AsyncRename("/D1/s" + std::to_string(i) + ".bin",
+                                     "/D1/d" + std::to_string(i) + ".bin"));
+    }
+    for (auto& f : futs) { f.Wait(); REQUIRE(f->GetReturnCode() == 0); }
+    for (int i = 0; i < kFiles; ++i) {
+      REQUIRE_FALSE(exists("/D1/s" + std::to_string(i) + ".bin"));
+      REQUIRE(exists("/D1/d" + std::to_string(i) + ".bin"));
+      REQUIRE(first_byte("/D1/d" + std::to_string(i) + ".bin") == ('A' + i));
+    }
+  }
+
+  // ======================================================================
+  // D2. Concurrent renames to the SAME destination (N -> 1). Each rename is
+  // atomic, so afterward EXACTLY ONE file named dst must exist, holding one
+  // source's data, with every source gone and NO orphan/duplicate binding.
+  // This is where the non-atomic DelTag(dst)+RenameTag is most dangerous:
+  // a losing rename can leave its tag resolvable upward (readdir lists it)
+  // but not forward, i.e. a duplicate "dst" or a leaked tag.
+  // ======================================================================
+  {
+    constexpr int kSrc = 12;
+    for (int i = 0; i < kSrc; ++i) {
+      mkfile("/D2/src" + std::to_string(i) + ".bin",
+             (char)('0' + i), kN);
+    }
+    std::vector<chi::Future<clio::cte::filesystem::RenameTask>> futs;
+    futs.reserve(kSrc);
+    for (int i = 0; i < kSrc; ++i) {
+      futs.push_back(cfs.AsyncRename("/D2/src" + std::to_string(i) + ".bin",
+                                     "/D2/dst.bin"));
+    }
+    for (auto& f : futs) { f.Wait(); }  // return codes may vary; check state
+
+    // Exactly one destination, readable, with some source's marker.
+    REQUIRE(exists("/D2/dst.bin"));
+    int b = first_byte("/D2/dst.bin");
+    REQUIRE(b >= '0');
+    REQUIRE(b < '0' + kSrc);
+    // Every source name must be gone.
+    for (int i = 0; i < kSrc; ++i) {
+      REQUIRE_FALSE(exists("/D2/src" + std::to_string(i) + ".bin"));
+    }
+    // readdir must show dst exactly once and nothing else: no duplicate
+    // entries from an orphaned loser tag, no leftover sources.
+    auto [total, matches] = readdir_count("/D2", "/D2/dst.bin");
+    REQUIRE(matches == 1);
+    REQUIRE(total == 1);
+  }
+
+  // ======================================================================
+  // D3. Concurrent rename racing create on the same name. A renamer moves
+  // X -> N while a creator opens N (O_CREAT). Afterward N must resolve to a
+  // SINGLE tag (readdir shows it once); X must be gone.
+  // ======================================================================
+  {
+    mkfile("/D3/x.bin", 'z', kN);
+    auto mv = cfs.AsyncRename("/D3/x.bin", "/D3/n.bin");
+    auto cr = cfs.AsyncOpen("/D3/n.bin", O_CREAT | O_RDWR, 0644);
+    mv.Wait();
+    cr.Wait();
+    if (cr->GetReturnCode() == 0) {
+      auto cl = cfs.AsyncClose(cr->handle_);
+      cl.Wait();
+    }
+    REQUIRE_FALSE(exists("/D3/x.bin"));
+    REQUIRE(exists("/D3/n.bin"));
+    auto [total, matches] = readdir_count("/D3", "/D3/n.bin");
+    REQUIRE(matches == 1);   // exactly one binding for n.bin (no duplicate)
+    REQUIRE(total == 1);
+  }
+
+  // ======================================================================
+  // D4. Rename racing readdir: while N files are concurrently renamed from
+  // their "a" name to their "b" name, a flurry of readdir calls runs in the
+  // same wave. Each rebind is atomic (issue #596), so EVERY readdir must list
+  // exactly N files — a file may show under its old or new name, but must
+  // never disappear (the "resolvable upward but not forward" hazard) nor be
+  // listed twice. Repeated over several rounds to widen the race window.
+  // ======================================================================
+  {
+    constexpr int kFiles = 12;
+    constexpr int kRounds = 6;
+    for (int i = 0; i < kFiles; ++i) {
+      mkfile("/D4/a" + std::to_string(i) + ".bin", (char)('a' + i), kN);
+    }
+    for (int round = 0; round < kRounds; ++round) {
+      const std::string from = (round % 2 == 0) ? "a" : "b";
+      const std::string to = (round % 2 == 0) ? "b" : "a";
+      std::vector<chi::Future<clio::cte::filesystem::RenameTask>> rmv;
+      std::vector<chi::Future<clio::cte::filesystem::ReaddirTask>> rdd;
+      rmv.reserve(kFiles);
+      for (int i = 0; i < kFiles; ++i) {
+        rmv.push_back(cfs.AsyncRename("/D4/" + from + std::to_string(i) + ".bin",
+                                      "/D4/" + to + std::to_string(i) + ".bin"));
+      }
+      for (int k = 0; k < kFiles; ++k) rdd.push_back(cfs.AsyncReaddir("/D4"));
+      for (auto &f : rmv) { f.Wait(); REQUIRE(f->GetReturnCode() == 0); }
+      // Every concurrent listing must have seen all kFiles (never fewer).
+      for (auto &f : rdd) {
+        f.Wait();
+        REQUIRE(f->GetReturnCode() == 0);
+        int n = 0;
+        for (const auto &e : f->entries_) {
+          if (e.str().find(".__clio_dir__") == std::string::npos) ++n;
+        }
+        REQUIRE(n == kFiles);
+      }
+    }
+    // Final settle: all kFiles present under their round-parity name, intact.
+    const std::string fin = (kRounds % 2 == 0) ? "a" : "b";
+    for (int i = 0; i < kFiles; ++i) {
+      REQUIRE(exists("/D4/" + fin + std::to_string(i) + ".bin"));
+      REQUIRE(first_byte("/D4/" + fin + std::to_string(i) + ".bin") ==
+              ('a' + i));
+    }
+  }
+
+  RunCliTimed({"stop", "--grace-period", "2000"}, 90);
+  for (int i = 0; i < 200 && server.IsRunning(); ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  server.Stop();
+  fs::remove_all(work);
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-transfer-engine/adapter/libfuse/fuse_cte.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.cc
@@ -90,6 +90,14 @@ static void *cte_fuse_init(struct fuse_conn_info *conn,
   (void)conn;
   cfg->use_ino = 0;
   cfg->direct_io = 1;
+  // Disable the kernel attribute/entry caches. Metadata (size, and especially
+  // st_nlink for hard links) can change without this FUSE process being the one
+  // that triggered the change, and there is no upcall to invalidate the cache.
+  // Without this, e.g. `ln a b; stat a` returns a's stale cached nlink. Every
+  // getattr/lookup goes to the chimod, which is the source of truth.
+  cfg->attr_timeout = 0;
+  cfg->entry_timeout = 0;
+  cfg->negative_timeout = 0;
 
   bool success = chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
   if (!success) {
@@ -149,7 +157,18 @@ static int cte_fuse_getattr(const char *path, struct stat *stbuf,
     stbuf->st_nlink = 2;
   } else {
     stbuf->st_mode = S_IFREG | 0644;
-    stbuf->st_nlink = 1;
+    // POSIX link count = canonical name (1) + tag-level hard-link aliases.
+    // Ask the CTE core how many extra names are bound to this tag.
+    nlink_t nlink = 1;
+    auto *cte = CLIO_CTE_CLIENT;
+    if (cte != nullptr) {
+      auto na = cte->AsyncGetNumAliases(p);
+      na.Wait();
+      if (na->return_code_ == 0 && na->found_) {
+        nlink = static_cast<nlink_t>(na->num_aliases_) + 1;
+      }
+    }
+    stbuf->st_nlink = nlink;
     stbuf->st_size = static_cast<off_t>(t->size_);
   }
   return 0;

--- a/context-transfer-engine/adapter/libfuse/fuse_cte.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.cc
@@ -45,6 +45,7 @@
                                   // apptainer --fusemount fd-injection path)
 #include <sys/uio.h>              // struct iovec, writev
 #include <sys/mount.h>            // mount syscall
+#include <sys/statvfs.h>          // struct statvfs (statfs op)
 #include <unistd.h>               // read, getuid, getgid
 #include <cerrno>                 // errno
 #include <cstdio>                 // snprintf, fprintf
@@ -390,6 +391,32 @@ static int cte_fuse_rename(const char *from, const char *to,
 // Main
 // ============================================================================
 
+// Report filesystem statistics. The clio filesystem is backed by elastic CTE
+// storage rather than a fixed device, so we advertise a large, mostly-free
+// synthetic capacity. Without this, statfs returns all zeros and a 0-block
+// filesystem is hidden by `df` (which lists no path) — that in turn breaks
+// tools that probe free space and xfstests' mount detection (its `_fs_type`
+// runs `df` with no path and sees nothing, so `./check` thinks the fs is not
+// mounted and tries to remount it).
+static int cte_fuse_statfs(const char *path, struct statvfs *stbuf) {
+  (void)path;
+  std::memset(stbuf, 0, sizeof(*stbuf));
+  constexpr fsblkcnt_t kBlockSize = 4096;
+  constexpr fsblkcnt_t kTotalBlocks =
+      (static_cast<fsblkcnt_t>(1) << 40) / kBlockSize;  // ~1 TiB
+  constexpr fsfilcnt_t kTotalInodes = static_cast<fsfilcnt_t>(1) << 20;
+  stbuf->f_bsize = kBlockSize;
+  stbuf->f_frsize = kBlockSize;
+  stbuf->f_blocks = kTotalBlocks;
+  stbuf->f_bfree = kTotalBlocks;
+  stbuf->f_bavail = kTotalBlocks;
+  stbuf->f_files = kTotalInodes;
+  stbuf->f_ffree = kTotalInodes;
+  stbuf->f_favail = kTotalInodes;
+  stbuf->f_namemax = 255;
+  return 0;
+}
+
 static const struct fuse_operations cte_fuse_ops = {
     .getattr = cte_fuse_getattr,
     .mkdir = cte_fuse_mkdir,
@@ -401,6 +428,7 @@ static const struct fuse_operations cte_fuse_ops = {
     .open = cte_fuse_open,
     .read = cte_fuse_read,
     .write = cte_fuse_write,
+    .statfs = cte_fuse_statfs,
     .flush = cte_fuse_flush,
     .release = cte_fuse_release,
     .fsync = cte_fuse_fsync,

--- a/context-transfer-engine/adapter/libfuse/fuse_cte.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.cc
@@ -53,6 +53,7 @@
 
 #include "clio_runtime/clio_runtime.h"
 #include "clio_cte/core/content_transfer_engine.h"
+#include "clio_cte/core/core_client.h"  // CLIO_CTE_CLIENT + GetMaxCapacity
 #include "clio_cte/filesystem/filesystem_client.h"
 
 using namespace clio::cae::fuse;
@@ -100,6 +101,11 @@ static void *cte_fuse_init(struct fuse_conn_info *conn,
   if (!clio::cte::filesystem::CLIO_CFS_CLIENT_INIT()) {
     fprintf(stderr, "ERROR: filesystem client init failed\n");
     return nullptr;
+  }
+  // Bind the CTE core client to the same clio_cte_core pool (idempotent) so
+  // statfs can query real capacity via GetMaxCapacity.
+  if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
+    fprintf(stderr, "WARNING: CTE core client init failed; statfs capacity=0\n");
   }
   return nullptr;
 }
@@ -391,28 +397,40 @@ static int cte_fuse_rename(const char *from, const char *to,
 // Main
 // ============================================================================
 
-// Report filesystem statistics. The clio filesystem is backed by elastic CTE
-// storage rather than a fixed device, so we advertise a large, mostly-free
-// synthetic capacity. Without this, statfs returns all zeros and a 0-block
-// filesystem is hidden by `df` (which lists no path) — that in turn breaks
-// tools that probe free space and xfstests' mount detection (its `_fs_type`
-// runs `df` with no path and sees nothing, so `./check` thinks the fs is not
-// mounted and tries to remount it).
+// Report filesystem statistics. Total capacity is the real cluster-wide
+// storage capacity, obtained from the CTE: GetMaxCapacity sums the registered
+// targets' capacity per node, and a Broadcast aggregates that across the
+// cluster (the task's AggregateOut sums per-node results). Reporting a non-zero
+// capacity also matters operationally: a 0-block fs is hidden by `df` (which
+// lists no path), which breaks tools that probe free space and xfstests' mount
+// detection.
 static int cte_fuse_statfs(const char *path, struct statvfs *stbuf) {
   (void)path;
   std::memset(stbuf, 0, sizeof(*stbuf));
   constexpr fsblkcnt_t kBlockSize = 4096;
-  constexpr fsblkcnt_t kTotalBlocks =
-      (static_cast<fsblkcnt_t>(1) << 40) / kBlockSize;  // ~1 TiB
-  constexpr fsfilcnt_t kTotalInodes = static_cast<fsfilcnt_t>(1) << 20;
+
+  chi::u64 capacity_bytes = 0;
+  auto *cte = CLIO_CTE_CLIENT;
+  if (cte != nullptr) {
+    // Broadcast: total capacity across the whole cluster.
+    auto t = cte->AsyncGetMaxCapacity(chi::PoolQuery::Broadcast());
+    t.Wait();
+    if (t->return_code_ == 0) {
+      capacity_bytes = t->max_capacity_;
+    }
+  }
+  fsblkcnt_t total_blocks = capacity_bytes / kBlockSize;
+
   stbuf->f_bsize = kBlockSize;
   stbuf->f_frsize = kBlockSize;
-  stbuf->f_blocks = kTotalBlocks;
-  stbuf->f_bfree = kTotalBlocks;
-  stbuf->f_bavail = kTotalBlocks;
-  stbuf->f_files = kTotalInodes;
-  stbuf->f_ffree = kTotalInodes;
-  stbuf->f_favail = kTotalInodes;
+  stbuf->f_blocks = total_blocks;
+  // Free-space accounting (used vs. free) is a follow-up; report capacity as
+  // available so writes aren't gated and df shows the real total size.
+  stbuf->f_bfree = total_blocks;
+  stbuf->f_bavail = total_blocks;
+  stbuf->f_files = static_cast<fsfilcnt_t>(1) << 20;
+  stbuf->f_ffree = static_cast<fsfilcnt_t>(1) << 20;
+  stbuf->f_favail = static_cast<fsfilcnt_t>(1) << 20;
   stbuf->f_namemax = 255;
   return 0;
 }

--- a/context-transfer-engine/adapter/libfuse/fuse_cte.cc
+++ b/context-transfer-engine/adapter/libfuse/fuse_cte.cc
@@ -53,7 +53,7 @@
 
 #include "clio_runtime/clio_runtime.h"
 #include "clio_cte/core/content_transfer_engine.h"
-#include "clio_cte/core/core_client.h"  // CLIO_CTE_CLIENT + GetMaxCapacity
+#include "clio_cte/core/core_client.h"  // CLIO_CTE_CLIENT + GetCapacity
 #include "clio_cte/filesystem/filesystem_client.h"
 
 using namespace clio::cae::fuse;
@@ -103,7 +103,7 @@ static void *cte_fuse_init(struct fuse_conn_info *conn,
     return nullptr;
   }
   // Bind the CTE core client to the same clio_cte_core pool (idempotent) so
-  // statfs can query real capacity via GetMaxCapacity.
+  // statfs can query real capacity via GetCapacity.
   if (!clio::cte::core::CLIO_CTE_CLIENT_INIT()) {
     fprintf(stderr, "WARNING: CTE core client init failed; statfs capacity=0\n");
   }
@@ -397,37 +397,40 @@ static int cte_fuse_rename(const char *from, const char *to,
 // Main
 // ============================================================================
 
-// Report filesystem statistics. Total capacity is the real cluster-wide
-// storage capacity, obtained from the CTE: GetMaxCapacity sums the registered
-// targets' capacity per node, and a Broadcast aggregates that across the
-// cluster (the task's AggregateOut sums per-node results). Reporting a non-zero
-// capacity also matters operationally: a 0-block fs is hidden by `df` (which
-// lists no path), which breaks tools that probe free space and xfstests' mount
-// detection.
+// Report filesystem statistics. Total and remaining capacity are the real
+// cluster-wide values, obtained from the CTE: GetCapacity sums the registered
+// targets' total and remaining capacity per node, and a Broadcast aggregates
+// that across the cluster (the task's AggregateOut sums per-node results).
+// Reporting a non-zero capacity also matters operationally: a 0-block fs is
+// hidden by `df` (which lists no path), which breaks tools that probe free
+// space and xfstests' mount detection.
 static int cte_fuse_statfs(const char *path, struct statvfs *stbuf) {
   (void)path;
   std::memset(stbuf, 0, sizeof(*stbuf));
   constexpr fsblkcnt_t kBlockSize = 4096;
 
-  chi::u64 capacity_bytes = 0;
+  chi::u64 total_bytes = 0;
+  chi::u64 remaining_bytes = 0;
   auto *cte = CLIO_CTE_CLIENT;
   if (cte != nullptr) {
-    // Broadcast: total capacity across the whole cluster.
-    auto t = cte->AsyncGetMaxCapacity(chi::PoolQuery::Broadcast());
+    // Broadcast: total + remaining capacity across the whole cluster.
+    auto t = cte->AsyncGetCapacity(chi::PoolQuery::Broadcast());
     t.Wait();
     if (t->return_code_ == 0) {
-      capacity_bytes = t->max_capacity_;
+      total_bytes = t->total_capacity_;
+      remaining_bytes = t->remaining_capacity_;
     }
   }
-  fsblkcnt_t total_blocks = capacity_bytes / kBlockSize;
+  fsblkcnt_t total_blocks = total_bytes / kBlockSize;
+  fsblkcnt_t free_blocks = remaining_bytes / kBlockSize;
 
   stbuf->f_bsize = kBlockSize;
   stbuf->f_frsize = kBlockSize;
   stbuf->f_blocks = total_blocks;
-  // Free-space accounting (used vs. free) is a follow-up; report capacity as
-  // available so writes aren't gated and df shows the real total size.
-  stbuf->f_bfree = total_blocks;
-  stbuf->f_bavail = total_blocks;
+  // Report real remaining space as both free and available (no reservation
+  // distinction), so df shows used = total - remaining.
+  stbuf->f_bfree = free_blocks;
+  stbuf->f_bavail = free_blocks;
   stbuf->f_files = static_cast<fsfilcnt_t>(1) << 20;
   stbuf->f_ffree = static_cast<fsfilcnt_t>(1) << 20;
   stbuf->f_favail = static_cast<fsfilcnt_t>(1) << 20;

--- a/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
+++ b/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
@@ -46,8 +46,9 @@ GLOBAL_CROSS_CONST chi::u32 kRenameTag = 38;
 GLOBAL_CROSS_CONST chi::u32 kGetOrCreateTagAlias = 39;
 GLOBAL_CROSS_CONST chi::u32 kGetTagName = 40;
 GLOBAL_CROSS_CONST chi::u32 kGetCapacity = 41;
+GLOBAL_CROSS_CONST chi::u32 kGetNumAliases = 42;
 
-GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 42;
+GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 43;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -83,6 +84,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[39] = "GetOrCreateTagAlias";
     v[40] = "GetTagName";
     v[41] = "GetCapacity";
+    v[42] = "GetNumAliases";
     return v;
   }();
   return names;

--- a/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
+++ b/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
@@ -45,8 +45,9 @@ GLOBAL_CROSS_CONST chi::u32 kTruncateBlob = 37;
 GLOBAL_CROSS_CONST chi::u32 kRenameTag = 38;
 GLOBAL_CROSS_CONST chi::u32 kGetOrCreateTagAlias = 39;
 GLOBAL_CROSS_CONST chi::u32 kGetTagName = 40;
+GLOBAL_CROSS_CONST chi::u32 kGetMaxCapacity = 41;
 
-GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 41;
+GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 42;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -81,6 +82,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[38] = "RenameTag";
     v[39] = "GetOrCreateTagAlias";
     v[40] = "GetTagName";
+    v[41] = "GetMaxCapacity";
     return v;
   }();
   return names;

--- a/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
+++ b/context-transfer-engine/core/include/clio_cte/core/autogen/core_methods.h
@@ -45,7 +45,7 @@ GLOBAL_CROSS_CONST chi::u32 kTruncateBlob = 37;
 GLOBAL_CROSS_CONST chi::u32 kRenameTag = 38;
 GLOBAL_CROSS_CONST chi::u32 kGetOrCreateTagAlias = 39;
 GLOBAL_CROSS_CONST chi::u32 kGetTagName = 40;
-GLOBAL_CROSS_CONST chi::u32 kGetMaxCapacity = 41;
+GLOBAL_CROSS_CONST chi::u32 kGetCapacity = 41;
 
 GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 42;
 
@@ -82,7 +82,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[38] = "RenameTag";
     v[39] = "GetOrCreateTagAlias";
     v[40] = "GetTagName";
-    v[41] = "GetMaxCapacity";
+    v[41] = "GetCapacity";
     return v;
   }();
   return names;

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -506,6 +506,36 @@ class Client : public chi::ContainerClient {
   }
 
   /**
+   * Get the number of extra names (tag-level hard links) bound to a tag, by
+   * path/name. Excludes the canonical name, so the POSIX link count is
+   * num_aliases_ + 1. found_ is 1 if the tag exists.
+   * @param tag_name Tag name / absolute path.
+   * @param pool_query Broadcast() finds the tag wherever it lives; Local() if
+   *        the caller knows the tag is on this node. Default Local.
+   */
+  chi::Future<GetNumAliasesTask> AsyncGetNumAliases(
+      const std::string &tag_name,
+      const chi::PoolQuery &pool_query = chi::PoolQuery::Local()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+    auto task = ipc_manager->NewTask<GetNumAliasesTask>(
+        chi::CreateTaskId(), pool_id_, pool_query, tag_name, TagId::GetNull());
+    return ipc_manager->Send(task);
+  }
+
+  /**
+   * Get the number of extra names bound to a tag, by id. See the by-name
+   * overload above for the link-count semantics.
+   */
+  chi::Future<GetNumAliasesTask> AsyncGetNumAliases(
+      const TagId &tag_id,
+      const chi::PoolQuery &pool_query = chi::PoolQuery::Local()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+    auto task = ipc_manager->NewTask<GetNumAliasesTask>(
+        chi::CreateTaskId(), pool_id_, pool_query, std::string(), tag_id);
+    return ipc_manager->Send(task);
+  }
+
+  /**
    * Asynchronous poll telemetry log - returns immediately
    * @param minimum_logical_time Minimum logical time filter
    * @param pool_query Pool query for task routing (default: Dynamic)

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -493,6 +493,19 @@ class Client : public chi::ContainerClient {
   }
 
   /**
+   * Get max (total) storage capacity in bytes.
+   * @param pool_query Local() sums this node's targets; Broadcast() sums the
+   *        whole cluster (AggregateOut adds per-node results). Default Local.
+   */
+  chi::Future<GetMaxCapacityTask> AsyncGetMaxCapacity(
+      const chi::PoolQuery &pool_query = chi::PoolQuery::Local()) {
+    auto *ipc_manager = CLIO_CPU_IPC;
+    auto task = ipc_manager->NewTask<GetMaxCapacityTask>(
+        chi::CreateTaskId(), pool_id_, pool_query);
+    return ipc_manager->Send(task);
+  }
+
+  /**
    * Asynchronous poll telemetry log - returns immediately
    * @param minimum_logical_time Minimum logical time filter
    * @param pool_query Pool query for task routing (default: Dynamic)

--- a/context-transfer-engine/core/include/clio_cte/core/core_client.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_client.h
@@ -497,10 +497,10 @@ class Client : public chi::ContainerClient {
    * @param pool_query Local() sums this node's targets; Broadcast() sums the
    *        whole cluster (AggregateOut adds per-node results). Default Local.
    */
-  chi::Future<GetMaxCapacityTask> AsyncGetMaxCapacity(
+  chi::Future<GetCapacityTask> AsyncGetCapacity(
       const chi::PoolQuery &pool_query = chi::PoolQuery::Local()) {
     auto *ipc_manager = CLIO_CPU_IPC;
-    auto task = ipc_manager->NewTask<GetMaxCapacityTask>(
+    auto task = ipc_manager->NewTask<GetCapacityTask>(
         chi::CreateTaskId(), pool_id_, pool_query);
     return ipc_manager->Send(task);
   }

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -205,6 +205,15 @@ public:
   chi::TaskResume GetCapacity(ctp::ipc::FullPtr<GetCapacityTask> task, chi::RunContext &ctx);
 
   /**
+   * GetNumAliases (Method::kGetNumAliases) - number of extra names (tag-level
+   * hard links) bound to a tag, by name or id. Excludes the canonical name, so
+   * the POSIX link count is num_aliases_ + 1. Broadcast op; the container that
+   * owns the tag answers.
+   */
+  chi::TaskResume GetNumAliases(ctp::ipc::FullPtr<GetNumAliasesTask> task,
+                                chi::RunContext &ctx);
+
+  /**
    * Schedule a task by resolving Dynamic pool queries.
    */
   chi::PoolQuery ScheduleTask(const ctp::ipc::FullPtr<chi::Task> &task) override;

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -199,6 +199,12 @@ public:
   chi::TaskResume GetTagSize(ctp::ipc::FullPtr<GetTagSizeTask> task, chi::RunContext &ctx);
 
   /**
+   * Get max (total) capacity — sum of max_capacity_ over targets registered on
+   * this node. Broadcast to sum across the cluster (AggregateOut adds replicas).
+   */
+  chi::TaskResume GetMaxCapacity(ctp::ipc::FullPtr<GetMaxCapacityTask> task, chi::RunContext &ctx);
+
+  /**
    * Schedule a task by resolving Dynamic pool queries.
    */
   chi::PoolQuery ScheduleTask(const ctp::ipc::FullPtr<chi::Task> &task) override;

--- a/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_runtime.h
@@ -202,7 +202,7 @@ public:
    * Get max (total) capacity — sum of max_capacity_ over targets registered on
    * this node. Broadcast to sum across the cluster (AggregateOut adds replicas).
    */
-  chi::TaskResume GetMaxCapacity(ctp::ipc::FullPtr<GetMaxCapacityTask> task, chi::RunContext &ctx);
+  chi::TaskResume GetCapacity(ctp::ipc::FullPtr<GetCapacityTask> task, chi::RunContext &ctx);
 
   /**
    * Schedule a task by resolving Dynamic pool queries.

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -2009,6 +2009,79 @@ struct GetCapacityTask : public chi::Task {
 };
 
 /**
+ * GetNumAliases task - number of extra names (tag-level hard links) bound to a
+ * tag, identified by name or id. The canonical name is NOT counted, so a file
+ * with no hard links returns 0; the POSIX link count is num_aliases_ + 1.
+ *
+ * The tag's metadata (and its aliases_ list) lives on a single container, so
+ * this is a Broadcast-safe op: AggregateOut keeps the answer from whichever
+ * replica located the tag (mirrors GetTagName).
+ */
+struct GetNumAliasesTask : public chi::Task {
+  IN chi::priv::string tag_name_;  // Tag name/path (empty => use tag_id_)
+  IN TagId tag_id_;                // Tag id (used when tag_name_ is empty)
+  OUT chi::u32 num_aliases_;       // # of extra names bound to the tag
+  OUT chi::u32 found_;             // 1 if the tag's metadata was located
+
+  // SHM constructor
+  GetNumAliasesTask()
+      : chi::Task(),
+        tag_name_(CLIO_PRIV_ALLOC),
+        tag_id_(TagId::GetNull()),
+        num_aliases_(0),
+        found_(0) {}
+
+  // Emplace constructor
+  CTP_CROSS_FUN explicit GetNumAliasesTask(const chi::TaskId &task_id,
+                                           const chi::PoolId &pool_id,
+                                           const chi::PoolQuery &pool_query,
+                                           const std::string &tag_name,
+                                           const TagId &tag_id)
+      : chi::Task(task_id, pool_id, pool_query, Method::kGetNumAliases),
+        tag_name_(CLIO_PRIV_ALLOC, tag_name),
+        tag_id_(tag_id),
+        num_aliases_(0),
+        found_(0) {
+    task_id_ = task_id;
+    pool_id_ = pool_id;
+    method_ = Method::kGetNumAliases;
+    task_flags_.Clear();
+    pool_query_ = pool_query;
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeIn(Archive &ar) {
+    Task::SerializeIn(ar);
+    ar(tag_name_, tag_id_);
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeOut(Archive &ar) {
+    Task::SerializeOut(ar);
+    ar(num_aliases_, found_);
+  }
+
+  void Copy(const ctp::ipc::FullPtr<GetNumAliasesTask> &other) {
+    Task::Copy(other.template Cast<Task>());
+    tag_name_ = other->tag_name_;
+    tag_id_ = other->tag_id_;
+    num_aliases_ = other->num_aliases_;
+    found_ = other->found_;
+  }
+
+  // Broadcast aggregation: keep the answer from whichever container owns the
+  // tag (the one that set found_).
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
+    auto other = other_base.template Cast<GetNumAliasesTask>();
+    if (other->found_ && !found_) {
+      found_ = 1;
+      num_aliases_ = other->num_aliases_;
+    }
+  }
+};
+
+/**
  * PollTelemetryLog task - Poll telemetry log with minimum logical time filter
  */
 struct PollTelemetryLogTask : public chi::Task {

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -217,6 +217,7 @@ struct TargetInfo {
   chi::u64 ops_written_;
   float target_score_;        // Target score (0-1, normalized log bandwidth)
   chi::u64 remaining_space_;  // Remaining allocatable space in bytes
+  chi::u64 max_capacity_;     // Total (max) capacity in bytes, fixed at register
   clio::run::bdev::PerfMetrics perf_metrics_;  // Performance metrics from bdev
   clio::run::bdev::PersistenceLevel persistence_level_;
   // Underlying bdev type, captured at RegisterTarget time. Used by the
@@ -233,6 +234,7 @@ struct TargetInfo {
         ops_written_(0),
         target_score_(0.0f),
         remaining_space_(0),
+        max_capacity_(0),
         persistence_level_(clio::run::bdev::PersistenceLevel::kVolatile),
         bdev_type_(clio::run::bdev::BdevType::kFile) {}
 
@@ -246,6 +248,7 @@ struct TargetInfo {
         ops_written_(0),
         target_score_(0.0f),
         remaining_space_(0),
+        max_capacity_(0),
         persistence_level_(clio::run::bdev::PersistenceLevel::kVolatile) {}
 #endif
 
@@ -260,6 +263,7 @@ struct TargetInfo {
         ops_written_(other.ops_written_),
         target_score_(other.target_score_),
         remaining_space_(other.remaining_space_),
+        max_capacity_(other.max_capacity_),
         perf_metrics_(other.perf_metrics_),
         persistence_level_(other.persistence_level_),
         bdev_type_(other.bdev_type_) {}
@@ -276,6 +280,7 @@ struct TargetInfo {
       ops_written_ = other.ops_written_;
       target_score_ = other.target_score_;
       remaining_space_ = other.remaining_space_;
+      max_capacity_ = other.max_capacity_;
       perf_metrics_ = other.perf_metrics_;
       persistence_level_ = other.persistence_level_;
       bdev_type_ = other.bdev_type_;
@@ -1941,6 +1946,58 @@ struct GetTagSizeTask : public chi::Task {
     Task::AggregateOut(other_base);
     auto replica = other_base.template Cast<GetTagSizeTask>();
     tag_size_ += replica->tag_size_;
+  }
+};
+
+/**
+ * GetMaxCapacity task - total (max) storage capacity.
+ *
+ * The handler sums max_capacity_ over the targets registered on this node, so a
+ * Local query returns this node's capacity. Because AggregateOut sums across
+ * replicas, a Broadcast query returns the whole cluster's capacity.
+ */
+struct GetMaxCapacityTask : public chi::Task {
+  OUT chi::u64 max_capacity_;  // Summed capacity in bytes
+
+  // SHM constructor
+  GetMaxCapacityTask() : chi::Task(), max_capacity_(0) {}
+
+  // Emplace constructor
+  CTP_CROSS_FUN explicit GetMaxCapacityTask(const chi::TaskId &task_id,
+                                            const chi::PoolId &pool_id,
+                                            const chi::PoolQuery &pool_query)
+      : chi::Task(task_id, pool_id, pool_query, Method::kGetMaxCapacity),
+        max_capacity_(0) {
+    task_id_ = task_id;
+    pool_id_ = pool_id;
+    method_ = Method::kGetMaxCapacity;
+    task_flags_.Clear();
+    pool_query_ = pool_query;
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeIn(Archive &ar) {
+    Task::SerializeIn(ar);
+  }
+
+  template <typename Archive>
+  CTP_CROSS_FUN void SerializeOut(Archive &ar) {
+    Task::SerializeOut(ar);
+    ar(max_capacity_);
+  }
+
+  void Copy(const ctp::ipc::FullPtr<GetMaxCapacityTask> &other) {
+    Task::Copy(other.template Cast<Task>());
+    max_capacity_ = other->max_capacity_;
+  }
+
+  /**
+   * AggregateOut: sum capacity from each node so a Broadcast yields the total
+   * cluster capacity.
+   */
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
+    max_capacity_ += other_base.template Cast<GetMaxCapacityTask>()->max_capacity_;
   }
 };
 

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -1598,8 +1598,8 @@ struct TruncateBlobTask : public chi::Task {
     new_size_ = other->new_size_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<TruncateBlobTask>());
   }
 };
@@ -1736,8 +1736,8 @@ struct RenameTagTask : public chi::Task {
     new_name_ = other->new_name_;
   }
 
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     Copy(other_base.template Cast<RenameTagTask>());
   }
 };
@@ -1801,8 +1801,8 @@ struct GetOrCreateTagAliasTask : public chi::Task {
 
   // Broadcast aggregation: the alias exists if ANY container confirmed the
   // target, and the resolved id is whichever non-null id a replica reported.
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<GetOrCreateTagAliasTask>();
     if (other->found_) {
       found_ = 1;
@@ -1870,8 +1870,8 @@ struct GetTagNameTask : public chi::Task {
 
   // Broadcast aggregation: keep the answer from whichever container owns the
   // tag (the one that set found_ and a non-empty resolved name).
-  void Aggregate(const ctp::ipc::FullPtr<chi::Task> &other_base) {
-    Task::Aggregate(other_base);
+  void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
+    Task::AggregateOut(other_base);
     auto other = other_base.template Cast<GetTagNameTask>();
     if (other->found_ && !found_) {
       found_ = 1;

--- a/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
+++ b/context-transfer-engine/core/include/clio_cte/core/core_tasks.h
@@ -1950,27 +1950,31 @@ struct GetTagSizeTask : public chi::Task {
 };
 
 /**
- * GetMaxCapacity task - total (max) storage capacity.
+ * GetCapacity task - total and remaining storage capacity.
  *
- * The handler sums max_capacity_ over the targets registered on this node, so a
- * Local query returns this node's capacity. Because AggregateOut sums across
- * replicas, a Broadcast query returns the whole cluster's capacity.
+ * The handler sums max_capacity_ (total) and remaining_space_ (free) over the
+ * targets registered on this node, so a Local query returns this node's
+ * capacity. Because AggregateOut sums both fields across replicas, a Broadcast
+ * query returns the whole cluster's total and remaining capacity.
  */
-struct GetMaxCapacityTask : public chi::Task {
-  OUT chi::u64 max_capacity_;  // Summed capacity in bytes
+struct GetCapacityTask : public chi::Task {
+  OUT chi::u64 total_capacity_;      // Summed total capacity in bytes
+  OUT chi::u64 remaining_capacity_;  // Summed remaining (free) capacity in bytes
 
   // SHM constructor
-  GetMaxCapacityTask() : chi::Task(), max_capacity_(0) {}
+  GetCapacityTask()
+      : chi::Task(), total_capacity_(0), remaining_capacity_(0) {}
 
   // Emplace constructor
-  CTP_CROSS_FUN explicit GetMaxCapacityTask(const chi::TaskId &task_id,
+  CTP_CROSS_FUN explicit GetCapacityTask(const chi::TaskId &task_id,
                                             const chi::PoolId &pool_id,
                                             const chi::PoolQuery &pool_query)
-      : chi::Task(task_id, pool_id, pool_query, Method::kGetMaxCapacity),
-        max_capacity_(0) {
+      : chi::Task(task_id, pool_id, pool_query, Method::kGetCapacity),
+        total_capacity_(0),
+        remaining_capacity_(0) {
     task_id_ = task_id;
     pool_id_ = pool_id;
-    method_ = Method::kGetMaxCapacity;
+    method_ = Method::kGetCapacity;
     task_flags_.Clear();
     pool_query_ = pool_query;
   }
@@ -1983,21 +1987,24 @@ struct GetMaxCapacityTask : public chi::Task {
   template <typename Archive>
   CTP_CROSS_FUN void SerializeOut(Archive &ar) {
     Task::SerializeOut(ar);
-    ar(max_capacity_);
+    ar(total_capacity_, remaining_capacity_);
   }
 
-  void Copy(const ctp::ipc::FullPtr<GetMaxCapacityTask> &other) {
+  void Copy(const ctp::ipc::FullPtr<GetCapacityTask> &other) {
     Task::Copy(other.template Cast<Task>());
-    max_capacity_ = other->max_capacity_;
+    total_capacity_ = other->total_capacity_;
+    remaining_capacity_ = other->remaining_capacity_;
   }
 
   /**
    * AggregateOut: sum capacity from each node so a Broadcast yields the total
-   * cluster capacity.
+   * and remaining cluster capacity.
    */
   void AggregateOut(const ctp::ipc::FullPtr<chi::Task> &other_base) {
     Task::AggregateOut(other_base);
-    max_capacity_ += other_base.template Cast<GetMaxCapacityTask>()->max_capacity_;
+    auto other = other_base.template Cast<GetCapacityTask>();
+    total_capacity_ += other->total_capacity_;
+    remaining_capacity_ += other->remaining_capacity_;
   }
 };
 

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -150,6 +150,12 @@ chi::TaskResume Runtime::Run(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_
       CLIO_CO_AWAIT(GetCapacity(typed_task, rctx));
       break;
     }
+    case Method::kGetNumAliases: {
+      // Cast task FullPtr to specific type
+      ctp::ipc::FullPtr<GetNumAliasesTask> typed_task = task_ptr.template Cast<GetNumAliasesTask>();
+      CLIO_CO_AWAIT(GetNumAliases(typed_task, rctx));
+      break;
+    }
     case Method::kPollTelemetryLog: {
       // Cast task FullPtr to specific type
       ctp::ipc::FullPtr<PollTelemetryLogTask> typed_task = task_ptr.template Cast<PollTelemetryLogTask>();
@@ -327,6 +333,11 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
       archive << *typed_task.ptr_;
       break;
     }
+    case Method::kGetNumAliases: {
+      auto typed_task = task_ptr.template Cast<GetNumAliasesTask>();
+      archive << *typed_task.ptr_;
+      break;
+    }
     case Method::kPollTelemetryLog: {
       auto typed_task = task_ptr.template Cast<PollTelemetryLogTask>();
       archive << *typed_task.ptr_;
@@ -489,6 +500,11 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
     }
     case Method::kGetCapacity: {
       auto typed_task = task_ptr.template Cast<GetCapacityTask>();
+      archive >> *typed_task.ptr_;
+      break;
+    }
+    case Method::kGetNumAliases: {
+      auto typed_task = task_ptr.template Cast<GetNumAliasesTask>();
       archive >> *typed_task.ptr_;
       break;
     }
@@ -677,6 +693,12 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::DefaultLoadArchive& archive,
     }
     case Method::kGetCapacity: {
       auto typed_task = task_ptr.template Cast<GetCapacityTask>();
+      // Use archive operator which respects msg_type
+      archive >> *typed_task.ptr_;
+      break;
+    }
+    case Method::kGetNumAliases: {
+      auto typed_task = task_ptr.template Cast<GetNumAliasesTask>();
       // Use archive operator which respects msg_type
       archive >> *typed_task.ptr_;
       break;
@@ -877,6 +899,12 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::DefaultSaveArchive& archive,
     }
     case Method::kGetCapacity: {
       auto typed_task = task_ptr.template Cast<GetCapacityTask>();
+      // Use archive operator which respects msg_type
+      archive << *typed_task.ptr_;
+      break;
+    }
+    case Method::kGetNumAliases: {
+      auto typed_task = task_ptr.template Cast<GetNumAliasesTask>();
       // Use archive operator which respects msg_type
       archive << *typed_task.ptr_;
       break;
@@ -1167,6 +1195,17 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewCopyTask(chi::u32 method, ctp::ipc::Ful
       }
       break;
     }
+    case Method::kGetNumAliases: {
+      // Allocate new task
+      auto new_task_ptr = ipc_manager->NewTask<GetNumAliasesTask>();
+      if (!new_task_ptr.IsNull()) {
+        // Copy task fields (includes base Task fields)
+        auto task_typed = orig_task_ptr.template Cast<GetNumAliasesTask>();
+        new_task_ptr->Copy(task_typed);
+        return new_task_ptr.template Cast<chi::Task>();
+      }
+      break;
+    }
     case Method::kPollTelemetryLog: {
       // Allocate new task
       auto new_task_ptr = ipc_manager->NewTask<PollTelemetryLogTask>();
@@ -1393,6 +1432,10 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
       auto new_task_ptr = ipc_manager->NewTask<GetCapacityTask>();
       return new_task_ptr.template Cast<chi::Task>();
     }
+    case Method::kGetNumAliases: {
+      auto new_task_ptr = ipc_manager->NewTask<GetNumAliasesTask>();
+      return new_task_ptr.template Cast<chi::Task>();
+    }
     case Method::kPollTelemetryLog: {
       auto new_task_ptr = ipc_manager->NewTask<PollTelemetryLogTask>();
       return new_task_ptr.template Cast<chi::Task>();
@@ -1546,6 +1589,11 @@ void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_ta
       typed_task->AggregateOut(replica_task);
       break;
     }
+    case Method::kGetNumAliases: {
+      auto typed_task = orig_task.template Cast<GetNumAliasesTask>();
+      typed_task->AggregateOut(replica_task);
+      break;
+    }
     case Method::kPollTelemetryLog: {
       auto typed_task = orig_task.template Cast<PollTelemetryLogTask>();
       typed_task->AggregateOut(replica_task);
@@ -1691,6 +1739,10 @@ void Runtime::DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) {
     }
     case Method::kGetCapacity: {
       ipc_manager->DelTask(task_ptr.template Cast<GetCapacityTask>());
+      break;
+    }
+    case Method::kGetNumAliases: {
+      ipc_manager->DelTask(task_ptr.template Cast<GetNumAliasesTask>());
       break;
     }
     case Method::kPollTelemetryLog: {

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -144,10 +144,10 @@ chi::TaskResume Runtime::Run(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_
       CLIO_CO_AWAIT(GetTagSize(typed_task, rctx));
       break;
     }
-    case Method::kGetMaxCapacity: {
+    case Method::kGetCapacity: {
       // Cast task FullPtr to specific type
-      ctp::ipc::FullPtr<GetMaxCapacityTask> typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
-      CLIO_CO_AWAIT(GetMaxCapacity(typed_task, rctx));
+      ctp::ipc::FullPtr<GetCapacityTask> typed_task = task_ptr.template Cast<GetCapacityTask>();
+      CLIO_CO_AWAIT(GetCapacity(typed_task, rctx));
       break;
     }
     case Method::kPollTelemetryLog: {
@@ -322,8 +322,8 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
       archive << *typed_task.ptr_;
       break;
     }
-    case Method::kGetMaxCapacity: {
-      auto typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
+    case Method::kGetCapacity: {
+      auto typed_task = task_ptr.template Cast<GetCapacityTask>();
       archive << *typed_task.ptr_;
       break;
     }
@@ -487,8 +487,8 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
       archive >> *typed_task.ptr_;
       break;
     }
-    case Method::kGetMaxCapacity: {
-      auto typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
+    case Method::kGetCapacity: {
+      auto typed_task = task_ptr.template Cast<GetCapacityTask>();
       archive >> *typed_task.ptr_;
       break;
     }
@@ -675,8 +675,8 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::DefaultLoadArchive& archive,
       archive >> *typed_task.ptr_;
       break;
     }
-    case Method::kGetMaxCapacity: {
-      auto typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
+    case Method::kGetCapacity: {
+      auto typed_task = task_ptr.template Cast<GetCapacityTask>();
       // Use archive operator which respects msg_type
       archive >> *typed_task.ptr_;
       break;
@@ -875,8 +875,8 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::DefaultSaveArchive& archive,
       archive << *typed_task.ptr_;
       break;
     }
-    case Method::kGetMaxCapacity: {
-      auto typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
+    case Method::kGetCapacity: {
+      auto typed_task = task_ptr.template Cast<GetCapacityTask>();
       // Use archive operator which respects msg_type
       archive << *typed_task.ptr_;
       break;
@@ -1156,12 +1156,12 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewCopyTask(chi::u32 method, ctp::ipc::Ful
       }
       break;
     }
-    case Method::kGetMaxCapacity: {
+    case Method::kGetCapacity: {
       // Allocate new task
-      auto new_task_ptr = ipc_manager->NewTask<GetMaxCapacityTask>();
+      auto new_task_ptr = ipc_manager->NewTask<GetCapacityTask>();
       if (!new_task_ptr.IsNull()) {
         // Copy task fields (includes base Task fields)
-        auto task_typed = orig_task_ptr.template Cast<GetMaxCapacityTask>();
+        auto task_typed = orig_task_ptr.template Cast<GetCapacityTask>();
         new_task_ptr->Copy(task_typed);
         return new_task_ptr.template Cast<chi::Task>();
       }
@@ -1389,8 +1389,8 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
       auto new_task_ptr = ipc_manager->NewTask<GetTagSizeTask>();
       return new_task_ptr.template Cast<chi::Task>();
     }
-    case Method::kGetMaxCapacity: {
-      auto new_task_ptr = ipc_manager->NewTask<GetMaxCapacityTask>();
+    case Method::kGetCapacity: {
+      auto new_task_ptr = ipc_manager->NewTask<GetCapacityTask>();
       return new_task_ptr.template Cast<chi::Task>();
     }
     case Method::kPollTelemetryLog: {
@@ -1541,8 +1541,8 @@ void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_ta
       typed_task->AggregateOut(replica_task);
       break;
     }
-    case Method::kGetMaxCapacity: {
-      auto typed_task = orig_task.template Cast<GetMaxCapacityTask>();
+    case Method::kGetCapacity: {
+      auto typed_task = orig_task.template Cast<GetCapacityTask>();
       typed_task->AggregateOut(replica_task);
       break;
     }
@@ -1689,8 +1689,8 @@ void Runtime::DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) {
       ipc_manager->DelTask(task_ptr.template Cast<GetTagSizeTask>());
       break;
     }
-    case Method::kGetMaxCapacity: {
-      ipc_manager->DelTask(task_ptr.template Cast<GetMaxCapacityTask>());
+    case Method::kGetCapacity: {
+      ipc_manager->DelTask(task_ptr.template Cast<GetCapacityTask>());
       break;
     }
     case Method::kPollTelemetryLog: {

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -144,6 +144,12 @@ chi::TaskResume Runtime::Run(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_
       CLIO_CO_AWAIT(GetTagSize(typed_task, rctx));
       break;
     }
+    case Method::kGetMaxCapacity: {
+      // Cast task FullPtr to specific type
+      ctp::ipc::FullPtr<GetMaxCapacityTask> typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
+      CLIO_CO_AWAIT(GetMaxCapacity(typed_task, rctx));
+      break;
+    }
     case Method::kPollTelemetryLog: {
       // Cast task FullPtr to specific type
       ctp::ipc::FullPtr<PollTelemetryLogTask> typed_task = task_ptr.template Cast<PollTelemetryLogTask>();
@@ -316,6 +322,11 @@ void Runtime::SaveTask(chi::u32 method, chi::SaveTaskArchive& archive,
       archive << *typed_task.ptr_;
       break;
     }
+    case Method::kGetMaxCapacity: {
+      auto typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
+      archive << *typed_task.ptr_;
+      break;
+    }
     case Method::kPollTelemetryLog: {
       auto typed_task = task_ptr.template Cast<PollTelemetryLogTask>();
       archive << *typed_task.ptr_;
@@ -473,6 +484,11 @@ void Runtime::LoadTask(chi::u32 method, chi::LoadTaskArchive& archive,
     }
     case Method::kGetTagSize: {
       auto typed_task = task_ptr.template Cast<GetTagSizeTask>();
+      archive >> *typed_task.ptr_;
+      break;
+    }
+    case Method::kGetMaxCapacity: {
+      auto typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
       archive >> *typed_task.ptr_;
       break;
     }
@@ -655,6 +671,12 @@ void Runtime::LocalLoadTask(chi::u32 method, chi::DefaultLoadArchive& archive,
     }
     case Method::kGetTagSize: {
       auto typed_task = task_ptr.template Cast<GetTagSizeTask>();
+      // Use archive operator which respects msg_type
+      archive >> *typed_task.ptr_;
+      break;
+    }
+    case Method::kGetMaxCapacity: {
+      auto typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
       // Use archive operator which respects msg_type
       archive >> *typed_task.ptr_;
       break;
@@ -849,6 +871,12 @@ void Runtime::LocalSaveTask(chi::u32 method, chi::DefaultSaveArchive& archive,
     }
     case Method::kGetTagSize: {
       auto typed_task = task_ptr.template Cast<GetTagSizeTask>();
+      // Use archive operator which respects msg_type
+      archive << *typed_task.ptr_;
+      break;
+    }
+    case Method::kGetMaxCapacity: {
+      auto typed_task = task_ptr.template Cast<GetMaxCapacityTask>();
       // Use archive operator which respects msg_type
       archive << *typed_task.ptr_;
       break;
@@ -1128,6 +1156,17 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewCopyTask(chi::u32 method, ctp::ipc::Ful
       }
       break;
     }
+    case Method::kGetMaxCapacity: {
+      // Allocate new task
+      auto new_task_ptr = ipc_manager->NewTask<GetMaxCapacityTask>();
+      if (!new_task_ptr.IsNull()) {
+        // Copy task fields (includes base Task fields)
+        auto task_typed = orig_task_ptr.template Cast<GetMaxCapacityTask>();
+        new_task_ptr->Copy(task_typed);
+        return new_task_ptr.template Cast<chi::Task>();
+      }
+      break;
+    }
     case Method::kPollTelemetryLog: {
       // Allocate new task
       auto new_task_ptr = ipc_manager->NewTask<PollTelemetryLogTask>();
@@ -1350,6 +1389,10 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
       auto new_task_ptr = ipc_manager->NewTask<GetTagSizeTask>();
       return new_task_ptr.template Cast<chi::Task>();
     }
+    case Method::kGetMaxCapacity: {
+      auto new_task_ptr = ipc_manager->NewTask<GetMaxCapacityTask>();
+      return new_task_ptr.template Cast<chi::Task>();
+    }
     case Method::kPollTelemetryLog: {
       auto new_task_ptr = ipc_manager->NewTask<PollTelemetryLogTask>();
       return new_task_ptr.template Cast<chi::Task>();
@@ -1498,6 +1541,11 @@ void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_ta
       typed_task->AggregateOut(replica_task);
       break;
     }
+    case Method::kGetMaxCapacity: {
+      auto typed_task = orig_task.template Cast<GetMaxCapacityTask>();
+      typed_task->AggregateOut(replica_task);
+      break;
+    }
     case Method::kPollTelemetryLog: {
       auto typed_task = orig_task.template Cast<PollTelemetryLogTask>();
       typed_task->AggregateOut(replica_task);
@@ -1639,6 +1687,10 @@ void Runtime::DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) {
     }
     case Method::kGetTagSize: {
       ipc_manager->DelTask(task_ptr.template Cast<GetTagSizeTask>());
+      break;
+    }
+    case Method::kGetMaxCapacity: {
+      ipc_manager->DelTask(task_ptr.template Cast<GetMaxCapacityTask>());
       break;
     }
     case Method::kPollTelemetryLog: {

--- a/context-transfer-engine/core/src/autogen/core_lib_exec.cc
+++ b/context-transfer-engine/core/src/autogen/core_lib_exec.cc
@@ -1470,7 +1470,7 @@ void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_ta
     }
     case Method::kTruncateBlob: {
       auto typed_task = orig_task.template Cast<TruncateBlobTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kDelTag: {
@@ -1480,17 +1480,17 @@ void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_ta
     }
     case Method::kRenameTag: {
       auto typed_task = orig_task.template Cast<RenameTagTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetOrCreateTagAlias: {
       auto typed_task = orig_task.template Cast<GetOrCreateTagAliasTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetTagName: {
       auto typed_task = orig_task.template Cast<GetTagNameTask>();
-      typed_task->Aggregate(replica_task);
+      typed_task->AggregateOut(replica_task);
       break;
     }
     case Method::kGetTagSize: {

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -1700,23 +1700,6 @@ chi::TaskResume Runtime::RenameTag(ctp::ipc::FullPtr<RenameTagTask> task,
     // O(1) regardless of how many descendants it has.
     if (IsHierPath(old_name) && IsHierPath(new_name)) {
       // ---- Hierarchical move: rebind only the leaf under its new parent. ----
-      // Phase A: resolve the target tag id and its current stored name.
-      std::string old_rel;
-      {
-        chi::ScopedCoRwReadLock lock(tag_map_lock_);
-        if (tag_id.IsNull()) {
-          tag_id = ResolvePathToIdLocked(old_name);
-        }
-        if (tag_id.IsNull()) {
-          task->return_code_ = 1;  // source path not found
-          CLIO_CO_RETURN;
-        }
-        TagInfo *info = tag_id_to_info_.find(tag_id);
-        if (info != nullptr) {
-          old_rel = info->tag_name_.str();
-        }
-      }
-
       // Split destination into parent path + leaf.
       std::vector<std::string> comps = SplitPathComponents(new_name);
       if (comps.empty()) {
@@ -1729,24 +1712,44 @@ chi::TaskResume Runtime::RenameTag(ctp::ipc::FullPtr<RenameTagTask> task,
         new_parent_path += (i == 0 ? "" : "/") + comps[i];
       }
 
-      // Phase B: get-or-create the destination parent chain (no lock held —
-      // GetOrCreateTagChain takes tag_map_lock_ itself). Auto-creates missing
-      // parents (mkdir -p semantics).
+      // Get-or-create the destination parent chain FIRST, before taking the tag
+      // map lock — GetOrCreateTagChain acquires tag_map_lock_ itself, so it
+      // cannot run while we hold it. Auto-creates missing parents (mkdir -p).
       TagId new_parent_id = GetOrCreateTagChain(new_parent_path);
       std::string new_rel = MakeRelativeName(new_parent_id, new_leaf);
 
-      // Phase C: atomically move the name binding and refresh the stored name.
+      // Resolve the source, move the name binding, and refresh the stored name
+      // as a SINGLE atomic read-modify-write under the write lock. The previous
+      // design read the tag's current name under a read lock, released it, then
+      // erased that value under a separate write lock — so a name read before
+      // the lock could go stale and erase a binding a racing rename/create had
+      // since reassigned to a *different* tag. That left a tag still resolvable
+      // upward (readdir/stat list it) but not forward (unlink/rmdir cannot find
+      // it). Reading the canonical name under the SAME lock that erases it, with
+      // no gap, serializes overlapping renames and keeps tag_name_to_id_ and the
+      // per-tag canonical name in agreement. See issue #596.
       {
         chi::ScopedCoRwWriteLock lock(tag_map_lock_);
-        if (!old_rel.empty()) {
-          tag_name_to_id_.erase(old_rel);
+        if (tag_id.IsNull()) {
+          tag_id = ResolvePathToIdLocked(old_name);
+        }
+        if (tag_id.IsNull()) {
+          task->return_code_ = 1;  // source path not found
+          CLIO_CO_RETURN;
+        }
+        TagInfo *info = tag_id_to_info_.find(tag_id);
+        if (info == nullptr) {
+          task->return_code_ = 1;  // source tag has no metadata
+          CLIO_CO_RETURN;
+        }
+        // Fresh read of the canonical name, under the lock that erases it.
+        std::string cur_rel = info->tag_name_.str();
+        if (cur_rel != new_rel) {
+          tag_name_to_id_.erase(cur_rel);
         }
         tag_name_to_id_.insert_or_assign(new_rel, tag_id);
-        TagInfo *info = tag_id_to_info_.find(tag_id);
-        if (info != nullptr) {
-          info->tag_name_ = chi::priv::string(CLIO_PRIV_ALLOC, new_rel);
-          info->last_modified_ = GetCurrentTimeNs();
-        }
+        info->tag_name_ = chi::priv::string(CLIO_PRIV_ALLOC, new_rel);
+        info->last_modified_ = GetCurrentTimeNs();
       }
       task->tag_id_ = tag_id;
       task->return_code_ = 0;

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -2182,25 +2182,35 @@ chi::TaskResume Runtime::GetTagSize(ctp::ipc::FullPtr<GetTagSizeTask> task,
   CLIO_TASK_BODY_END
 }
 
-chi::TaskResume Runtime::GetMaxCapacity(
-    ctp::ipc::FullPtr<GetMaxCapacityTask> task, chi::RunContext &ctx) {
+chi::TaskResume Runtime::GetCapacity(
+    ctp::ipc::FullPtr<GetCapacityTask> task, chi::RunContext &ctx) {
 #ifdef __NVCOMPILER
   chi::RunContext &rctx = ctx;
 #else
   (void)ctx;
 #endif
   CLIO_TASK_BODY_BEGIN
-  // Sum the fixed capacity of every target registered on this node. A Local
-  // query returns this node's capacity; the task's AggregateOut sums replicas,
-  // so a Broadcast returns the whole cluster's capacity.
+  // Sum the total and remaining capacity of every target registered on this
+  // node. A Local query returns this node's capacity; the task's AggregateOut
+  // sums replicas, so a Broadcast returns the whole cluster's capacity.
+  //
+  // Iterate registered_targets_ (the canonical map) rather than the target_list_
+  // mirror: the PutBlob/Free data path debits/credits remaining_space_ on the
+  // canonical entry only (the mirror is refreshed lazily by StatTargets), so the
+  // mirror lags real usage. for_each takes the map's internal lock for a
+  // consistent snapshot; target_lock_ (read) guards structural stability.
   chi::u64 total = 0;
+  chi::u64 remaining = 0;
   {
     chi::ScopedCoRwReadLock read_lock(target_lock_);
-    for (const auto &t : target_list_) {
-      total += t.max_capacity_;
-    }
+    registered_targets_.for_each(
+        [&total, &remaining](const chi::PoolId & /*key*/, const TargetInfo &t) {
+          total += t.max_capacity_;
+          remaining += t.remaining_space_;
+        });
   }
-  task->max_capacity_ = total;
+  task->total_capacity_ = total;
+  task->remaining_capacity_ = remaining;
   task->return_code_ = 0;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -2216,6 +2216,65 @@ chi::TaskResume Runtime::GetCapacity(
   CLIO_TASK_BODY_END
 }
 
+chi::TaskResume Runtime::GetNumAliases(
+    ctp::ipc::FullPtr<GetNumAliasesTask> task, chi::RunContext &ctx) {
+#ifdef __NVCOMPILER
+  chi::RunContext &rctx = ctx;
+#else
+  (void)ctx;
+#endif
+  CLIO_TASK_BODY_BEGIN
+  try {
+    task->num_aliases_ = 0;
+    task->found_ = 0;
+
+    chi::ScopedCoRwReadLock lock(tag_map_lock_);
+
+    // Resolve the tag id: prefer an explicit id, else resolve the name the same
+    // way DelTag does — hierarchical "$tagid{parent}/leaf" key first, then a
+    // verbatim lookup for flat names and flat aliases.
+    TagId tag_id = task->tag_id_;
+    if (tag_id.IsNull()) {
+      std::string tag_name = task->tag_name_.str();
+      if (!tag_name.empty()) {
+        if (IsHierPath(tag_name)) {
+          if (tag_name == "/") {
+            TagId *r = tag_name_to_id_.find(std::string("/"));
+            if (r != nullptr) tag_id = *r;
+          } else {
+            std::string parent_path, leaf;
+            if (SplitParentLeaf(tag_name, parent_path, leaf)) {
+              TagId parent_id = ResolvePathToIdLocked(parent_path);
+              if (!parent_id.IsNull()) {
+                TagId *p = tag_name_to_id_.find(MakeRelativeName(parent_id, leaf));
+                if (p != nullptr) tag_id = *p;
+              }
+            }
+          }
+        }
+        if (tag_id.IsNull()) {
+          TagId *p = tag_name_to_id_.find(tag_name);
+          if (p != nullptr) tag_id = *p;
+        }
+      }
+    }
+
+    if (!tag_id.IsNull()) {
+      TagInfo *info = tag_id_to_info_.find(tag_id);
+      if (info != nullptr) {
+        task->num_aliases_ = static_cast<chi::u32>(info->aliases_.size());
+        task->found_ = 1;
+      }
+    }
+    task->return_code_ = 0;  // found_ conveys existence; the op itself is fine
+  } catch (const std::exception &e) {
+    HLOG(kError, "GetNumAliases failed: {}", e.what());
+    task->return_code_ = 1;
+  }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
 // Private helper methods
 const Config &Runtime::GetConfig() const { return config_; }
 

--- a/context-transfer-engine/core/src/core_runtime.cc
+++ b/context-transfer-engine/core/src/core_runtime.cc
@@ -707,6 +707,8 @@ chi::TaskResume Runtime::RegisterTarget(ctp::ipc::FullPtr<RegisterTargetTask> ta
     }
     target_info.remaining_space_ =
         total_size;  // Use actual remaining space from bdev
+    target_info.max_capacity_ =
+        total_size;  // Total (max) capacity, fixed for the life of the target
     target_info.perf_metrics_ =
         perf_metrics;  // Store the entire PerfMetrics structure
     target_info.persistence_level_ = GetPersistenceLevelForTarget(target_name);
@@ -2176,6 +2178,30 @@ chi::TaskResume Runtime::GetTagSize(ctp::ipc::FullPtr<GetTagSizeTask> task,
     task->return_code_ = 1;
     task->tag_size_ = 0;
   }
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+chi::TaskResume Runtime::GetMaxCapacity(
+    ctp::ipc::FullPtr<GetMaxCapacityTask> task, chi::RunContext &ctx) {
+#ifdef __NVCOMPILER
+  chi::RunContext &rctx = ctx;
+#else
+  (void)ctx;
+#endif
+  CLIO_TASK_BODY_BEGIN
+  // Sum the fixed capacity of every target registered on this node. A Local
+  // query returns this node's capacity; the task's AggregateOut sums replicas,
+  // so a Broadcast returns the whole cluster's capacity.
+  chi::u64 total = 0;
+  {
+    chi::ScopedCoRwReadLock read_lock(target_lock_);
+    for (const auto &t : target_list_) {
+      total += t.max_capacity_;
+    }
+  }
+  task->max_capacity_ = total;
+  task->return_code_ = 0;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
 }

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/autogen/filesystem_methods.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/autogen/filesystem_methods.h
@@ -31,8 +31,12 @@ GLOBAL_CROSS_CONST chi::u32 kUnlink = 20;
 GLOBAL_CROSS_CONST chi::u32 kRename = 21;
 GLOBAL_CROSS_CONST chi::u32 kStatSize = 22;
 GLOBAL_CROSS_CONST chi::u32 kLink = 23;
+// Deferred-append pipeline (collective, log-structured appends):
+GLOBAL_CROSS_CONST chi::u32 kAppendSequence = 24;   // periodic local queue drain
+GLOBAL_CROSS_CONST chi::u32 kAppendCollect = 25;    // ManyToOne collect+plan per tag
+GLOBAL_CROSS_CONST chi::u32 kAppendExecution = 26;  // merge a plan slice into pages
 
-GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 24;
+GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 27;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -54,6 +58,9 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[21] = "Rename";
     v[22] = "StatSize";
     v[23] = "Link";
+    v[24] = "AppendSequence";
+    v[25] = "AppendCollect";
+    v[26] = "AppendExecution";
     return v;
   }();
   return names;

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/autogen/filesystem_methods.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/autogen/filesystem_methods.h
@@ -33,10 +33,11 @@ GLOBAL_CROSS_CONST chi::u32 kStatSize = 22;
 GLOBAL_CROSS_CONST chi::u32 kLink = 23;
 // Deferred-append pipeline (collective, log-structured appends):
 GLOBAL_CROSS_CONST chi::u32 kAppendSequence = 24;   // periodic local queue drain
-GLOBAL_CROSS_CONST chi::u32 kAppendCollect = 25;    // ManyToOne collect+plan per tag
+GLOBAL_CROSS_CONST chi::u32 kAppendCollect = 25;    // ManyToOne collect (synchronous)
 GLOBAL_CROSS_CONST chi::u32 kAppendExecution = 26;  // merge a plan slice into pages
+GLOBAL_CROSS_CONST chi::u32 kAppendPlan = 27;       // sort+plan+dispatch (suspendable)
 
-GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 27;
+GLOBAL_CROSS_CONST chi::u32 kMaxMethodId = 28;
 
 inline const std::vector<std::string>& GetMethodNames() {
   static const std::vector<std::string> names = [] {
@@ -61,6 +62,7 @@ inline const std::vector<std::string>& GetMethodNames() {
     v[24] = "AppendSequence";
     v[25] = "AppendCollect";
     v[26] = "AppendExecution";
+    v[27] = "AppendPlan";
     return v;
   }();
   return names;

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
@@ -160,10 +160,11 @@ class Client : public clio::cte::core::Client {
   /** Apply a slice of the merge plan (GetBlob->PutBlob->DelBlob). */
   chi::Future<AppendExecutionTask> AsyncAppendExecution(
       const clio::cte::core::TagId &tag_id,
+      const clio::cte::core::TagId &staging_tag_id,
       const std::vector<AppendPlanStep> &steps, const chi::PoolQuery &pool_query) {
     auto *ipc = CLIO_CPU_IPC;
-    auto task = ipc->NewTask<AppendExecutionTask>(chi::CreateTaskId(), pool_id_,
-                                                  pool_query, tag_id, steps);
+    auto task = ipc->NewTask<AppendExecutionTask>(
+        chi::CreateTaskId(), pool_id_, pool_query, tag_id, staging_tag_id, steps);
     return ipc->Send(task);
   }
 

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
@@ -157,6 +157,16 @@ class Client : public clio::cte::core::Client {
     return ipc->Send(task);
   }
 
+  /** Plan + dispatch one tag's batch (suspendable; submitted by AppendCollect). */
+  chi::Future<AppendPlanTask> AsyncAppendPlan(
+      const clio::cte::core::TagId &tag_id,
+      const std::vector<AppendEntry> &entries, const chi::PoolQuery &pool_query) {
+    auto *ipc = CLIO_CPU_IPC;
+    auto task = ipc->NewTask<AppendPlanTask>(chi::CreateTaskId(), pool_id_,
+                                             pool_query, tag_id, entries);
+    return ipc->Send(task);
+  }
+
   /** Apply a slice of the merge plan (GetBlob->PutBlob->DelBlob). */
   chi::Future<AppendExecutionTask> AsyncAppendExecution(
       const clio::cte::core::TagId &tag_id,

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_client.h
@@ -132,6 +132,41 @@ class Client : public clio::cte::core::Client {
     return ipc->Send(task);
   }
 
+  // ---- deferred-append pipeline ----
+  /** Kick off (or tick) the periodic local pending-append drain. */
+  chi::Future<AppendSequenceTask> AsyncAppendSequence(
+      double period_us = 0.0,
+      const chi::PoolQuery &pool_query = chi::PoolQuery::Local()) {
+    auto *ipc = CLIO_CPU_IPC;
+    auto task = ipc->NewTask<AppendSequenceTask>(chi::CreateTaskId(), pool_id_,
+                                                 pool_query);
+    if (period_us > 0.0) {
+      task->SetPeriod(period_us, chi::kMicro);
+      task->SetFlags(TASK_PERIODIC);
+    }
+    return ipc->Send(task);
+  }
+
+  /** Collect one tag's pending appends at its sequencer (ManyToOne batch). */
+  chi::Future<AppendCollectTask> AsyncAppendCollect(
+      const clio::cte::core::TagId &tag_id,
+      const std::vector<AppendEntry> &entries, const chi::PoolQuery &pool_query) {
+    auto *ipc = CLIO_CPU_IPC;
+    auto task = ipc->NewTask<AppendCollectTask>(chi::CreateTaskId(), pool_id_,
+                                                pool_query, tag_id, entries);
+    return ipc->Send(task);
+  }
+
+  /** Apply a slice of the merge plan (GetBlob->PutBlob->DelBlob). */
+  chi::Future<AppendExecutionTask> AsyncAppendExecution(
+      const clio::cte::core::TagId &tag_id,
+      const std::vector<AppendPlanStep> &steps, const chi::PoolQuery &pool_query) {
+    auto *ipc = CLIO_CPU_IPC;
+    auto task = ipc->NewTask<AppendExecutionTask>(chi::CreateTaskId(), pool_id_,
+                                                  pool_query, tag_id, steps);
+    return ipc->Send(task);
+  }
+
   chi::Future<ReaddirTask> AsyncReaddir(const std::string &path) {
     auto *ipc = CLIO_CPU_IPC;
     auto task = ipc->NewTask<ReaddirTask>(chi::CreateTaskId(), pool_id_,

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_runtime.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_runtime.h
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <clio_runtime/clio_runtime.h>
 #include <clio_cte/core/core_client.h>
@@ -48,6 +49,10 @@ class Runtime : public chi::Container {
   chi::TaskResume Link(ctp::ipc::FullPtr<LinkTask> task, chi::RunContext &ctx);
   chi::TaskResume Readdir(ctp::ipc::FullPtr<ReaddirTask> task, chi::RunContext &ctx);
   chi::TaskResume StatSize(ctp::ipc::FullPtr<StatSizeTask> task, chi::RunContext &ctx);
+  // ---- deferred-append pipeline ----
+  chi::TaskResume AppendSequence(ctp::ipc::FullPtr<AppendSequenceTask> task, chi::RunContext &ctx);
+  chi::TaskResume AppendCollect(ctp::ipc::FullPtr<AppendCollectTask> task, chi::RunContext &ctx);
+  chi::TaskResume AppendExecution(ctp::ipc::FullPtr<AppendExecutionTask> task, chi::RunContext &ctx);
 
   // ---- Container virtuals (defined in autogen/filesystem_lib_exec.cc) ----
   void Init(const chi::PoolId &pool_id, const std::string &pool_name,
@@ -63,6 +68,8 @@ class Runtime : public chi::Container {
                      ctp::ipc::FullPtr<chi::Task> task_ptr) override;
   void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
                     const ctp::ipc::FullPtr<chi::Task> &replica_task) override;
+  void AggregateIn(chi::u32 method, ctp::ipc::FullPtr<chi::Task> agg_task,
+                   const ctp::ipc::FullPtr<chi::Task> &member_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
   void SaveTask(chi::u32 method, chi::SaveTaskArchive &archive,
                 ctp::ipc::FullPtr<chi::Task> task_ptr) override;
@@ -79,6 +86,9 @@ class Runtime : public chi::Container {
   // CTE core client this filesystem sits over (set at Create from next_pool_id_).
   clio::cte::core::Client cte_;
   chi::PoolId next_pool_id_ = chi::PoolId::GetNull();
+  // Client bound to THIS filesystem pool, for self-submitted pipeline tasks
+  // (periodic AppendSequence, AppendCollect, AppendExecution).
+  Client self_;
 
   // ---- per-file logical-size metadata + handle table ----
   struct FileInfo {
@@ -90,6 +100,21 @@ class Runtime : public chi::Container {
   std::unordered_map<chi::u64, std::shared_ptr<FileInfo>> handles_;  // handle -> file
   std::unordered_map<std::string, std::shared_ptr<FileInfo>> by_path_;
   std::atomic<chi::u64> next_handle_{1};
+
+  // ---- deferred-append pipeline state ----
+  // Per-node logical append counter (orders appends sharing a UTC tick).
+  std::atomic<chi::u64> append_logical_{0};
+  // Pending appends placed locally, awaiting the periodic AppendSequence drain.
+  // Multi-producer (worker threads running Append), single-consumer
+  // (AppendSequence) — guarded by a mutex rather than a fixed-capacity ring so
+  // a burst of appends can never be silently dropped.
+  struct PendingAppend {
+    clio::cte::core::TagId tag_id_;
+    AppendEntry entry_;
+  };
+  std::mutex append_mu_;
+  std::vector<PendingAppend> append_pending_;
+  bool append_seq_started_ = false;  // periodic AppendSequence kicked off once
 };
 
 }  // namespace clio::cte::filesystem

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_runtime.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_runtime.h
@@ -61,8 +61,8 @@ class Runtime : public chi::Container {
       chi::u32 method, chi::DefaultLoadArchive &archive) override;
   void LocalSaveTask(chi::u32 method, chi::DefaultSaveArchive &archive,
                      ctp::ipc::FullPtr<chi::Task> task_ptr) override;
-  void Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
-                 const ctp::ipc::FullPtr<chi::Task> &replica_task) override;
+  void AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+                    const ctp::ipc::FullPtr<chi::Task> &replica_task) override;
   void DelTask(chi::u32 method, ctp::ipc::FullPtr<chi::Task> task_ptr) override;
   void SaveTask(chi::u32 method, chi::SaveTaskArchive &archive,
                 ctp::ipc::FullPtr<chi::Task> task_ptr) override;

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_runtime.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_runtime.h
@@ -89,6 +89,10 @@ class Runtime : public chi::Container {
   // Client bound to THIS filesystem pool, for self-submitted pipeline tasks
   // (periodic AppendSequence, AppendCollect, AppendExecution).
   Client self_;
+  // Staging tag for append data blobs. Append writes the bytes here (NOT under
+  // the file's tag) so GetTagSize(file_tag) reports the true file tail,
+  // unpolluted by still-unmerged staged appends. Resolved once at Create.
+  clio::cte::core::TagId staging_tag_id_ = clio::cte::core::TagId::GetNull();
 
   // ---- per-file logical-size metadata + handle table ----
   struct FileInfo {

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_runtime.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_runtime.h
@@ -52,6 +52,7 @@ class Runtime : public chi::Container {
   // ---- deferred-append pipeline ----
   chi::TaskResume AppendSequence(ctp::ipc::FullPtr<AppendSequenceTask> task, chi::RunContext &ctx);
   chi::TaskResume AppendCollect(ctp::ipc::FullPtr<AppendCollectTask> task, chi::RunContext &ctx);
+  chi::TaskResume AppendPlan(ctp::ipc::FullPtr<AppendPlanTask> task, chi::RunContext &ctx);
   chi::TaskResume AppendExecution(ctp::ipc::FullPtr<AppendExecutionTask> task, chi::RunContext &ctx);
 
   // ---- Container virtuals (defined in autogen/filesystem_lib_exec.cc) ----

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_tasks.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_tasks.h
@@ -473,6 +473,34 @@ struct AppendCollectTask : public chi::Task {
   }
 };
 
+/**
+ * AppendPlan: a REGULAR (suspendable) task that does the heavy planning work
+ * for one tag's batch. Submitted by the synchronous AppendCollect aggregate
+ * (the ManyToOne synthetic aggregate task can't itself suspend). Sorts the
+ * batch, reads the file tail, builds the page-merge plan, and dispatches
+ * AppendExecution slices.
+ */
+struct AppendPlanTask : public chi::Task {
+  IN clio::cte::core::TagId tag_id_;
+  IN std::vector<AppendEntry> entries_;
+  AppendPlanTask()
+      : chi::Task(), tag_id_(clio::cte::core::TagId::GetNull()) {}
+  explicit AppendPlanTask(const chi::TaskId &task_id, const chi::PoolId &pool_id,
+                          const chi::PoolQuery &pool_query,
+                          const clio::cte::core::TagId &tag_id,
+                          const std::vector<AppendEntry> &entries)
+      : chi::Task(task_id, pool_id, pool_query, Method::kAppendPlan),
+        tag_id_(tag_id), entries_(entries) {}
+  void Copy(const ctp::ipc::FullPtr<AppendPlanTask> &o) {
+    Task::Copy(o.template Cast<Task>());
+    tag_id_ = o->tag_id_; entries_ = o->entries_;
+  }
+  template <typename Ar> void SerializeIn(Ar &ar) {
+    Task::SerializeIn(ar); ar(tag_id_, entries_);
+  }
+  template <typename Ar> void SerializeOut(Ar &ar) { Task::SerializeOut(ar); }
+};
+
 /** AppendExecution: apply a slice of the merge plan (GetBlob->PutBlob->DelBlob). */
 struct AppendExecutionTask : public chi::Task {
   IN clio::cte::core::TagId tag_id_;          // destination file tag

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_tasks.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_tasks.h
@@ -22,6 +22,9 @@
 #ifndef CLIO_CTE_FILESYSTEM_FILESYSTEM_TASKS_H_
 #define CLIO_CTE_FILESYSTEM_FILESYSTEM_TASKS_H_
 
+#include <string>
+#include <vector>
+
 #include <clio_runtime/clio_runtime.h>
 #include <clio_runtime/task.h>
 #include <clio_runtime/admin/admin_tasks.h>
@@ -378,6 +381,119 @@ struct StatSizeTask : public chi::Task {
   template <typename Ar> void SerializeOut(Ar &ar) {
     Task::SerializeOut(ar); ar(exists_, size_);
   }
+};
+
+// ===========================================================================
+// Deferred-append pipeline
+//
+// Appends are NOT applied to the tail synchronously. Instead Append stamps a
+// (UTC, logical) order, writes the bytes as a standalone "data blob" under the
+// file's tag, and queues a pending entry. A periodic AppendSequence drains the
+// per-node queue and, per tag, submits an AppendCollect routed ManyToOne to the
+// tag's sequencer. There the batched members' entries are combined (AggregateIn)
+// into one global, timestamp-sorted batch (the "plan" phase): it reads the file
+// tail (GetTagSize minus this batch's still-staged data), lays each data blob
+// out into 1 MiB file pages, and dispatches AppendExecution slices (<=16 MiB
+// each) that GetBlob->PutBlob->DelBlob the data into the file pages.
+// ===========================================================================
+
+/** One pending append: a staged data blob waiting to be merged into a file. */
+struct AppendEntry {
+  std::string data_blob_id_;     ///< name of the staged blob (under file tag)
+  chi::u64 data_blob_size_ = 0;  ///< staged blob length in bytes
+  chi::u64 utc_ns_ = 0;          ///< wallclock at placement (primary sort key)
+  chi::u64 logical_ = 0;         ///< per-node logical counter (tiebreak)
+  template <class Ar> void serialize(Ar &ar) {
+    ar(data_blob_id_, data_blob_size_, utc_ns_, logical_);
+  }
+};
+
+/** One merge step: copy [size_] bytes of a data blob into a file page blob. */
+struct AppendPlanStep {
+  chi::u64 file_page_ = 0;       ///< destination file page index (blob name)
+  std::string data_blob_id_;     ///< source staged blob
+  chi::u64 off_in_page_ = 0;     ///< destination offset within the file page
+  chi::u64 off_in_data_ = 0;     ///< source offset within the data blob
+  chi::u64 size_ = 0;            ///< bytes copied by this step (<= data size)
+  chi::u64 data_blob_size_ = 0;  ///< full data blob size (the final step for a
+                                 ///< blob has size_==data_blob_size_ so its
+                                 ///< DelBlob can't race a partial copy)
+  template <class Ar> void serialize(Ar &ar) {
+    ar(file_page_, data_blob_id_, off_in_page_, off_in_data_, size_,
+       data_blob_size_);
+  }
+};
+
+/** AppendSequence: periodic local trigger to drain the pending-append queue. */
+struct AppendSequenceTask : public chi::Task {
+  AppendSequenceTask() : chi::Task() {}
+  explicit AppendSequenceTask(const chi::TaskId &task_id,
+                              const chi::PoolId &pool_id,
+                              const chi::PoolQuery &pool_query)
+      : chi::Task(task_id, pool_id, pool_query, Method::kAppendSequence) {}
+  void Copy(const ctp::ipc::FullPtr<AppendSequenceTask> &o) {
+    Task::Copy(o.template Cast<Task>());
+  }
+  template <typename Ar> void SerializeIn(Ar &ar) { Task::SerializeIn(ar); }
+  template <typename Ar> void SerializeOut(Ar &ar) { Task::SerializeOut(ar); }
+};
+
+/**
+ * AppendCollect: ManyToOne collective per tag. Each node submits its pending
+ * entries for the tag; AggregateIn concatenates them at the sequencer; the
+ * single aggregate run sorts + plans + dispatches the merge.
+ */
+struct AppendCollectTask : public chi::Task {
+  IN clio::cte::core::TagId tag_id_;
+  IN std::vector<AppendEntry> entries_;
+  OUT chi::u64 new_size_;  ///< file logical size after the batch is applied
+  AppendCollectTask()
+      : chi::Task(), tag_id_(clio::cte::core::TagId::GetNull()), new_size_(0) {}
+  explicit AppendCollectTask(const chi::TaskId &task_id,
+                             const chi::PoolId &pool_id,
+                             const chi::PoolQuery &pool_query,
+                             const clio::cte::core::TagId &tag_id,
+                             const std::vector<AppendEntry> &entries)
+      : chi::Task(task_id, pool_id, pool_query, Method::kAppendCollect),
+        tag_id_(tag_id), entries_(entries), new_size_(0) {}
+  void Copy(const ctp::ipc::FullPtr<AppendCollectTask> &o) {
+    Task::Copy(o.template Cast<Task>());
+    tag_id_ = o->tag_id_; entries_ = o->entries_; new_size_ = o->new_size_;
+  }
+  template <typename Ar> void SerializeIn(Ar &ar) {
+    Task::SerializeIn(ar); ar(tag_id_, entries_);
+  }
+  template <typename Ar> void SerializeOut(Ar &ar) {
+    Task::SerializeOut(ar); ar(new_size_);
+  }
+  /** ManyToOne: fold a batched member's pending entries into this aggregate. */
+  void AggregateIn(const ctp::ipc::FullPtr<chi::Task> &member_base) {
+    auto m = member_base.template Cast<AppendCollectTask>();
+    entries_.insert(entries_.end(), m->entries_.begin(), m->entries_.end());
+  }
+};
+
+/** AppendExecution: apply a slice of the merge plan (GetBlob->PutBlob->DelBlob). */
+struct AppendExecutionTask : public chi::Task {
+  IN clio::cte::core::TagId tag_id_;
+  IN std::vector<AppendPlanStep> steps_;
+  AppendExecutionTask()
+      : chi::Task(), tag_id_(clio::cte::core::TagId::GetNull()) {}
+  explicit AppendExecutionTask(const chi::TaskId &task_id,
+                               const chi::PoolId &pool_id,
+                               const chi::PoolQuery &pool_query,
+                               const clio::cte::core::TagId &tag_id,
+                               const std::vector<AppendPlanStep> &steps)
+      : chi::Task(task_id, pool_id, pool_query, Method::kAppendExecution),
+        tag_id_(tag_id), steps_(steps) {}
+  void Copy(const ctp::ipc::FullPtr<AppendExecutionTask> &o) {
+    Task::Copy(o.template Cast<Task>());
+    tag_id_ = o->tag_id_; steps_ = o->steps_;
+  }
+  template <typename Ar> void SerializeIn(Ar &ar) {
+    Task::SerializeIn(ar); ar(tag_id_, steps_);
+  }
+  template <typename Ar> void SerializeOut(Ar &ar) { Task::SerializeOut(ar); }
 };
 
 }  // namespace clio::cte::filesystem

--- a/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_tasks.h
+++ b/context-transfer-engine/filesystem/include/clio_cte/filesystem/filesystem_tasks.h
@@ -475,23 +475,27 @@ struct AppendCollectTask : public chi::Task {
 
 /** AppendExecution: apply a slice of the merge plan (GetBlob->PutBlob->DelBlob). */
 struct AppendExecutionTask : public chi::Task {
-  IN clio::cte::core::TagId tag_id_;
+  IN clio::cte::core::TagId tag_id_;          // destination file tag
+  IN clio::cte::core::TagId staging_tag_id_;  // source staged data blobs
   IN std::vector<AppendPlanStep> steps_;
   AppendExecutionTask()
-      : chi::Task(), tag_id_(clio::cte::core::TagId::GetNull()) {}
+      : chi::Task(), tag_id_(clio::cte::core::TagId::GetNull()),
+        staging_tag_id_(clio::cte::core::TagId::GetNull()) {}
   explicit AppendExecutionTask(const chi::TaskId &task_id,
                                const chi::PoolId &pool_id,
                                const chi::PoolQuery &pool_query,
                                const clio::cte::core::TagId &tag_id,
+                               const clio::cte::core::TagId &staging_tag_id,
                                const std::vector<AppendPlanStep> &steps)
       : chi::Task(task_id, pool_id, pool_query, Method::kAppendExecution),
-        tag_id_(tag_id), steps_(steps) {}
+        tag_id_(tag_id), staging_tag_id_(staging_tag_id), steps_(steps) {}
   void Copy(const ctp::ipc::FullPtr<AppendExecutionTask> &o) {
     Task::Copy(o.template Cast<Task>());
-    tag_id_ = o->tag_id_; steps_ = o->steps_;
+    tag_id_ = o->tag_id_; staging_tag_id_ = o->staging_tag_id_;
+    steps_ = o->steps_;
   }
   template <typename Ar> void SerializeIn(Ar &ar) {
-    Task::SerializeIn(ar); ar(tag_id_, steps_);
+    Task::SerializeIn(ar); ar(tag_id_, staging_tag_id_, steps_);
   }
   template <typename Ar> void SerializeOut(Ar &ar) { Task::SerializeOut(ar); }
 };

--- a/context-transfer-engine/filesystem/src/autogen/filesystem_lib_exec.cc
+++ b/context-transfer-engine/filesystem/src/autogen/filesystem_lib_exec.cc
@@ -182,17 +182,17 @@ ctp::ipc::FullPtr<chi::Task> Runtime::NewTask(chi::u32 method) {
   }
 }
 
-void Runtime::Aggregate(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
-                        const ctp::ipc::FullPtr<chi::Task> &replica_task) {
+void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_task,
+                           const ctp::ipc::FullPtr<chi::Task> &replica_task) {
   switch (method) {
-#define X(MID, TASK, HANDLER)                                  \
-    case Method::MID:                                          \
-      orig_task.template Cast<TASK>()->Aggregate(replica_task); \
+#define X(MID, TASK, HANDLER)                                      \
+    case Method::MID:                                              \
+      orig_task.template Cast<TASK>()->AggregateOut(replica_task); \
       break;
     CLIO_FS_FOR_EACH_METHOD(X)
 #undef X
     default:
-      orig_task->Aggregate(replica_task);
+      orig_task->AggregateOut(replica_task);
       break;
   }
 }

--- a/context-transfer-engine/filesystem/src/autogen/filesystem_lib_exec.cc
+++ b/context-transfer-engine/filesystem/src/autogen/filesystem_lib_exec.cc
@@ -33,7 +33,8 @@ namespace clio::cte::filesystem {
   X(kStatSize, StatSizeTask, StatSize)    \
   X(kAppendSequence, AppendSequenceTask, AppendSequence)    \
   X(kAppendCollect, AppendCollectTask, AppendCollect)       \
-  X(kAppendExecution, AppendExecutionTask, AppendExecution)
+  X(kAppendExecution, AppendExecutionTask, AppendExecution) \
+  X(kAppendPlan, AppendPlanTask, AppendPlan)
 
 void Runtime::Init(const chi::PoolId &pool_id, const std::string &pool_name,
                    chi::u32 container_id) {

--- a/context-transfer-engine/filesystem/src/autogen/filesystem_lib_exec.cc
+++ b/context-transfer-engine/filesystem/src/autogen/filesystem_lib_exec.cc
@@ -30,7 +30,10 @@ namespace clio::cte::filesystem {
   X(kUnlink, UnlinkTask, Unlink)          \
   X(kRename, RenameTask, Rename)          \
   X(kLink, LinkTask, Link)                \
-  X(kStatSize, StatSizeTask, StatSize)
+  X(kStatSize, StatSizeTask, StatSize)    \
+  X(kAppendSequence, AppendSequenceTask, AppendSequence)    \
+  X(kAppendCollect, AppendCollectTask, AppendCollect)       \
+  X(kAppendExecution, AppendExecutionTask, AppendExecution)
 
 void Runtime::Init(const chi::PoolId &pool_id, const std::string &pool_name,
                    chi::u32 container_id) {
@@ -194,6 +197,15 @@ void Runtime::AggregateOut(chi::u32 method, ctp::ipc::FullPtr<chi::Task> orig_ta
     default:
       orig_task->AggregateOut(replica_task);
       break;
+  }
+}
+
+void Runtime::AggregateIn(chi::u32 method, ctp::ipc::FullPtr<chi::Task> agg_task,
+                          const ctp::ipc::FullPtr<chi::Task> &member_task) {
+  // Only AppendCollect combines member inputs (ManyToOne). All other methods
+  // keep the default no-op (the aggregate is a copy of the first member).
+  if (method == Method::kAppendCollect) {
+    agg_task.template Cast<AppendCollectTask>()->AggregateIn(member_task);
   }
 }
 

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -674,6 +674,63 @@ chi::TaskResume Runtime::Rename(ctp::ipc::FullPtr<RenameTask> task,
     CLIO_CO_RETURN;
   }
 
+  // Classify source as a directory iff it has at least one child entry (a dir
+  // always has at least its hidden marker child; a regular file has none).
+  bool src_is_dir = false;
+  {
+    std::string re = "^" + EscapeExact(src) + "/[^/]+$";
+    auto q = cte_.AsyncTagQuery(re, 1, chi::PoolQuery::Local());
+    CLIO_CO_AWAIT(q);
+    src_is_dir = (q->GetReturnCode() == 0 && !q->results_.empty());
+  }
+
+  // Classify the destination and enforce POSIX rename-overwrite rules before
+  // touching anything (issue #597 B1, generic/245). Replacing a destination is
+  // only legal file-over-file or dir-over-empty-dir; everything else is an error
+  // and must leave both operands untouched.
+  //   dst_state: 0 = absent, 1 = file, 2 = empty dir, 3 = non-empty dir.
+  int dst_state = 0;
+  {
+    std::string re = "^" + EscapeExact(dst) + "/[^/]+$";
+    auto q = cte_.AsyncTagQuery(re, 0, chi::PoolQuery::Local());
+    CLIO_CO_AWAIT(q);
+    if (q->GetReturnCode() == 0 && !q->results_.empty()) {
+      const size_t prefix = dst.size() + 1;  // strip "<dst>/"
+      dst_state = 2;                          // has a child => directory
+      for (const auto &full : q->results_) {
+        std::string base =
+            full.size() > prefix ? full.substr(prefix) : std::string();
+        if (base != kDirMarker) { dst_state = 3; break; }  // real child
+      }
+    } else {
+      // No children: a regular file if an exact tag exists, else nonexistent.
+      auto qf =
+          cte_.AsyncTagQuery(EscapeExact(dst), 1, chi::PoolQuery::Local());
+      CLIO_CO_AWAIT(qf);
+      dst_state =
+          (qf->GetReturnCode() == 0 && !qf->results_.empty()) ? 1 : 0;
+    }
+  }
+  if (dst_state != 0) {
+    if (dst_state == 2 || dst_state == 3) {  // destination is a directory
+      if (!src_is_dir) {
+        task->return_code_ = EISDIR;  // non-dir onto a directory
+        CLIO_CO_RETURN;
+      }
+      if (dst_state == 3) {
+        task->return_code_ = ENOTEMPTY;  // directory onto a non-empty directory
+        CLIO_CO_RETURN;
+      }
+      // dir onto an empty dir: allowed (the empty dst is replaced below).
+    } else {  // destination is a regular file
+      if (src_is_dir) {
+        task->return_code_ = ENOTDIR;  // directory onto a non-dir
+        CLIO_CO_RETURN;
+      }
+      // file onto file: allowed (overwrite below).
+    }
+  }
+
   // POSIX rename overwrites an existing destination: drop dst's tag first.
   {
     auto d = cte_.AsyncDelTag(dst, chi::PoolQuery::Local());

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -820,18 +820,17 @@ chi::TaskResume Runtime::AppendSequence(
   // One AppendCollect per tag, routed ManyToOne so every node's batch for the
   // same tag aggregates at that tag's sequencer (the leader chosen by the
   // container hash). batch_key = the tag id keeps distinct tags' collectives
-  // separate on the same leader.
-  std::vector<chi::Future<AppendCollectTask>> futs;
-  futs.reserve(by_tag.size());
+  // separate on the same leader. Submitted and awaited one tag at a time so
+  // that at most one subtask future is ever outstanding in this coroutine — see
+  // the use-after-free note in AppendExecution: the CPU await path cannot tell
+  // which of several in-flight futures a sibling completion belongs to.
   for (auto &kv : by_tag) {
     const clio::cte::core::TagId &tag = kv.first;
     chi::u32 chash = static_cast<chi::u32>(
         std::hash<clio::cte::core::TagId>()(tag));
     chi::u64 bkey = (static_cast<chi::u64>(tag.major_) << 32) | tag.minor_;
     auto q = chi::PoolQuery::ManyToOne(chash, bkey, /*batch_for_ns=*/50000);
-    futs.push_back(self_.AsyncAppendCollect(tag, kv.second, q));
-  }
-  for (auto &f : futs) {
+    auto f = self_.AsyncAppendCollect(tag, kv.second, q);
     CLIO_CO_AWAIT(f);
   }
   task->return_code_ = 0;
@@ -843,8 +842,42 @@ chi::TaskResume Runtime::AppendSequence(
 chi::TaskResume Runtime::AppendCollect(
     ctp::ipc::FullPtr<AppendCollectTask> task, chi::RunContext &ctx) {
   CLIO_TASK_BODY_BEGIN
-  // This runs ONCE per batch (the ManyToOne aggregate). task->entries_ already
-  // holds every node's pending entries for this tag (combined via AggregateIn).
+  // Runs ONCE per batch as the ManyToOne aggregate; task->entries_ holds every
+  // node's pending entries for this tag (combined via AggregateIn). The actual
+  // merge needs to suspend (it reads the file tail and drives PutBlobs), which a
+  // ManyToOne aggregate cannot express directly, so it is delegated to a regular
+  // AppendPlan task. We AWAIT that task rather than fire-and-forget it, which is
+  // essential for two reasons:
+  //   1. Lifetime: AppendPlan's parent RunContext is THIS aggregate's. If we
+  //      returned immediately, EndTask -> OnAggregateComplete would free the
+  //      aggregate (and its RunContext) while AppendPlan was still running, so
+  //      AppendPlan's completion would dereference a freed parent (a UAF in
+  //      IpcCpu2Self::RuntimeSend). Awaiting keeps the parent alive until the
+  //      merge finishes.
+  //   2. Serialization: the BatchManager holds this group's in-flight claim
+  //      until the aggregate completes. Awaiting the merge keeps the claim held
+  //      for the whole merge, so no second batch for the same tag can start
+  //      while this one is still writing the tail — concurrent merges would both
+  //      plan from the same GetTagSize and clobber each other.
+  // Only one subtask future (AppendPlan) is ever outstanding here, so the
+  // single-outstanding-future rule documented in AppendExecution holds.
+  std::vector<AppendEntry> entries(task->entries_.begin(),
+                                   task->entries_.end());
+  auto f =
+      self_.AsyncAppendPlan(task->tag_id_, entries, chi::PoolQuery::Local());
+  CLIO_CO_AWAIT(f);
+  task->new_size_ = 0;  // settled by the merge; members don't read it
+  task->return_code_ = 0;
+  (void)ctx;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+chi::TaskResume Runtime::AppendPlan(ctp::ipc::FullPtr<AppendPlanTask> task,
+                                    chi::RunContext &ctx) {
+  CLIO_TASK_BODY_BEGIN
+  // Regular (suspendable) task: sort the batch, read the file tail, build the
+  // 1 MiB-page merge plan, and dispatch AppendExecution slices.
   clio::cte::core::TagId tag_id = task->tag_id_;
   std::vector<AppendEntry> entries(task->entries_.begin(),
                                    task->entries_.end());
@@ -891,7 +924,6 @@ chi::TaskResume Runtime::AppendCollect(
   // split across two slices, so exactly one execution task DelBlobs it (no
   // double-free race); a single blob larger than 16 MiB forms its own slice.
   constexpr chi::u64 kMaxExecBytes = 16ull * 1024 * 1024;
-  std::vector<chi::Future<AppendExecutionTask>> futs;
   chi::u32 spread = 0;
   size_t i = 0;
   while (i < plan.size()) {
@@ -907,15 +939,19 @@ chi::TaskResume Runtime::AppendCollect(
           (plan[i].data_blob_id_ != slice.back().data_blob_id_);
       if (bytes >= kMaxExecBytes && at_blob_boundary) break;
     }
+    // Dispatch and await one slice at a time. Slices of a single batch write
+    // disjoint file regions, but they MUST NOT be in flight simultaneously:
+    // the CPU await path keeps only one coroutine handle, so an out-of-order
+    // slice completion would resume this coroutine onto the wrong awaiter and
+    // free a still-queued task's FutureShm (the use-after-free documented in
+    // AppendExecution). Concurrency across the system still comes from distinct
+    // tags' batches, which run as independent top-level AppendPlan tasks.
     auto q = chi::PoolQuery::DirectHash(spread++);
-    futs.push_back(
-        self_.AsyncAppendExecution(tag_id, staging_tag_id_, slice, q));
-  }
-  for (auto &f : futs) {
+    auto f = self_.AsyncAppendExecution(tag_id, staging_tag_id_, slice, q);
     CLIO_CO_AWAIT(f);
   }
 
-  task->new_size_ = file_off;
+  (void)file_off;
   task->return_code_ = 0;
   (void)ctx;
   CLIO_CO_RETURN;
@@ -931,63 +967,58 @@ chi::TaskResume Runtime::AppendExecution(
   const size_t n = task->steps_.size();
   bool ok = true;
 
-  // Allocate one staging buffer per step up front so buffers/futures stay
-  // index-aligned with steps_. If any allocation fails, unwind and bail.
-  std::vector<ctp::ipc::FullPtr<char>> bufs;
-  bufs.reserve(n);
-  for (size_t i = 0; i < n; ++i) {
-    ctp::ipc::FullPtr<char> b = ipc->AllocateBuffer(task->steps_[i].size_);
-    if (b.IsNull()) { ok = false; break; }
-    bufs.push_back(b);
-  }
-  if (!ok) {
-    for (auto &b : bufs) ipc->FreeBuffer(b);
-    task->return_code_ = ENOMEM;
-    CLIO_CO_RETURN;
-  }
-
-  // 1) GetBlob each step's data slice in parallel.
-  std::vector<chi::Future<clio::cte::core::GetBlobTask>> gets;
-  gets.reserve(n);
-  for (size_t i = 0; i < n; ++i) {
+  // Apply each step strictly sequentially: AT MOST ONE subtask future may be
+  // outstanding at a time. The runtime's CPU await path stores only the
+  // coroutine handle (RunContext::coro_handle_) — it does NOT record *which*
+  // future the coroutine is suspended on. Any sibling subtask completion
+  // resumes the coroutine, and await_resume() then unconditionally Destroy()s
+  // whatever future it is currently awaiting. So if several subtasks were in
+  // flight at once, an out-of-order completion would run await_resume() on a
+  // DIFFERENT, still-running task — freeing that task's FutureShm while it is
+  // still queued in a worker lane, a heap-use-after-free (observed as garbage
+  // pool ids in Worker::ProcessNewTask). Issuing get -> await -> put -> await
+  // one step at a time keeps exactly one future live, so only that future's
+  // completion can ever resume us. System-wide concurrency still comes from
+  // distinct tags' batches, which run as independent top-level merge tasks.
+  for (size_t i = 0; i < n && ok; ++i) {
     const AppendPlanStep &s = task->steps_[i];
-    gets.push_back(cte_.AsyncGetBlob(staging, s.data_blob_id_, s.off_in_data_,
-                                     s.size_, 0u,
-                                     bufs[i].shm_.template Cast<void>(),
-                                     chi::PoolQuery::Local()));
-  }
+    ctp::ipc::FullPtr<char> buf = ipc->AllocateBuffer(s.size_);
+    if (buf.IsNull()) {
+      ok = false;
+      break;
+    }
 
-  // 2) As each Get completes, PutBlob the bytes into the destination file page.
-  // PutBlobs are issued SEQUENTIALLY (await each before the next): multiple
-  // steps in a slice can target the SAME 1 MiB page blob at different offsets,
-  // and concurrent PutBlobs to one blob race in the core's extend/modify path
-  // (corrupting the block list). The GetBlobs above already overlap, so the
-  // reads still pipeline; only the same-tag writes are serialized.
-  for (size_t i = 0; i < n; ++i) {
-    CLIO_CO_AWAIT(gets[i]);  // a short/hole read just leaves zeros
-    const AppendPlanStep &s = task->steps_[i];
+    // Read this step's staged data slice (a short/hole read leaves zeros).
+    auto g = cte_.AsyncGetBlob(staging, s.data_blob_id_, s.off_in_data_,
+                               s.size_, 0u, buf.shm_.template Cast<void>(),
+                               chi::PoolQuery::Local());
+    CLIO_CO_AWAIT(g);
+
+    // Write the bytes into the destination file page. PutBlobs are necessarily
+    // serialized: multiple steps can target the SAME 1 MiB page blob at
+    // different offsets, and concurrent PutBlobs to one blob race in the core's
+    // extend/modify path (corrupting the block list).
     auto p = cte_.AsyncPutBlob(
         tag_id, std::to_string(s.file_page_), s.off_in_page_, s.size_,
-        bufs[i].shm_.template Cast<void>(), -1.0f, clio::cte::core::Context(),
-        0u, chi::PoolQuery::Local());
+        buf.shm_.template Cast<void>(), -1.0f, clio::cte::core::Context(), 0u,
+        chi::PoolQuery::Local());
     CLIO_CO_AWAIT(p);
     if (p->GetReturnCode() != 0) ok = false;
-  }
-  for (auto &b : bufs) ipc->FreeBuffer(b);
 
-  // 3) DelBlob each distinct staged data blob (once), then await all. Because a
-  // data blob's steps are confined to one execution task, this is the only task
-  // that deletes it — no double-free.
+    ipc->FreeBuffer(buf);
+  }
+
+  // DelBlob each distinct staged data blob exactly once, one at a time (same
+  // single-outstanding-future rule as the read/write loop above). Because a
+  // data blob's steps are confined to one execution task, this is the only
+  // task that deletes it — no double-free.
   std::unordered_set<std::string> seen;
-  std::vector<chi::Future<clio::cte::core::DelBlobTask>> dels;
   for (const auto &s : task->steps_) {
     if (seen.insert(s.data_blob_id_).second) {
-      dels.push_back(
-          cte_.AsyncDelBlob(staging, s.data_blob_id_, chi::PoolQuery::Local()));
+      auto d = cte_.AsyncDelBlob(staging, s.data_blob_id_,
+                                 chi::PoolQuery::Local());
+      CLIO_CO_AWAIT(d);
     }
-  }
-  for (auto &d : dels) {
-    CLIO_CO_AWAIT(d);
   }
 
   task->return_code_ = ok ? 0 : EIO;

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -89,6 +89,19 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
   // assigned pool id from the CreateTask (pool_id_ isn't reliable yet here),
   // matching how the CTE core initializes its self-client.
   self_.Init(task->new_pool_id_);
+
+  // Resolve the global append-staging tag (shared by all files). Append data
+  // blobs live here, so they don't inflate any file's GetTagSize. Flat tag
+  // name (no leading '/') => not hierarchical.
+  {
+    auto st = cte_.AsyncGetOrCreateTag("_clio_append_staging",
+                                       clio::cte::core::TagId::GetNull(),
+                                       chi::PoolQuery::Local());
+    CLIO_CO_AWAIT(st);
+    if (st->GetReturnCode() == 0) {
+      staging_tag_id_ = st->tag_id_;
+    }
+  }
   HLOG(kInfo, "filesystem: Create over CTE core pool {}",
        next_pool_id_.ToString());
   task->return_code_ = 0;
@@ -335,8 +348,10 @@ chi::TaskResume Runtime::Append(ctp::ipc::FullPtr<AppendTask> task,
   chi::u32 node_id = CLIO_IPC->GetNodeId();
   std::string data_blob_id = MakeDataBlobId(node_id, logical);
 
-  auto p = cte_.AsyncPutBlob(tag_id, data_blob_id, 0, want, task->data_, -1.0f,
-                             clio::cte::core::Context(), 0u,
+  // Stage the bytes under the shared staging tag (NOT the file tag), so the
+  // file's GetTagSize stays equal to its merged content (the true tail).
+  auto p = cte_.AsyncPutBlob(staging_tag_id_, data_blob_id, 0, want,
+                             task->data_, -1.0f, clio::cte::core::Context(), 0u,
                              chi::PoolQuery::Local());
   CLIO_CO_AWAIT(p);
   if (p->GetReturnCode() != 0) {
@@ -840,20 +855,17 @@ chi::TaskResume Runtime::AppendCollect(
               return a.logical_ < b.logical_;
             });
 
-  chi::u64 batch_total = 0;
-  for (auto &e : entries) batch_total += e.data_blob_size_;
-
-  // Tail of the file. GetTagSize (broadcast) sums all blobs under the tag,
-  // which still includes this batch's staged data blobs — subtract them to get
-  // the true file content size to append at. (Concurrent batches for the same
-  // tag are serialized by ManyToOne batching; cross-batch size tracking is a
-  // separate hardening issue.)
+  // Tail of the file = its merged content size. Append data blobs live under
+  // the separate staging tag, so GetTagSize(file_tag) is exactly the tail.
+  // Because at most one AppendCollect per tag runs at a time (BatchManager
+  // serialization) and each fully merges + deletes its staged blobs before
+  // completing, this read is stable: the previous batch's bytes are already in
+  // the file pages and no other batch is mutating it.
   chi::u64 cur_size = 0;
   {
     auto s = cte_.AsyncGetTagSize(tag_id, chi::PoolQuery::Broadcast());
     CLIO_CO_AWAIT(s);
-    chi::u64 total = (s->GetReturnCode() == 0) ? s->tag_size_ : 0;
-    cur_size = (total >= batch_total) ? (total - batch_total) : 0;
+    cur_size = (s->GetReturnCode() == 0) ? s->tag_size_ : 0;
   }
 
   // Build the merge plan: lay each data blob out contiguously starting at
@@ -896,7 +908,8 @@ chi::TaskResume Runtime::AppendCollect(
       if (bytes >= kMaxExecBytes && at_blob_boundary) break;
     }
     auto q = chi::PoolQuery::DirectHash(spread++);
-    futs.push_back(self_.AsyncAppendExecution(tag_id, slice, q));
+    futs.push_back(
+        self_.AsyncAppendExecution(tag_id, staging_tag_id_, slice, q));
   }
   for (auto &f : futs) {
     CLIO_CO_AWAIT(f);
@@ -912,7 +925,8 @@ chi::TaskResume Runtime::AppendCollect(
 chi::TaskResume Runtime::AppendExecution(
     ctp::ipc::FullPtr<AppendExecutionTask> task, chi::RunContext &ctx) {
   CLIO_TASK_BODY_BEGIN
-  clio::cte::core::TagId tag_id = task->tag_id_;
+  clio::cte::core::TagId tag_id = task->tag_id_;        // destination file tag
+  clio::cte::core::TagId staging = task->staging_tag_id_;  // source staged blobs
   auto *ipc = CLIO_IPC;
   const size_t n = task->steps_.size();
   bool ok = true;
@@ -937,24 +951,25 @@ chi::TaskResume Runtime::AppendExecution(
   gets.reserve(n);
   for (size_t i = 0; i < n; ++i) {
     const AppendPlanStep &s = task->steps_[i];
-    gets.push_back(cte_.AsyncGetBlob(tag_id, s.data_blob_id_, s.off_in_data_,
+    gets.push_back(cte_.AsyncGetBlob(staging, s.data_blob_id_, s.off_in_data_,
                                      s.size_, 0u,
                                      bufs[i].shm_.template Cast<void>(),
                                      chi::PoolQuery::Local()));
   }
 
   // 2) As each Get completes, PutBlob the bytes into the destination file page.
-  std::vector<chi::Future<clio::cte::core::PutBlobTask>> puts;
-  puts.reserve(n);
+  // PutBlobs are issued SEQUENTIALLY (await each before the next): multiple
+  // steps in a slice can target the SAME 1 MiB page blob at different offsets,
+  // and concurrent PutBlobs to one blob race in the core's extend/modify path
+  // (corrupting the block list). The GetBlobs above already overlap, so the
+  // reads still pipeline; only the same-tag writes are serialized.
   for (size_t i = 0; i < n; ++i) {
     CLIO_CO_AWAIT(gets[i]);  // a short/hole read just leaves zeros
     const AppendPlanStep &s = task->steps_[i];
-    puts.push_back(cte_.AsyncPutBlob(
+    auto p = cte_.AsyncPutBlob(
         tag_id, std::to_string(s.file_page_), s.off_in_page_, s.size_,
         bufs[i].shm_.template Cast<void>(), -1.0f, clio::cte::core::Context(),
-        0u, chi::PoolQuery::Local()));
-  }
-  for (auto &p : puts) {
+        0u, chi::PoolQuery::Local());
     CLIO_CO_AWAIT(p);
     if (p->GetReturnCode() != 0) ok = false;
   }
@@ -968,7 +983,7 @@ chi::TaskResume Runtime::AppendExecution(
   for (const auto &s : task->steps_) {
     if (seen.insert(s.data_blob_id_).second) {
       dels.push_back(
-          cte_.AsyncDelBlob(tag_id, s.data_blob_id_, chi::PoolQuery::Local()));
+          cte_.AsyncDelBlob(staging, s.data_blob_id_, chi::PoolQuery::Local()));
     }
   }
   for (auto &d : dels) {

--- a/context-transfer-engine/filesystem/src/filesystem_runtime.cc
+++ b/context-transfer-engine/filesystem/src/filesystem_runtime.cc
@@ -10,14 +10,36 @@
 #include <cerrno>
 #include <cstring>
 #include <fcntl.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include <clio_cte/filesystem/filesystem_runtime.h>
 
 namespace clio::cte::filesystem {
 
 namespace {
+/** UTC wallclock nanoseconds (system_clock) — the primary append order key. */
+inline chi::u64 NowUtcNs() {
+  return static_cast<chi::u64>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count());
+}
+
+/**
+ * Reserved name for a staged append data blob, under the file's own tag. The
+ * "_append/" prefix can't collide with the numeric page-blob names ("0","1",
+ * ...); node id keeps it unique across nodes, the logical counter within a node.
+ */
+inline std::string MakeDataBlobId(chi::u32 node_id, chi::u64 logical) {
+  return "_append/" + std::to_string(node_id) + "." + std::to_string(logical);
+}
 /**
  * Reserved child tag that marks an explicit (possibly empty) directory.
  *
@@ -63,6 +85,10 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
   if (!next_pool_id_.IsNull()) {
     cte_ = clio::cte::core::Client(next_pool_id_);
   }
+  // Bind a client to our own pool for self-submitted pipeline tasks. Use the
+  // assigned pool id from the CreateTask (pool_id_ isn't reliable yet here),
+  // matching how the CTE core initializes its self-client.
+  self_.Init(task->new_pool_id_);
   HLOG(kInfo, "filesystem: Create over CTE core pool {}",
        next_pool_id_.ToString());
   task->return_code_ = 0;
@@ -296,34 +322,54 @@ chi::TaskResume Runtime::Append(ctp::ipc::FullPtr<AppendTask> task,
     CLIO_CO_RETURN;
   }
   clio::cte::core::TagId tag_id = fi->tag_id_;
-  chi::u64 offset = fi->size_.load();  // append at current logical EOF
-
-  // Append directly out of the task payload (no staging copy).
-  ctp::ipc::ShmPtr<char> data_base = task->data_.template Cast<char>();
   chi::u64 want = task->size_;
-  chi::u64 done = 0;
-  chi::u64 cur = offset;
-  bool ok = true;
-  while (done < want) {
-    chi::u64 page_off = cur % kFsPageSize;
-    chi::u64 to_write = std::min(kFsPageSize - page_off, want - done);
-    auto p = cte_.AsyncPutBlob(tag_id, PageName(cur), page_off, to_write,
-                               (data_base + done).template Cast<void>(), -1.0f,
-                               clio::cte::core::Context(), 0u,
-                               chi::PoolQuery::Local());
-    CLIO_CO_AWAIT(p);
-    if (p->GetReturnCode() != 0) { ok = false; break; }
-    done += to_write;
-    cur += to_write;
+
+  // Deferred append (local placement). Stamp a global order — wallclock UTC
+  // (primary) + per-node logical counter (tiebreak) — and write the bytes as a
+  // standalone "data blob" under the file's tag. The actual merge into the file
+  // tail happens later in the AppendSequence -> AppendCollect -> AppendExecution
+  // pipeline, so this path does no read-modify-write of the tail and needs no
+  // global coordination.
+  chi::u64 logical = append_logical_.fetch_add(1) + 1;
+  chi::u64 utc_ns = NowUtcNs();
+  chi::u32 node_id = CLIO_IPC->GetNodeId();
+  std::string data_blob_id = MakeDataBlobId(node_id, logical);
+
+  auto p = cte_.AsyncPutBlob(tag_id, data_blob_id, 0, want, task->data_, -1.0f,
+                             clio::cte::core::Context(), 0u,
+                             chi::PoolQuery::Local());
+  CLIO_CO_AWAIT(p);
+  if (p->GetReturnCode() != 0) {
+    task->return_code_ = EIO;
+    CLIO_CO_RETURN;
   }
-  chi::u64 end = offset + done;
-  chi::u64 old = fi->size_.load();
-  while (end > old && !fi->size_.compare_exchange_weak(old, end)) {
+
+  // Queue the pending entry; start the periodic drain on first use.
+  bool need_start = false;
+  {
+    std::lock_guard<std::mutex> g(append_mu_);
+    append_pending_.push_back(
+        PendingAppend{tag_id, AppendEntry{data_blob_id, want, utc_ns, logical}});
+    if (!append_seq_started_) {
+      append_seq_started_ = true;
+      need_start = true;
+    }
   }
-  task->offset_ = offset;
-  task->bytes_written_ = done;
-  task->new_size_ = fi->size_.load();
-  task->return_code_ = ok ? 0 : EIO;
+  if (need_start) {
+    // Periodic local drain (1 ms). The future is intentionally discarded — a
+    // periodic task is auto-rescheduled by the worker and never "completes".
+    self_.AsyncAppendSequence(/*period_us=*/1000.0, chi::PoolQuery::Local());
+  }
+
+  // Optimistically advance the tracked logical size. For a single writer this
+  // is exact; with concurrent appends across nodes the precise offset is only
+  // settled when the batch is sequenced (eventual consistency), so offset_ is
+  // best-effort.
+  chi::u64 newsz = fi->size_.fetch_add(want) + want;
+  task->offset_ = newsz - want;
+  task->bytes_written_ = want;
+  task->new_size_ = newsz;
+  task->return_code_ = 0;
   (void)ctx;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
@@ -729,6 +775,207 @@ chi::TaskResume Runtime::StatSize(ctp::ipc::FullPtr<StatSizeTask> task,
     task->size_ = 0;
   }
   task->return_code_ = 0;
+  (void)ctx;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+// ===========================================================================
+// Deferred-append pipeline handlers
+// ===========================================================================
+
+chi::TaskResume Runtime::AppendSequence(
+    ctp::ipc::FullPtr<AppendSequenceTask> task, chi::RunContext &ctx) {
+  CLIO_TASK_BODY_BEGIN
+  // Drain the per-node pending queue, then group entries by tag.
+  std::vector<PendingAppend> drained;
+  {
+    std::lock_guard<std::mutex> g(append_mu_);
+    drained.swap(append_pending_);
+  }
+  if (drained.empty()) {
+    task->return_code_ = 0;
+    CLIO_CO_RETURN;
+  }
+  std::unordered_map<clio::cte::core::TagId, std::vector<AppendEntry>> by_tag;
+  for (auto &pa : drained) {
+    by_tag[pa.tag_id_].push_back(pa.entry_);
+  }
+
+  // One AppendCollect per tag, routed ManyToOne so every node's batch for the
+  // same tag aggregates at that tag's sequencer (the leader chosen by the
+  // container hash). batch_key = the tag id keeps distinct tags' collectives
+  // separate on the same leader.
+  std::vector<chi::Future<AppendCollectTask>> futs;
+  futs.reserve(by_tag.size());
+  for (auto &kv : by_tag) {
+    const clio::cte::core::TagId &tag = kv.first;
+    chi::u32 chash = static_cast<chi::u32>(
+        std::hash<clio::cte::core::TagId>()(tag));
+    chi::u64 bkey = (static_cast<chi::u64>(tag.major_) << 32) | tag.minor_;
+    auto q = chi::PoolQuery::ManyToOne(chash, bkey, /*batch_for_ns=*/50000);
+    futs.push_back(self_.AsyncAppendCollect(tag, kv.second, q));
+  }
+  for (auto &f : futs) {
+    CLIO_CO_AWAIT(f);
+  }
+  task->return_code_ = 0;
+  (void)ctx;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+chi::TaskResume Runtime::AppendCollect(
+    ctp::ipc::FullPtr<AppendCollectTask> task, chi::RunContext &ctx) {
+  CLIO_TASK_BODY_BEGIN
+  // This runs ONCE per batch (the ManyToOne aggregate). task->entries_ already
+  // holds every node's pending entries for this tag (combined via AggregateIn).
+  clio::cte::core::TagId tag_id = task->tag_id_;
+  std::vector<AppendEntry> entries(task->entries_.begin(),
+                                   task->entries_.end());
+  // Global order: UTC first, logical counter as tiebreak.
+  std::sort(entries.begin(), entries.end(),
+            [](const AppendEntry &a, const AppendEntry &b) {
+              if (a.utc_ns_ != b.utc_ns_) return a.utc_ns_ < b.utc_ns_;
+              return a.logical_ < b.logical_;
+            });
+
+  chi::u64 batch_total = 0;
+  for (auto &e : entries) batch_total += e.data_blob_size_;
+
+  // Tail of the file. GetTagSize (broadcast) sums all blobs under the tag,
+  // which still includes this batch's staged data blobs — subtract them to get
+  // the true file content size to append at. (Concurrent batches for the same
+  // tag are serialized by ManyToOne batching; cross-batch size tracking is a
+  // separate hardening issue.)
+  chi::u64 cur_size = 0;
+  {
+    auto s = cte_.AsyncGetTagSize(tag_id, chi::PoolQuery::Broadcast());
+    CLIO_CO_AWAIT(s);
+    chi::u64 total = (s->GetReturnCode() == 0) ? s->tag_size_ : 0;
+    cur_size = (total >= batch_total) ? (total - batch_total) : 0;
+  }
+
+  // Build the merge plan: lay each data blob out contiguously starting at
+  // cur_size, splitting on 1 MiB file-page boundaries.
+  std::vector<AppendPlanStep> plan;
+  chi::u64 file_off = cur_size;
+  for (auto &e : entries) {
+    chi::u64 remaining = e.data_blob_size_;
+    chi::u64 doff = 0;
+    while (remaining > 0) {
+      chi::u64 page = file_off / kFsPageSize;
+      chi::u64 page_off = file_off % kFsPageSize;
+      chi::u64 step = std::min(kFsPageSize - page_off, remaining);
+      plan.push_back(AppendPlanStep{page, e.data_blob_id_, page_off, doff, step,
+                                    e.data_blob_size_});
+      file_off += step;
+      doff += step;
+      remaining -= step;
+    }
+  }
+
+  // Split into AppendExecution slices of up to 16 MiB. A data blob is never
+  // split across two slices, so exactly one execution task DelBlobs it (no
+  // double-free race); a single blob larger than 16 MiB forms its own slice.
+  constexpr chi::u64 kMaxExecBytes = 16ull * 1024 * 1024;
+  std::vector<chi::Future<AppendExecutionTask>> futs;
+  chi::u32 spread = 0;
+  size_t i = 0;
+  while (i < plan.size()) {
+    std::vector<AppendPlanStep> slice;
+    chi::u64 bytes = 0;
+    while (i < plan.size()) {
+      slice.push_back(plan[i]);
+      bytes += plan[i].size_;
+      ++i;
+      // Stop at a data-blob boundary once we've reached the size target.
+      bool at_blob_boundary =
+          (i >= plan.size()) ||
+          (plan[i].data_blob_id_ != slice.back().data_blob_id_);
+      if (bytes >= kMaxExecBytes && at_blob_boundary) break;
+    }
+    auto q = chi::PoolQuery::DirectHash(spread++);
+    futs.push_back(self_.AsyncAppendExecution(tag_id, slice, q));
+  }
+  for (auto &f : futs) {
+    CLIO_CO_AWAIT(f);
+  }
+
+  task->new_size_ = file_off;
+  task->return_code_ = 0;
+  (void)ctx;
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+chi::TaskResume Runtime::AppendExecution(
+    ctp::ipc::FullPtr<AppendExecutionTask> task, chi::RunContext &ctx) {
+  CLIO_TASK_BODY_BEGIN
+  clio::cte::core::TagId tag_id = task->tag_id_;
+  auto *ipc = CLIO_IPC;
+  const size_t n = task->steps_.size();
+  bool ok = true;
+
+  // Allocate one staging buffer per step up front so buffers/futures stay
+  // index-aligned with steps_. If any allocation fails, unwind and bail.
+  std::vector<ctp::ipc::FullPtr<char>> bufs;
+  bufs.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    ctp::ipc::FullPtr<char> b = ipc->AllocateBuffer(task->steps_[i].size_);
+    if (b.IsNull()) { ok = false; break; }
+    bufs.push_back(b);
+  }
+  if (!ok) {
+    for (auto &b : bufs) ipc->FreeBuffer(b);
+    task->return_code_ = ENOMEM;
+    CLIO_CO_RETURN;
+  }
+
+  // 1) GetBlob each step's data slice in parallel.
+  std::vector<chi::Future<clio::cte::core::GetBlobTask>> gets;
+  gets.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    const AppendPlanStep &s = task->steps_[i];
+    gets.push_back(cte_.AsyncGetBlob(tag_id, s.data_blob_id_, s.off_in_data_,
+                                     s.size_, 0u,
+                                     bufs[i].shm_.template Cast<void>(),
+                                     chi::PoolQuery::Local()));
+  }
+
+  // 2) As each Get completes, PutBlob the bytes into the destination file page.
+  std::vector<chi::Future<clio::cte::core::PutBlobTask>> puts;
+  puts.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    CLIO_CO_AWAIT(gets[i]);  // a short/hole read just leaves zeros
+    const AppendPlanStep &s = task->steps_[i];
+    puts.push_back(cte_.AsyncPutBlob(
+        tag_id, std::to_string(s.file_page_), s.off_in_page_, s.size_,
+        bufs[i].shm_.template Cast<void>(), -1.0f, clio::cte::core::Context(),
+        0u, chi::PoolQuery::Local()));
+  }
+  for (auto &p : puts) {
+    CLIO_CO_AWAIT(p);
+    if (p->GetReturnCode() != 0) ok = false;
+  }
+  for (auto &b : bufs) ipc->FreeBuffer(b);
+
+  // 3) DelBlob each distinct staged data blob (once), then await all. Because a
+  // data blob's steps are confined to one execution task, this is the only task
+  // that deletes it — no double-free.
+  std::unordered_set<std::string> seen;
+  std::vector<chi::Future<clio::cte::core::DelBlobTask>> dels;
+  for (const auto &s : task->steps_) {
+    if (seen.insert(s.data_blob_id_).second) {
+      dels.push_back(
+          cte_.AsyncDelBlob(tag_id, s.data_blob_id_, chi::PoolQuery::Local()));
+    }
+  }
+  for (auto &d : dels) {
+    CLIO_CO_AWAIT(d);
+  }
+
+  task->return_code_ = ok ? 0 : EIO;
   (void)ctx;
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END

--- a/context-transport-primitives/include/clio_ctp/data_structures/priv/unordered_map_ll.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/priv/unordered_map_ll.h
@@ -563,10 +563,19 @@ class unordered_map_ll {
   /** Erase by key. */
   CTP_CROSS_FUN
   size_type erase(const Key &key) {
+    // Must hold the global read lock for the whole bucket access, exactly like
+    // insert/find/operator[]: it pins the bucket/lock arrays so a concurrent
+    // rehash (which takes the global write lock and momentarily empties
+    // buckets_ during its move+resize) cannot run underneath us. Without it,
+    // bucket_of() can read buckets_.size()==0 mid-rehash and divide by zero
+    // (observed as a "Numerical" crash in the concurrent insert/erase/grow
+    // stress test on stricter toolchains).
+    global_read_lock();
     size_type b = bucket_of(key);
     write_lock_bucket(b);
     size_type r = erase_locked(key);
     write_unlock_bucket(b);
+    global_read_unlock();
     return r;
   }
 

--- a/context-transport-primitives/include/clio_ctp/data_structures/priv/unordered_map_ll.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/priv/unordered_map_ll.h
@@ -46,20 +46,26 @@
 // THREAD-SAFETY CONTRACT (important):
 //   * Single-key operations (insert, insert_or_assign, operator[],
 //     find, contains, count, erase) ARE self-locking and safe to call
-//     concurrently from many threads when EnableLocking is true.
-//   * Rehash is NOT thread-safe and is intentionally not made so. A
-//     rehash reallocates BOTH the bucket array and the per-bucket lock
-//     array; the lock array cannot protect its own reallocation, so a
-//     rehash that runs concurrently with ANY other map operation is a
-//     data race / use-after-free. Rehash happens (a) automatically
-//     inside maybe_rehash() when size exceeds bucket_count() after an
-//     insert, and (b) explicitly via rehash().
-//   * Therefore, for concurrent use the caller MUST guarantee the map
-//     never rehashes while other threads touch it. The simple, intended
-//     way is to construct the map with bucket_count() > the maximum
-//     number of distinct keys ever inserted, so the load factor stays
-//     <= 1 and maybe_rehash() always early-returns. Otherwise the
-//     caller must quiesce all other threads around any rehash.
+//     concurrently from many threads when EnableLocking is true —
+//     INCLUDING while the table grows. They are safe to interleave with
+//     automatic rehash (growth) at any time.
+//   * Safe growth is provided by a map-wide RwLock (`global_lock_`): every
+//     single-key op holds it in READ mode (shared) for the duration of its
+//     bucket access, and rehash takes it in WRITE mode (exclusive). The
+//     write lock drains all in-flight ops before reallocating the bucket
+//     and per-bucket-lock arrays, and blocks new ops until growth finishes —
+//     so the old use-after-free (a rehash racing the lock-array realloc) can
+//     no longer happen. Automatic rehash fires inside maybe_rehash() once
+//     size reaches ext_percent_ * bucket_count() after an insert; explicit
+//     rehash() / clear() / for_each() also take the write lock.
+//   * Bucket-local concurrency is preserved: while the global lock is held
+//     shared, ops on DIFFERENT buckets still run in parallel via the
+//     per-bucket RwLocks; only growth serializes everything briefly.
+//   * Cost: each op takes one shared global read-lock in addition to its
+//     bucket lock. A callback passed to for_each MUST NOT re-enter the same
+//     map (the exclusive lock would deadlock).
+//   * Sizing still matters for PERFORMANCE (not safety): construct with
+//     bucket_count() near the expected key count to avoid growth churn.
 //
 // Counterpart to `unordered_map_lhash` (linear-probing open-addressing,
 // previously named `unordered_map_ll`). Chaining trades the predictable
@@ -127,10 +133,26 @@ class unordered_map_ll {
 
   vector<Node *, AllocT> buckets_;  // bucket heads (nullptr = empty)
   vector<ctp::RwLock, AllocT> locks_;  // per-bucket; size 0 when !EnableLocking
+  // Map-wide lock making in-place rehash safe under concurrency. Every
+  // single-key op holds it in READ mode (shared) for the duration of the
+  // bucket access, so the bucket/lock arrays can't be reallocated underneath
+  // it; rehash/clear/for_each take it in WRITE mode (exclusive), which drains
+  // all in-flight ops first. See the THREAD-SAFETY CONTRACT above.
+  ctp::RwLock global_lock_;
   ctp::ipc::atomic<size_type> size_;
   AllocT *alloc_;
   Hash hash_fn_;
   KeyEqual key_eq_;
+  // Growth policy: rehash once size reaches ext_percent_ * bucket_count, to a
+  // new bucket_count of ext_mult_ * bucket_count.
+  double ext_percent_;
+  size_type ext_mult_;
+
+  /** Rehash threshold (>= 1) for the current bucket count. */
+  CTP_INLINE_CROSS_FUN size_type rehash_threshold(size_type cap) const {
+    size_type t = static_cast<size_type>(ext_percent_ * static_cast<double>(cap));
+    return t < 1 ? 1 : t;
+  }
 
   /** Map a key to a bucket index. */
   CTP_INLINE_CROSS_FUN
@@ -155,6 +177,24 @@ class unordered_map_ll {
   CTP_INLINE_CROSS_FUN
   void write_unlock_bucket(size_type b) {
     if constexpr (EnableLocking) locks_[b].WriteUnlock();
+  }
+
+  /** Map-wide read lock — shared; held during every single-key operation so a
+   *  concurrent rehash (which needs the write lock) cannot reallocate the
+   *  bucket/lock arrays mid-operation. No-op when locking is disabled. */
+  CTP_INLINE_CROSS_FUN void global_read_lock() {
+    if constexpr (EnableLocking) global_lock_.ReadLock(0);
+  }
+  CTP_INLINE_CROSS_FUN void global_read_unlock() {
+    if constexpr (EnableLocking) global_lock_.ReadUnlock();
+  }
+  /** Map-wide write lock — exclusive; taken only to grow/clear/iterate. Drains
+   *  all in-flight single-key ops (their read locks) before proceeding. */
+  CTP_INLINE_CROSS_FUN void global_write_lock() {
+    if constexpr (EnableLocking) global_lock_.WriteLock(0);
+  }
+  CTP_INLINE_CROSS_FUN void global_write_unlock() {
+    if constexpr (EnableLocking) global_lock_.WriteUnlock();
   }
 
   /** Acquire every bucket's write lock. Used for rehash / clear / for_each. */
@@ -205,6 +245,9 @@ class unordered_map_ll {
     if constexpr (EnableLocking) {
       locks_.resize(num_buckets);
       for (size_type i = 0; i < num_buckets; ++i) locks_[i].Init();
+      // The map-wide lock persists across rehash (it guards the rehash), so it
+      // is initialized once here and NEVER re-Init()'d by rehash_no_lock().
+      global_lock_.Init();
     }
   }
 
@@ -238,41 +281,39 @@ class unordered_map_ll {
     }
   }
 
-  /** Trigger rehash if load factor (size / num_buckets) > 1. Caller
-   *  must NOT hold any per-bucket lock.
+  /** Grow the table when size reaches ext_percent_ * bucket_count. Caller must
+   *  NOT hold any per-bucket lock OR the global read lock (this takes the
+   *  global WRITE lock).
    *
-   *  NOT thread-safe: see the THREAD-SAFETY CONTRACT at the top of this
-   *  file. Although this takes write_lock_all(), the rehash reallocates
-   *  the lock array itself, so it races with any concurrent operation.
-   *  Concurrent users must size the map so this always early-returns
-   *  (bucket_count() > max distinct keys) or otherwise quiesce all
-   *  threads around growth. */
+   *  Thread-safe: the global write lock drains every in-flight single-key op
+   *  (each holds the global read lock for its duration) before the bucket and
+   *  lock arrays are reallocated, and blocks new ops until the rehash
+   *  completes. The cheap pre-check is racy but harmless — it is re-evaluated
+   *  under the exclusive lock. */
   CTP_INLINE_CROSS_FUN
   void maybe_rehash() {
     size_type cur_size = size_.load();
     size_type cap = buckets_.size();
-    if (cur_size <= cap) return;
-    write_lock_all();
+    if (cur_size < rehash_threshold(cap)) return;
+    global_write_lock();
     cur_size = size_.load();
     cap = buckets_.size();
-    if (cur_size > cap) {
-      // rehash_no_lock() re-Init()s (and thereby releases) every bucket
-      // lock while resizing locks_. Do NOT write_unlock_all() afterward:
-      // unlocking freshly Init()'d locks underflows writers_ and bumps
-      // cur_writer_, which wedges every subsequent WriteLock() forever.
-      rehash_no_lock(cap * 2);
-    } else {
-      // No rehash happened, so release exactly the locks we acquired.
-      write_unlock_all();
+    if (cur_size >= rehash_threshold(cap)) {
+      rehash_no_lock(cap * ext_mult_);
     }
+    global_write_unlock();
   }
 
  public:
 #if CTP_IS_HOST
-  /** Host-side constructor using the global MallocAllocator. */
-  explicit unordered_map_ll(size_type num_buckets = 16)
+  /** Host-side constructor using the global MallocAllocator.
+   *  @param ext_percent grow once size reaches this fraction of bucket_count
+   *  @param ext_mult    multiply bucket_count by this on each rehash (>= 2) */
+  explicit unordered_map_ll(size_type num_buckets = 16,
+                            double ext_percent = 0.6, size_type ext_mult = 2)
       : buckets_(CTP_MALLOC), locks_(CTP_MALLOC), size_(0),
-        alloc_(CTP_MALLOC), hash_fn_(), key_eq_() {
+        alloc_(CTP_MALLOC), hash_fn_(), key_eq_(),
+        ext_percent_(ext_percent), ext_mult_(ext_mult < 2 ? 2 : ext_mult) {
     init_buckets(num_buckets);
   }
   /** Three-arg constructor kept for source compatibility with the
@@ -281,16 +322,19 @@ class unordered_map_ll {
   CTP_CROSS_FUN
   unordered_map_ll(size_type num_buckets, size_type /*num_locks_ignored*/)
       : buckets_(CTP_MALLOC), locks_(CTP_MALLOC), size_(0),
-        alloc_(CTP_MALLOC), hash_fn_(), key_eq_() {
+        alloc_(CTP_MALLOC), hash_fn_(), key_eq_(),
+        ext_percent_(0.6), ext_mult_(2) {
     init_buckets(num_buckets);
   }
 #endif
 
   /** Constructor with an explicit allocator. */
   CTP_CROSS_FUN
-  explicit unordered_map_ll(AllocT *alloc, size_type num_buckets = 16)
+  explicit unordered_map_ll(AllocT *alloc, size_type num_buckets = 16,
+                            double ext_percent = 0.6, size_type ext_mult = 2)
       : buckets_(alloc), locks_(alloc), size_(0),
-        alloc_(alloc), hash_fn_(), key_eq_() {
+        alloc_(alloc), hash_fn_(), key_eq_(),
+        ext_percent_(ext_percent), ext_mult_(ext_mult < 2 ? 2 : ext_mult) {
     init_buckets(num_buckets);
   }
 
@@ -299,7 +343,8 @@ class unordered_map_ll {
   unordered_map_ll(AllocT *alloc, size_type num_buckets,
                    size_type /*num_locks_ignored*/)
       : buckets_(alloc), locks_(alloc), size_(0),
-        alloc_(alloc), hash_fn_(), key_eq_() {
+        alloc_(alloc), hash_fn_(), key_eq_(),
+        ext_percent_(0.6), ext_mult_(2) {
     init_buckets(num_buckets);
   }
 
@@ -334,14 +379,9 @@ class unordered_map_ll {
    *  erases would race and use freed memory. */
   CTP_CROSS_FUN
   bool rehash(size_type new_bucket_count) {
-    write_lock_all();
-    // rehash_no_lock() resizes locks_ and re-Init()s every bucket lock,
-    // which both releases the locks we just took and discards their held
-    // state. Calling write_unlock_all() afterward would run WriteUnlock()
-    // on freshly Init()'d (unlocked) locks -- underflowing writers_ and
-    // advancing cur_writer_ -- permanently wedging all future WriteLock()
-    // calls in an infinite spin. The rehash itself is the release.
+    global_write_lock();
     rehash_no_lock(new_bucket_count);
+    global_write_unlock();
     return true;
   }
 
@@ -402,10 +442,12 @@ class unordered_map_ll {
   /** Insert if absent; thread-safe. */
   CTP_CROSS_FUN
   InsertResult<T> insert(const Key &key, const T &value) {
+    global_read_lock();
     size_type b = bucket_of(key);
     write_lock_bucket(b);
     InsertResult<T> r = insert_locked(key, value);
     write_unlock_bucket(b);
+    global_read_unlock();
     if (r.inserted) maybe_rehash();
     return r;
   }
@@ -413,6 +455,7 @@ class unordered_map_ll {
   /** Insert if absent, else overwrite. */
   CTP_CROSS_FUN
   InsertResult<T> insert_or_assign(const Key &key, const T &value) {
+    global_read_lock();
     size_type b = bucket_of(key);
     write_lock_bucket(b);
     Node *n = find_in_bucket(b, key);
@@ -431,6 +474,7 @@ class unordered_map_ll {
       }
     }
     write_unlock_bucket(b);
+    global_read_unlock();
     if (r.inserted) maybe_rehash();
     return r;
   }
@@ -438,39 +482,51 @@ class unordered_map_ll {
   /** operator[] -- creates a default-valued entry if absent. */
   CTP_CROSS_FUN
   T &operator[](const Key &key) {
+    global_read_lock();
     size_type b = bucket_of(key);
     write_lock_bucket(b);
     Node *n = find_in_bucket(b, key);
+    bool inserted = false;
     if (n == nullptr) {
       Node *fresh = new_node(key, T(), buckets_[b]);
       buckets_[b] = fresh;
       size_.fetch_add(1);
       n = fresh;
+      inserted = true;
     }
+    // Safe to return the ref after unlocking: rehash only re-threads existing
+    // Node objects (never reallocates them), so &n->value_ stays valid.
     T &ref = n->value_;
     write_unlock_bucket(b);
+    global_read_unlock();
+    if (inserted) maybe_rehash();
     return ref;
   }
 
   /** Lookup (mutable) returning a pointer or nullptr. */
   CTP_CROSS_FUN
   T *find(const Key &key) {
+    global_read_lock();
     size_type b = bucket_of(key);
     read_lock_bucket(b);
     Node *n = find_in_bucket(b, key);
     T *res = n != nullptr ? &n->value_ : nullptr;
     read_unlock_bucket(b);
+    global_read_unlock();
     return res;
   }
 
   /** Lookup (const). */
   CTP_CROSS_FUN
   const T *find(const Key &key) const {
+    auto *self = const_cast<unordered_map_ll *>(this);
+    self->global_read_lock();
     size_type b = bucket_of(key);
-    const_cast<unordered_map_ll *>(this)->read_lock_bucket(b);
+    self->read_lock_bucket(b);
     Node *n = find_in_bucket(b, key);
     const T *res = n != nullptr ? &n->value_ : nullptr;
-    const_cast<unordered_map_ll *>(this)->read_unlock_bucket(b);
+    self->read_unlock_bucket(b);
+    self->global_read_unlock();
     return res;
   }
 
@@ -490,7 +546,7 @@ class unordered_map_ll {
   /** Drop all entries. */
   CTP_CROSS_FUN
   void clear() {
-    write_lock_all();
+    global_write_lock();
     for (size_type i = 0; i < buckets_.size(); ++i) {
       Node *cur = buckets_[i];
       while (cur != nullptr) {
@@ -501,14 +557,16 @@ class unordered_map_ll {
       buckets_[i] = nullptr;
     }
     size_.store(0);
-    write_unlock_all();
+    global_write_unlock();
   }
 
-  /** Apply `fn(key, value)` to every entry. Takes every write lock so
-   *  the callback sees a consistent snapshot. */
+  /** Apply `fn(key, value)` to every entry. Takes the map-wide write lock so
+   *  the callback sees a consistent snapshot (no concurrent mutation or
+   *  rehash). The callback MUST NOT re-enter this same map (it would deadlock
+   *  on the exclusive lock). */
   template <typename Func>
   CTP_CROSS_FUN void for_each(Func fn) {
-    write_lock_all();
+    global_write_lock();
     for (size_type i = 0; i < buckets_.size(); ++i) {
       Node *cur = buckets_[i];
       while (cur != nullptr) {
@@ -516,13 +574,13 @@ class unordered_map_ll {
         cur = cur->next_;
       }
     }
-    write_unlock_all();
+    global_write_unlock();
   }
 
   template <typename Func>
   CTP_CROSS_FUN void for_each(Func fn) const {
     auto *self = const_cast<unordered_map_ll *>(this);
-    self->write_lock_all();
+    self->global_write_lock();
     for (size_type i = 0; i < buckets_.size(); ++i) {
       Node *cur = buckets_[i];
       while (cur != nullptr) {
@@ -530,7 +588,7 @@ class unordered_map_ll {
         cur = cur->next_;
       }
     }
-    self->write_unlock_all();
+    self->global_write_unlock();
   }
 };
 

--- a/context-transport-primitives/include/clio_ctp/data_structures/priv/unordered_map_ll.h
+++ b/context-transport-primitives/include/clio_ctp/data_structures/priv/unordered_map_ll.h
@@ -139,6 +139,15 @@ class unordered_map_ll {
   // it; rehash/clear/for_each take it in WRITE mode (exclusive), which drains
   // all in-flight ops first. See the THREAD-SAFETY CONTRACT above.
   ctp::RwLock global_lock_;
+  // Writer-preference signal for global_lock_. ctp::RwLock is reader-preferring:
+  // ReadLock enters whenever the lock is already in read mode, regardless of a
+  // waiting writer, and the mode only drops to "none" once readers_ hits 0. A
+  // sustained stream of inserts/finds therefore keeps readers_ > 0 forever and
+  // the rehash WriteLock can starve indefinitely (observed as a Windows
+  // livelock/timeout in the concurrent-growth stress test). This counter rises
+  // only around the rare grow/clear/iterate path; readers yield while it is
+  // nonzero so in-flight readers drain and the writer can acquire.
+  ctp::ipc::atomic<size_type> pending_writers_;
   ctp::ipc::atomic<size_type> size_;
   AllocT *alloc_;
   Hash hash_fn_;
@@ -183,18 +192,36 @@ class unordered_map_ll {
    *  concurrent rehash (which needs the write lock) cannot reallocate the
    *  bucket/lock arrays mid-operation. No-op when locking is disabled. */
   CTP_INLINE_CROSS_FUN void global_read_lock() {
-    if constexpr (EnableLocking) global_lock_.ReadLock(0);
+    if constexpr (EnableLocking) {
+      // Defer to a pending writer (rehash) so it cannot starve — see the
+      // pending_writers_ comment. Stragglers that slip past this check before a
+      // writer bumps the counter are bounded (the writer's WriteLock simply
+      // drains them), so this throttles new readers without blocking forever.
+      while (pending_writers_.load() > 0) {
+#if !CTP_IS_DEVICE_PASS
+        CTP_THREAD_MODEL->Yield();
+#endif
+      }
+      global_lock_.ReadLock(0);
+    }
   }
   CTP_INLINE_CROSS_FUN void global_read_unlock() {
     if constexpr (EnableLocking) global_lock_.ReadUnlock();
   }
   /** Map-wide write lock — exclusive; taken only to grow/clear/iterate. Drains
-   *  all in-flight single-key ops (their read locks) before proceeding. */
+   *  all in-flight single-key ops (their read locks) before proceeding. Bumps
+   *  pending_writers_ first so new readers back off (writer preference). */
   CTP_INLINE_CROSS_FUN void global_write_lock() {
-    if constexpr (EnableLocking) global_lock_.WriteLock(0);
+    if constexpr (EnableLocking) {
+      pending_writers_.fetch_add(1);
+      global_lock_.WriteLock(0);
+    }
   }
   CTP_INLINE_CROSS_FUN void global_write_unlock() {
-    if constexpr (EnableLocking) global_lock_.WriteUnlock();
+    if constexpr (EnableLocking) {
+      global_lock_.WriteUnlock();
+      pending_writers_.fetch_sub(1);
+    }
   }
 
   /** Acquire every bucket's write lock. Used for rehash / clear / for_each. */
@@ -311,7 +338,7 @@ class unordered_map_ll {
    *  @param ext_mult    multiply bucket_count by this on each rehash (>= 2) */
   explicit unordered_map_ll(size_type num_buckets = 16,
                             double ext_percent = 0.6, size_type ext_mult = 2)
-      : buckets_(CTP_MALLOC), locks_(CTP_MALLOC), size_(0),
+      : buckets_(CTP_MALLOC), locks_(CTP_MALLOC), pending_writers_(0), size_(0),
         alloc_(CTP_MALLOC), hash_fn_(), key_eq_(),
         ext_percent_(ext_percent), ext_mult_(ext_mult < 2 ? 2 : ext_mult) {
     init_buckets(num_buckets);
@@ -321,7 +348,7 @@ class unordered_map_ll {
    *  one-per-bucket and toggled by the EnableLocking template arg). */
   CTP_CROSS_FUN
   unordered_map_ll(size_type num_buckets, size_type /*num_locks_ignored*/)
-      : buckets_(CTP_MALLOC), locks_(CTP_MALLOC), size_(0),
+      : buckets_(CTP_MALLOC), locks_(CTP_MALLOC), pending_writers_(0), size_(0),
         alloc_(CTP_MALLOC), hash_fn_(), key_eq_(),
         ext_percent_(0.6), ext_mult_(2) {
     init_buckets(num_buckets);
@@ -332,7 +359,7 @@ class unordered_map_ll {
   CTP_CROSS_FUN
   explicit unordered_map_ll(AllocT *alloc, size_type num_buckets = 16,
                             double ext_percent = 0.6, size_type ext_mult = 2)
-      : buckets_(alloc), locks_(alloc), size_(0),
+      : buckets_(alloc), locks_(alloc), pending_writers_(0), size_(0),
         alloc_(alloc), hash_fn_(), key_eq_(),
         ext_percent_(ext_percent), ext_mult_(ext_mult < 2 ? 2 : ext_mult) {
     init_buckets(num_buckets);
@@ -342,7 +369,7 @@ class unordered_map_ll {
   CTP_CROSS_FUN
   unordered_map_ll(AllocT *alloc, size_type num_buckets,
                    size_type /*num_locks_ignored*/)
-      : buckets_(alloc), locks_(alloc), size_(0),
+      : buckets_(alloc), locks_(alloc), pending_writers_(0), size_(0),
         alloc_(alloc), hash_fn_(), key_eq_(),
         ext_percent_(0.6), ext_mult_(2) {
     init_buckets(num_buckets);

--- a/context-transport-primitives/include/search/regex_search_engine.h
+++ b/context-transport-primitives/include/search/regex_search_engine.h
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_CTP_SEARCH_REGEX_SEARCH_ENGINE_H_
+#define CLIO_CTP_SEARCH_REGEX_SEARCH_ENGINE_H_
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <regex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace ctp::search {
+
+/**
+ * A regex-queryable string index that maps string keys to user-defined values.
+ *
+ * Keys are indexed by their character trigrams (overlapping 3-grams) in an
+ * inverted index `trigram -> {keys}`. A `Search(pattern)` derives the set of
+ * trigrams that EVERY match of the regex must contain, intersects their posting
+ * lists to obtain a small candidate set, and then verifies each candidate with
+ * the full regex. This is the technique behind Google Code Search (Cox, "Regular
+ * Expression Matching with a Trigram Index").
+ *
+ * Correctness: the trigram extractor is CONSERVATIVE — it only treats a trigram
+ * as "required" when it provably appears in every match (it comes from a literal
+ * run that is neither optional nor inside an alternation/group). Whenever it
+ * cannot prove a useful required trigram (alternation, groups, short literals,
+ * etc.) it falls back to scanning all keys. So the candidate set is always a
+ * superset of the true matches, and the final regex verification makes the
+ * result exact regardless of how good the prefilter was.
+ *
+ * Match semantics: a key matches when std::regex_match(key, pattern) is true
+ * (the whole key must match), using the ECMAScript grammar (std::regex default).
+ *
+ * Thread-safety: NOT internally synchronized. Callers that mutate and query
+ * concurrently must provide external synchronization. References returned by a
+ * SearchResult are valid only while the engine is unmodified.
+ */
+template <typename ValueT>
+class RegexSearchEngine {
+ public:
+  RegexSearchEngine() = default;
+
+  /**
+   * Bind `value` to `key`. If `key` already exists its value is overwritten.
+   * @return true if a new key was added, false if an existing one was updated.
+   */
+  bool Insert(const std::string &key, const ValueT &value) {
+    auto res = entries_.insert_or_assign(key, value);
+    const bool is_new = res.second;
+    if (is_new) {
+      std::vector<std::string> tg;
+      Trigrams(key, tg);
+      for (const auto &t : tg) {
+        index_[t].insert(key);
+      }
+    }
+    return is_new;
+  }
+
+  /** Remove `key`. @return true if it existed. */
+  bool Delete(const std::string &key) {
+    auto it = entries_.find(key);
+    if (it == entries_.end()) {
+      return false;
+    }
+    entries_.erase(it);
+    std::vector<std::string> tg;
+    Trigrams(key, tg);
+    for (const auto &t : tg) {
+      auto p = index_.find(t);
+      if (p != index_.end()) {
+        p->second.erase(key);
+        if (p->second.empty()) {
+          index_.erase(p);
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Move the entry at `old_key` to `new_key`, preserving its value. If
+   * `new_key` already exists its value is overwritten by the moved one.
+   * @return false if `old_key` does not exist.
+   */
+  bool Rename(const std::string &old_key, const std::string &new_key) {
+    auto it = entries_.find(old_key);
+    if (it == entries_.end()) {
+      return false;
+    }
+    if (old_key == new_key) {
+      return true;
+    }
+    ValueT moved = std::move(it->second);
+    Delete(old_key);
+    Insert(new_key, moved);
+    return true;
+  }
+
+  bool Contains(const std::string &key) const {
+    return entries_.find(key) != entries_.end();
+  }
+
+  /** @return pointer to the value bound to `key`, or nullptr if absent. */
+  const ValueT *Find(const std::string &key) const {
+    auto it = entries_.find(key);
+    return it == entries_.end() ? nullptr : &it->second;
+  }
+
+  size_t Size() const { return entries_.size(); }
+  bool Empty() const { return entries_.empty(); }
+
+  void Clear() {
+    entries_.clear();
+    index_.clear();
+  }
+
+  /**
+   * Iterable result of a Search. Holds a snapshot of the matching keys; the
+   * bound values are fetched live from the engine on dereference, so the engine
+   * must outlive the result and must not be mutated while iterating.
+   */
+  class SearchResult {
+   public:
+    /** (key, value) view yielded on dereference. */
+    using reference = std::pair<const std::string &, const ValueT &>;
+
+    class iterator {
+     public:
+      iterator(const SearchResult *r, size_t i) : r_(r), i_(i) {}
+      bool operator==(const iterator &o) const { return i_ == o.i_; }
+      bool operator!=(const iterator &o) const { return i_ != o.i_; }
+      iterator &operator++() {
+        ++i_;
+        return *this;
+      }
+      reference operator*() const {
+        const std::string &k = r_->keys_[i_];
+        return reference(k, *r_->eng_->Find(k));
+      }
+
+     private:
+      const SearchResult *r_;
+      size_t i_;
+    };
+
+    iterator begin() const { return iterator(this, 0); }
+    iterator end() const { return iterator(this, keys_.size()); }
+    size_t size() const { return keys_.size(); }
+    bool empty() const { return keys_.empty(); }
+    /** The matching keys (sorted), e.g. for callers that only need names. */
+    const std::vector<std::string> &keys() const { return keys_; }
+
+   private:
+    friend class RegexSearchEngine;
+    SearchResult(std::vector<std::string> keys, const RegexSearchEngine *eng)
+        : keys_(std::move(keys)), eng_(eng) {}
+    std::vector<std::string> keys_;
+    const RegexSearchEngine *eng_;
+  };
+
+  /**
+   * Return every (key, value) whose key fully matches `pattern`.
+   * @throws std::regex_error if `pattern` is not a valid ECMAScript regex.
+   */
+  SearchResult Search(const std::string &pattern) const {
+    std::regex re(pattern);  // compiled once per query; throws on bad pattern
+
+    std::vector<std::string> required;
+    const bool prefilterable = ExtractRequiredTrigrams(pattern, required);
+
+    std::vector<std::string> matches;
+    if (!prefilterable || required.empty()) {
+      // No usable prefilter: verify the regex against every key.
+      for (const auto &kv : entries_) {
+        if (std::regex_match(kv.first, re)) {
+          matches.push_back(kv.first);
+        }
+      }
+    } else {
+      // Candidates = keys present in the posting lists of ALL required
+      // trigrams. Walk the smallest posting list and test membership in the
+      // others; this is a superset of the true matches.
+      const std::unordered_set<std::string> *smallest = nullptr;
+      for (const auto &t : required) {
+        auto it = index_.find(t);
+        if (it == index_.end()) {
+          // Some required trigram indexes no key at all => no match possible.
+          return SearchResult(std::vector<std::string>(), this);
+        }
+        if (smallest == nullptr || it->second.size() < smallest->size()) {
+          smallest = &it->second;
+        }
+      }
+      for (const auto &key : *smallest) {
+        bool in_all = true;
+        for (const auto &t : required) {
+          const auto &posting = index_.find(t)->second;
+          if (posting.find(key) == posting.end()) {
+            in_all = false;
+            break;
+          }
+        }
+        if (in_all && std::regex_match(key, re)) {
+          matches.push_back(key);
+        }
+      }
+    }
+
+    std::sort(matches.begin(), matches.end());
+    return SearchResult(std::move(matches), this);
+  }
+
+ private:
+  /** Append the unique overlapping trigrams of `s` to `out` (empty if <3). */
+  static void Trigrams(const std::string &s, std::vector<std::string> &out) {
+    out.clear();
+    if (s.size() < 3) {
+      return;
+    }
+    std::set<std::string> uniq;
+    for (size_t i = 0; i + 3 <= s.size(); ++i) {
+      uniq.insert(s.substr(i, 3));
+    }
+    out.assign(uniq.begin(), uniq.end());
+  }
+
+  /**
+   * Derive the trigrams that EVERY match of `pattern` must contain (AND
+   * semantics). Conservative: returns false (caller must scan all keys) for any
+   * construct it can't reason about safely — alternation `|`, groups `()`, a
+   * dangling escape. Returns true with `out` = required trigrams otherwise; an
+   * empty `out` means "no useful constraint, scan all". The function NEVER emits
+   * a trigram that is not guaranteed to appear in every match.
+   */
+  static bool ExtractRequiredTrigrams(const std::string &p,
+                                      std::vector<std::string> &out) {
+    out.clear();
+    std::vector<std::string> runs;
+    std::string run;
+    auto flush = [&]() {
+      if (run.size() >= 3) {
+        runs.push_back(run);
+      }
+      run.clear();
+    };
+
+    const size_t n = p.size();
+    size_t i = 0;
+    while (i < n) {
+      const char c = p[i];
+      switch (c) {
+        case '|':
+        case '(':
+        case ')':
+          // Alternation / groups: a literal here is not guaranteed in every
+          // match. Bail to a full scan.
+          return false;
+        case '\\': {
+          if (i + 1 >= n) {
+            return false;  // dangling escape -> bail
+          }
+          const char nx = p[i + 1];
+          if (std::isalnum(static_cast<unsigned char>(nx))) {
+            // \d \w \s \b ... a class, not a reliable literal.
+            flush();
+          } else {
+            run.push_back(nx);  // \. \/ \+ \\ ... a literal character
+          }
+          i += 2;
+          continue;
+        }
+        case '[': {
+          // Character class matches one of a set -> not a fixed literal.
+          flush();
+          i++;
+          if (i < n && p[i] == '^') {
+            i++;
+          }
+          if (i < n && p[i] == ']') {
+            i++;  // a leading ']' is a literal member of the class
+          }
+          while (i < n && p[i] != ']') {
+            if (p[i] == '\\' && i + 1 < n) {
+              i += 2;
+            } else {
+              i++;
+            }
+          }
+          if (i < n) {
+            i++;  // consume ']'
+          }
+          continue;
+        }
+        case '.':
+        case '^':
+        case '$':
+          flush();
+          i++;
+          continue;
+        case '*':
+        case '?':
+          // The preceding atom is optional: drop it and break the run.
+          if (!run.empty()) {
+            run.pop_back();
+          }
+          flush();
+          i++;
+          continue;
+        case '+':
+          // The preceding atom occurs >=1 times: it stays in the run, but the
+          // run cannot extend across the repetition.
+          flush();
+          i++;
+          continue;
+        case '{': {
+          // Possible {n}, {n,}, {n,m} quantifier. Parse the minimum count.
+          size_t j = i + 1;
+          std::string mn;
+          while (j < n && std::isdigit(static_cast<unsigned char>(p[j]))) {
+            mn.push_back(p[j]);
+            j++;
+          }
+          size_t k = j;
+          while (k < n && p[k] != '}') {
+            k++;
+          }
+          const bool is_quant =
+              !mn.empty() && k < n && (p[j] == '}' || p[j] == ',');
+          if (!is_quant) {
+            run.push_back('{');  // a literal '{'
+            i++;
+            continue;
+          }
+          const long min_count = std::atol(mn.c_str());
+          if (min_count == 0 && !run.empty()) {
+            run.pop_back();  // preceding atom optional
+          }
+          flush();
+          i = k + 1;
+          continue;
+        }
+        default:
+          run.push_back(c);
+          i++;
+          continue;
+      }
+    }
+    flush();
+
+    std::set<std::string> tri;
+    for (const auto &r : runs) {
+      for (size_t a = 0; a + 3 <= r.size(); ++a) {
+        tri.insert(r.substr(a, 3));
+      }
+    }
+    out.assign(tri.begin(), tri.end());
+    return true;
+  }
+
+  std::unordered_map<std::string, ValueT> entries_;
+  std::unordered_map<std::string, std::unordered_set<std::string>> index_;
+};
+
+}  // namespace ctp::search
+
+#endif  // CLIO_CTP_SEARCH_REGEX_SEARCH_ENGINE_H_

--- a/context-transport-primitives/test/unit/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(allocator)
 add_subdirectory(backend)
 add_subdirectory(data_structures)
 add_subdirectory(introspect)
+add_subdirectory(search)
 add_subdirectory(util)
 # Following test directories disabled - depend on deleted code:
 # add_subdirectory(types)

--- a/context-transport-primitives/test/unit/data_structures/priv/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/data_structures/priv/CMakeLists.txt
@@ -25,12 +25,23 @@ target_link_libraries(test_priv_string_ext_exec
         clio_ctp_host
         ctp::serialize)
 
+add_executable(test_priv_unordered_map_ll_exec
+        test_priv_unordered_map_ll.cc)
+add_dependencies(test_priv_unordered_map_ll_exec clio_ctp_host)
+target_link_libraries(test_priv_unordered_map_ll_exec
+        clio_ctp_host
+        ctp::serialize
+        ${CMAKE_THREAD_LIBS_INIT})
+
 #------------------------------------------------------------------------------
 # Test Cases
 #------------------------------------------------------------------------------
 
 add_test(NAME ctp_priv_string_ext COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_priv_string_ext_exec)
+
+add_test(NAME ctp_priv_umap_ll COMMAND
+        ${CMAKE_BINARY_DIR}/bin/test_priv_unordered_map_ll_exec)
 
 add_test(NAME ctp_priv_vector COMMAND
         ${CMAKE_BINARY_DIR}/bin/test_priv_vector_exec)
@@ -94,6 +105,7 @@ install(TARGETS
         test_priv_vector_exec
         test_priv_string_exec
         test_priv_string_ext_exec
+        test_priv_unordered_map_ll_exec
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin)

--- a/context-transport-primitives/test/unit/data_structures/priv/test_priv_unordered_map_ll.cc
+++ b/context-transport-primitives/test/unit/data_structures/priv/test_priv_unordered_map_ll.cc
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ *
+ * Stress tests for ctp::priv::unordered_map_ll, focused on the property that
+ * matters most: automatic growth (rehash) is SAFE to interleave with concurrent
+ * single-key operations. The map starts deliberately tiny so a multi-threaded
+ * insert storm triggers many rehashes WHILE other threads are inserting,
+ * finding, and erasing — the exact race the map-wide RwLock is there to make
+ * safe. With the pre-RwLock in-place rehash these tests crash / corrupt.
+ */
+#include "../../../context-runtime/test/simple_test.h"
+#include "clio_ctp/data_structures/priv/unordered_map_ll.h"
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+using ctp::priv::unordered_map_ll;
+
+// ---------------------------------------------------------------------------
+// Single-threaded correctness across growth
+// ---------------------------------------------------------------------------
+
+TEST_CASE("umap_ll: single-thread grows and keeps all entries", "[priv_umap_ll]") {
+  // Tiny initial bucket count + 0.6 growth => dozens of rehashes.
+  unordered_map_ll<uint64_t, uint64_t> map(4, /*ext_percent=*/0.6,
+                                           /*ext_mult=*/2);
+  constexpr uint64_t kN = 20000;
+  for (uint64_t i = 0; i < kN; ++i) {
+    auto r = map.insert(i, i * 3 + 7);
+    REQUIRE(r.inserted);
+  }
+  REQUIRE(map.size() == kN);
+  REQUIRE(map.bucket_count() > 4);  // it actually grew
+  for (uint64_t i = 0; i < kN; ++i) {
+    auto *v = map.find(i);
+    REQUIRE(v != nullptr);
+    REQUIRE(*v == i * 3 + 7);
+  }
+  // Erase half, the rest must remain correct.
+  for (uint64_t i = 0; i < kN; i += 2) REQUIRE(map.erase(i) == 1);
+  REQUIRE(map.size() == kN / 2);
+  for (uint64_t i = 1; i < kN; i += 2) {
+    auto *v = map.find(i);
+    REQUIRE(v != nullptr);
+    REQUIRE(*v == i * 3 + 7);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent placement with growth: many threads insert disjoint key ranges
+// into a tiny map; every key must survive the storm of concurrent rehashes.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("umap_ll: concurrent inserts survive concurrent growth",
+          "[priv_umap_ll]") {
+  unordered_map_ll<uint64_t, uint64_t> map(4, 0.6, 2);
+  constexpr int kThreads = 8;
+  constexpr uint64_t kPer = 6000;  // 48k keys into a 4-bucket map
+
+  std::vector<std::thread> ts;
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&map, t]() {
+      for (uint64_t i = 0; i < kPer; ++i) {
+        uint64_t k = static_cast<uint64_t>(t) * kPer + i;
+        map.insert(k, k ^ 0xA5A5A5A5ULL);  // value derived from key
+      }
+    });
+  }
+  for (auto &th : ts) th.join();
+
+  REQUIRE(map.size() == static_cast<size_t>(kThreads) * kPer);
+  for (int t = 0; t < kThreads; ++t) {
+    for (uint64_t i = 0; i < kPer; ++i) {
+      uint64_t k = static_cast<uint64_t>(t) * kPer + i;
+      auto *v = map.find(k);
+      REQUIRE(v != nullptr);
+      REQUIRE(*v == (k ^ 0xA5A5A5A5ULL));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Readers running DURING expansion: writers grow the table while readers
+// hammer find(). Any value a reader observes must be the correct one (no torn
+// reads / use-after-free from a concurrent rehash), and the final contents
+// must be exactly correct.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("umap_ll: concurrent find during expansion is consistent",
+          "[priv_umap_ll]") {
+  unordered_map_ll<uint64_t, uint64_t> map(2, 0.6, 2);
+  constexpr int kWriters = 6;
+  constexpr int kReaders = 4;
+  constexpr uint64_t kPer = 5000;
+  const uint64_t kKeys = static_cast<uint64_t>(kWriters) * kPer;
+
+  std::atomic<bool> done{false};
+  std::atomic<uint64_t> bad{0};   // wrong value observed
+  std::atomic<uint64_t> reads{0};
+
+  auto value_of = [](uint64_t k) { return k * 1315423911ULL + 1; };
+
+  std::vector<std::thread> writers;
+  for (int t = 0; t < kWriters; ++t) {
+    writers.emplace_back([&map, &value_of, t]() {
+      for (uint64_t i = 0; i < kPer; ++i) {
+        uint64_t k = static_cast<uint64_t>(t) * kPer + i;
+        map.insert_or_assign(k, value_of(k));
+      }
+    });
+  }
+  std::vector<std::thread> readers;
+  for (int r = 0; r < kReaders; ++r) {
+    readers.emplace_back([&]() {
+      while (!done.load(std::memory_order_relaxed)) {
+        for (uint64_t k = 0; k < kKeys; ++k) {
+          auto *v = map.find(k);  // may or may not be present yet
+          if (v != nullptr) {
+            if (*v != value_of(k)) bad.fetch_add(1);
+            reads.fetch_add(1);
+          }
+        }
+      }
+    });
+  }
+
+  for (auto &w : writers) w.join();
+  done.store(true, std::memory_order_relaxed);
+  for (auto &r : readers) r.join();
+
+  REQUIRE(bad.load() == 0);            // never observed a corrupt value
+  REQUIRE(reads.load() > 0);           // readers actually found live entries
+  REQUIRE(map.size() == kKeys);
+  for (uint64_t k = 0; k < kKeys; ++k) {
+    auto *v = map.find(k);
+    REQUIRE(v != nullptr);
+    REQUIRE(*v == value_of(k));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mixed churn: insert + erase + find all racing growth on disjoint ranges.
+// Each thread owns its key range so the final state is deterministic.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("umap_ll: concurrent insert/erase/find churn with growth",
+          "[priv_umap_ll]") {
+  unordered_map_ll<uint64_t, uint64_t> map(4, 0.6, 2);
+  constexpr int kThreads = 8;
+  constexpr uint64_t kPer = 4000;
+
+  std::vector<std::thread> ts;
+  for (int t = 0; t < kThreads; ++t) {
+    ts.emplace_back([&map, t]() {
+      const uint64_t base = static_cast<uint64_t>(t) * kPer;
+      // Insert all, erase the even ones, re-find the odd ones.
+      for (uint64_t i = 0; i < kPer; ++i) map.insert(base + i, base + i);
+      for (uint64_t i = 0; i < kPer; i += 2) map.erase(base + i);
+      for (uint64_t i = 1; i < kPer; i += 2) {
+        auto *v = map.find(base + i);
+        // Our own odd keys are never erased by anyone => must be present.
+        if (v == nullptr || *v != base + i) {
+          // record via a known-bad write so the assert below trips
+          map.insert_or_assign(~0ULL, 1);
+        }
+      }
+    });
+  }
+  for (auto &th : ts) th.join();
+
+  REQUIRE(map.find(~0ULL) == nullptr);  // no thread hit a missing/odd key
+  REQUIRE(map.size() == static_cast<size_t>(kThreads) * (kPer / 2));
+  for (int t = 0; t < kThreads; ++t) {
+    const uint64_t base = static_cast<uint64_t>(t) * kPer;
+    for (uint64_t i = 1; i < kPer; i += 2) {
+      auto *v = map.find(base + i);
+      REQUIRE(v != nullptr);
+      REQUIRE(*v == base + i);
+    }
+    for (uint64_t i = 0; i < kPer; i += 2) {
+      REQUIRE(map.find(base + i) == nullptr);
+    }
+  }
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-transport-primitives/test/unit/search/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/search/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(clio_ctp)
+
+#------------------------------------------------------------------------------
+# Build Search Index Tests
+#------------------------------------------------------------------------------
+# The regex search engine is a header-only, std-only template, so the test only
+# needs Catch2 (with its own main) and the CTP include path.
+add_executable(test_regex_search_engine_exec
+        test_regex_search_engine.cc)
+target_link_libraries(test_regex_search_engine_exec
+        Catch2::Catch2WithMain)
+
+#------------------------------------------------------------------------------
+# Test Cases
+#------------------------------------------------------------------------------
+add_test(NAME ctp_regex_search_engine COMMAND
+        ${CMAKE_BINARY_DIR}/bin/test_regex_search_engine_exec)
+
+#------------------------------------------------------------------------------
+# Install Targets
+#------------------------------------------------------------------------------
+install(TARGETS
+        test_regex_search_engine_exec
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)

--- a/context-transport-primitives/test/unit/search/test_regex_search_engine.cc
+++ b/context-transport-primitives/test/unit/search/test_regex_search_engine.cc
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+#include <catch2/catch_all.hpp>
+#include <random>
+#include <regex>
+#include <string>
+#include <vector>
+
+#include "search/regex_search_engine.h"
+
+using ctp::search::RegexSearchEngine;
+
+namespace {
+
+// Sorted matching keys via the engine, for easy comparison.
+template <typename V>
+std::vector<std::string> SearchKeys(const RegexSearchEngine<V> &eng,
+                                    const std::string &pat) {
+  std::vector<std::string> out;
+  for (const auto &kv : eng.Search(pat)) {
+    out.push_back(kv.first);
+  }
+  std::sort(out.begin(), out.end());
+  return out;
+}
+
+// Ground-truth: brute-force std::regex_match over a key list.
+std::vector<std::string> BruteForce(const std::vector<std::string> &keys,
+                                    const std::string &pat) {
+  std::regex re(pat);
+  std::vector<std::string> out;
+  for (const auto &k : keys) {
+    if (std::regex_match(k, re)) {
+      out.push_back(k);
+    }
+  }
+  std::sort(out.begin(), out.end());
+  return out;
+}
+
+}  // namespace
+
+TEST_CASE("RegexSearch: insert/find/contains/size", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  REQUIRE(eng.Empty());
+  REQUIRE(eng.Insert("/a/b/c", 1));
+  REQUIRE(eng.Insert("/a/b/d", 2));
+  REQUIRE_FALSE(eng.Insert("/a/b/c", 99));  // overwrite -> not new
+  REQUIRE(eng.Size() == 2);
+  REQUIRE(eng.Contains("/a/b/c"));
+  REQUIRE(eng.Find("/a/b/c") != nullptr);
+  REQUIRE(*eng.Find("/a/b/c") == 99);  // value was overwritten
+  REQUIRE(eng.Find("/nope") == nullptr);
+}
+
+TEST_CASE("RegexSearch: exact-path match", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("/home/user/file.txt", 1);
+  eng.Insert("/home/user/other.txt", 2);
+  eng.Insert("/var/log/file.txt", 3);
+
+  auto r = SearchKeys(eng, "^/home/user/file\\.txt$");
+  REQUIRE(r == std::vector<std::string>{"/home/user/file.txt"});
+}
+
+TEST_CASE("RegexSearch: direct-children pattern", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("/dir/a", 1);
+  eng.Insert("/dir/b", 2);
+  eng.Insert("/dir/sub/c", 3);  // grandchild, must NOT match
+  eng.Insert("/dir", 4);        // the dir itself, must NOT match
+  eng.Insert("/other/x", 5);
+
+  auto r = SearchKeys(eng, "^/dir/[^/]+$");
+  REQUIRE(r == std::vector<std::string>{"/dir/a", "/dir/b"});
+}
+
+TEST_CASE("RegexSearch: substring via .* and unanchored-style", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("alpha_foo_beta", 1);
+  eng.Insert("xfooy", 2);
+  eng.Insert("nomatch", 3);
+
+  auto r = SearchKeys(eng, ".*foo.*");
+  REQUIRE(r == std::vector<std::string>{"alpha_foo_beta", "xfooy"});
+}
+
+TEST_CASE("RegexSearch: delete removes from results and index", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("/dir/a", 1);
+  eng.Insert("/dir/b", 2);
+  REQUIRE(eng.Delete("/dir/a"));
+  REQUIRE_FALSE(eng.Delete("/dir/a"));  // already gone
+  REQUIRE_FALSE(eng.Contains("/dir/a"));
+
+  auto r = SearchKeys(eng, "^/dir/[^/]+$");
+  REQUIRE(r == std::vector<std::string>{"/dir/b"});
+  // The trigrams of the deleted key must no longer surface it.
+  REQUIRE(SearchKeys(eng, ".*/a$").empty());
+}
+
+TEST_CASE("RegexSearch: rename preserves value and updates index",
+          "[regex_search]") {
+  RegexSearchEngine<std::string> eng;
+  eng.Insert("/old/name", "payload");
+
+  REQUIRE(eng.Rename("/old/name", "/new/place"));
+  REQUIRE_FALSE(eng.Contains("/old/name"));
+  REQUIRE(eng.Contains("/new/place"));
+  REQUIRE(*eng.Find("/new/place") == "payload");
+
+  // Old name no longer searchable; new name is.
+  REQUIRE(SearchKeys(eng, "^/old/.*").empty());
+  REQUIRE(SearchKeys(eng, "^/new/place$") ==
+          std::vector<std::string>{"/new/place"});
+
+  REQUIRE_FALSE(eng.Rename("/missing", "/whatever"));
+  // Rename onto itself is a no-op success.
+  REQUIRE(eng.Rename("/new/place", "/new/place"));
+  REQUIRE(eng.Contains("/new/place"));
+}
+
+TEST_CASE("RegexSearch: short keys (< 3 chars) found via scan fallback",
+          "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("a", 1);
+  eng.Insert("ab", 2);
+  eng.Insert("abc", 3);
+
+  // "^ab$" has a literal run "ab" of length 2 -> no trigram -> scan fallback.
+  REQUIRE(SearchKeys(eng, "^ab$") == std::vector<std::string>{"ab"});
+  REQUIRE(SearchKeys(eng, "^a$") == std::vector<std::string>{"a"});
+  REQUIRE(SearchKeys(eng, "^abc$") == std::vector<std::string>{"abc"});
+}
+
+TEST_CASE("RegexSearch: alternation/groups fall back to scan but stay correct",
+          "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("cat", 1);
+  eng.Insert("dog", 2);
+  eng.Insert("bird", 3);
+
+  REQUIRE(SearchKeys(eng, "^(cat|dog)$") ==
+          std::vector<std::string>{"cat", "dog"});
+  REQUIRE(SearchKeys(eng, "^(bird)$") == std::vector<std::string>{"bird"});
+}
+
+TEST_CASE("RegexSearch: match-all and no-match patterns", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("x1", 1);
+  eng.Insert("y2", 2);
+  REQUIRE(SearchKeys(eng, ".*").size() == 2);
+  REQUIRE(SearchKeys(eng, "^zzz$").empty());
+  // A required trigram that indexes nothing -> empty fast path.
+  REQUIRE(SearchKeys(eng, ".*qqq.*").empty());
+}
+
+TEST_CASE("RegexSearch: invalid pattern throws", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("abc", 1);
+  REQUIRE_THROWS_AS(eng.Search("([unclosed"), std::regex_error);
+}
+
+TEST_CASE("RegexSearch: iterator yields key and value", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  eng.Insert("/p/one", 11);
+  eng.Insert("/p/two", 22);
+
+  int sum = 0;
+  int count = 0;
+  for (const auto &kv : eng.Search("^/p/[^/]+$")) {
+    REQUIRE(kv.first.rfind("/p/", 0) == 0);
+    sum += kv.second;
+    ++count;
+  }
+  REQUIRE(count == 2);
+  REQUIRE(sum == 33);
+}
+
+// The core correctness guarantee: for a large, varied corpus and many patterns,
+// the engine's result must EXACTLY equal brute-force regex over all keys. This
+// is what proves the trigram prefilter never drops a real match.
+TEST_CASE("RegexSearch: matches brute force across many patterns",
+          "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  std::vector<std::string> keys;
+
+  std::mt19937 rng(1234567);  // fixed seed: deterministic
+  const char *dirs[] = {"home", "var", "usr", "etc", "data", "tmp", "opt"};
+  const char *leaves[] = {"file", "log", "config", "data", "cache",
+                          "index", "blob", "meta", "foo", "bar"};
+  const char *exts[] = {"txt", "log", "dat", "bin", "json", "csv"};
+  std::uniform_int_distribution<int> depthD(1, 4);
+  auto pick = [&](auto &arr, size_t len) { return arr[rng() % len]; };
+
+  for (int i = 0; i < 400; ++i) {
+    std::string path;
+    int depth = depthD(rng);
+    for (int d = 0; d < depth; ++d) {
+      path += "/";
+      path += pick(dirs, 7);
+    }
+    path += "/";
+    path += pick(leaves, 10);
+    path += "_";
+    path += std::to_string(rng() % 50);
+    path += ".";
+    path += pick(exts, 6);
+    if (eng.Insert(path, i)) {
+      keys.push_back(path);
+    }
+  }
+
+  std::vector<std::string> patterns = {
+      ".*foo.*",
+      ".*\\.log$",
+      "^/home/.*",
+      "^/var/log/.*",
+      "^/[^/]+/[^/]+$",          // exactly two components
+      ".*/file_[0-9]+\\..*",
+      ".*config.*\\.json$",
+      "^/(home|var)/.*",         // alternation -> scan fallback
+      ".*data.*",
+      ".*/bar_[0-9]+\\.csv$",
+      "^/etc/.*/meta_[0-9]+\\.dat$",
+      ".*",                       // everything
+      ".*zzzzz.*",                // nothing
+  };
+
+  for (const auto &pat : patterns) {
+    INFO("pattern: " << pat);
+    REQUIRE(SearchKeys(eng, pat) == BruteForce(keys, pat));
+  }
+}
+
+// Same correctness guarantee, but after a churn of deletes and renames, to
+// confirm the inverted index stays consistent under mutation.
+TEST_CASE("RegexSearch: consistent after delete/rename churn", "[regex_search]") {
+  RegexSearchEngine<int> eng;
+  std::vector<std::string> keys;
+  std::mt19937 rng(987654);
+
+  for (int i = 0; i < 300; ++i) {
+    std::string k = "/base/d" + std::to_string(rng() % 20) + "/item_" +
+                    std::to_string(i) + ".dat";
+    if (eng.Insert(k, i)) keys.push_back(k);
+  }
+  // Delete ~1/3.
+  for (size_t i = 0; i < keys.size(); i += 3) {
+    eng.Delete(keys[i]);
+  }
+  std::vector<std::string> alive;
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (i % 3 != 0) alive.push_back(keys[i]);
+  }
+  // Rename ~1/2 of the survivors into a new subtree.
+  std::vector<std::string> final_keys;
+  for (size_t i = 0; i < alive.size(); ++i) {
+    if (i % 2 == 0) {
+      std::string nk = "/moved/m" + std::to_string(i) + ".dat";
+      REQUIRE(eng.Rename(alive[i], nk));
+      final_keys.push_back(nk);
+    } else {
+      final_keys.push_back(alive[i]);
+    }
+  }
+
+  REQUIRE(eng.Size() == final_keys.size());
+  for (const auto &pat : std::vector<std::string>{
+           ".*\\.dat$", "^/base/.*", "^/moved/.*", ".*item_.*", ".*"}) {
+    INFO("pattern: " << pat);
+    REQUIRE(SearchKeys(eng, pat) == BruteForce(final_keys, pat));
+  }
+}

--- a/scripts/xfstests/run_clio_xfstests.sh
+++ b/scripts/xfstests/run_clio_xfstests.sh
@@ -63,12 +63,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mount_fuse() {  # $1 = mountpoint, $2 = with_runtime(1/0)
-  local mnt="$1" with_rt="$2"
-  echo "[xfstests] mounting clio FUSE at ${mnt} (runtime=${with_rt})"
+mount_fuse() {  # $1 = mountpoint, $2 = with_runtime(1/0), $3 = fsname (mount source)
+  local mnt="$1" with_rt="$2" fsname="$3"
+  echo "[xfstests] mounting clio FUSE at ${mnt} (runtime=${with_rt}, fsname=${fsname})"
+  # Distinct -o fsname per mount so xfstests can tell TEST_DEV and SCRATCH_DEV
+  # apart: _check_mounted_on uses `findmnt -S <dev>` and aborts if a device
+  # appears mounted on more than one target. (Both mounts otherwise share the
+  # source "clio_cte_fuse".)
   CHI_REPO_PATH="${BUILD_BIN}" LD_LIBRARY_PATH="${BUILD_BIN}:${HOME}/.local/lib:${LD_LIBRARY_PATH:-}" \
     CLIO_WITH_RUNTIME="${with_rt}" CLIO_BIND_ADDR=127.0.0.1 \
-    "${FUSE_BIN}" "${mnt}" -f &
+    "${FUSE_BIN}" "${mnt}" -o "fsname=${fsname}" -f &
   FUSE_PIDS+=("$!")
   # wait for the mount to appear
   for _ in $(seq 1 50); do
@@ -79,44 +83,70 @@ mount_fuse() {  # $1 = mountpoint, $2 = with_runtime(1/0)
   return 1
 }
 
-# TEST mount brings up the co-located runtime; SCRATCH mount joins as a client.
-mount_fuse "${TEST_DIR}" 1 || exit 1
-mount_fuse "${SCRATCH_MNT}" 0 || echo "[xfstests] warning: scratch mount failed (SCRATCH tests will notrun)"
+# --- root requirement -------------------------------------------------------
+# xfstests' ./check refuses to run unless euid==0. Re-exec under a user+mount
+# namespace ('unshare -r' maps the caller to root) so this works unprivileged;
+# a real-root invocation skips this.
+if [ "$(id -u)" -ne 0 ] && [ -z "${CLIO_XFS_INNS:-}" ]; then
+  echo "[xfstests] not root; re-executing under 'unshare -rm' (namespaced root)"
+  exec env CLIO_XFS_INNS=1 unshare -rm "$0" "$@"
+fi
 
 # --- xfstests config --------------------------------------------------------
-# A from-scratch FUSE fs has no mkfs/mount-by-device, so we present the already
-# mounted dirs and treat FSTYP generically. SCRATCH-reformatting tests will
-# 'notrun'; TEST_DIR-only tests execute.
+# SCRATCH_DEV is intentionally left UNSET: the clio fs can't be reformatted
+# (no mkfs/mount-by-device), and if SCRATCH_DEV is set ./check tries to mkfs it
+# during setup and aborts. With it unset, TEST_DIR tests run and
+# scratch-reformatting tests 'notrun'. A distinct -o fsname lets ./check's
+# device->mount detection (df / findmnt -S) recognize the already-mounted fs.
 export FSTYP="${FSTYP:-fuse}"
-export TEST_DEV="${TEST_DEV:-clio_fuse_test}"
-export TEST_DIR
-export SCRATCH_DEV="${SCRATCH_DEV:-clio_fuse_scratch}"
-export SCRATCH_MNT
-cat > "${XFSTESTS_DIR}/local.config" <<EOF
+TEST_DEV="${TEST_DEV:-clio_test}"
+write_config() {
+  cat > "${XFSTESTS_DIR}/local.config" <<EOF
 export FSTYP=${FSTYP}
 export TEST_DEV=${TEST_DEV}
 export TEST_DIR=${TEST_DIR}
-export SCRATCH_DEV=${SCRATCH_DEV}
-export SCRATCH_MNT=${SCRATCH_MNT}
 EOF
-echo "[xfstests] local.config:"; cat "${XFSTESTS_DIR}/local.config"
+}
+write_config
 
-# --- run --------------------------------------------------------------------
+# (Re)mount the clio FUSE test fs fresh. ./check unmounts TEST_DIR after each
+# test and our FUSE fs can't be remounted by ./check itself, so every test gets
+# its own fresh mount + runtime.
+remount() {
+  pkill -9 -x clio_cte_fuse 2>/dev/null; pkill -9 -x clio_run 2>/dev/null
+  fusermount3 -u "${TEST_DIR}" 2>/dev/null
+  rm -rf "/tmp/chimaera_$(id -un)" /dev/shm/chimaera* 2>/dev/null
+  sleep 0.5
+  mount_fuse "${TEST_DIR}" 1 "${TEST_DEV}"
+}
+
+# --- resolve test list (expands groups like '-g quick' via ./check -n) ------
 cd "${XFSTESTS_DIR}" || exit 1
-if [ "$#" -gt 0 ]; then
-  ARGS=("$@")
-elif [ -n "${TESTS:-}" ]; then
-  # shellcheck disable=SC2206
-  ARGS=(${TESTS})
-else
-  # A small, file-data-focused default set: open/write/read/seek/truncate,
-  # the exact surface the chimod implements. Expand as the fs matures.
-  ARGS=(generic/001 generic/002 generic/005 generic/007 generic/011
-        generic/013 generic/124 generic/130)
-fi
+if [ "$#" -gt 0 ]; then RAW=("$@")
+elif [ -n "${TESTS:-}" ]; then RAW=(${TESTS})  # shellcheck disable=SC2206
+else RAW=(generic/001 generic/002 generic/005 generic/007 generic/011
+          generic/013 generic/124 generic/130); fi
 
-echo "[xfstests] running: ./check ${ARGS[*]}"
-./check "${ARGS[@]}"
-rc=$?
-echo "[xfstests] ./check exit=${rc}"
-exit "${rc}"
+remount >/dev/null 2>&1 || { echo "ERROR: initial clio FUSE mount failed" >&2; exit 1; }
+mapfile -t LIST < <(./check -n "${RAW[@]}" 2>/dev/null | grep -E '^[a-z_]+/[0-9]+')
+[ "${#LIST[@]}" -eq 0 ] && LIST=("${RAW[@]}")
+echo "[xfstests] running ${#LIST[@]} test(s) (mount-per-test)"
+
+# --- run, one fresh mount per test ------------------------------------------
+pass=0; fail=0; notrun=0; hang=0; failed_list=""
+for t in "${LIST[@]}"; do
+  remount >/dev/null 2>&1 || { echo "${t}: MOUNTFAIL"; fail=$((fail+1)); failed_list="${failed_list} ${t}"; continue; }
+  out=$(timeout "${CLIO_XFS_PERTEST_TIMEOUT:-90}" ./check "${t}" 2>/dev/null)
+  rc=$?
+  if [ "${rc}" -eq 124 ]; then echo "${t}: HANG"; hang=$((hang+1)); failed_list="${failed_list} ${t}(hang)"
+  elif echo "${out}" | grep -q "^Passed all"; then echo "${t}: pass"; pass=$((pass+1))
+  elif echo "${out}" | grep -q "^Not run:"; then echo "${t}: notrun"; notrun=$((notrun+1))
+  else echo "${t}: FAIL"; fail=$((fail+1)); failed_list="${failed_list} ${t}"; fi
+done
+
+ran=$((pass+fail))
+echo "===================================================================="
+echo "[xfstests] TALLY: pass=${pass} fail=${fail} notrun=${notrun} hang=${hang} (list=${#LIST[@]})"
+[ "${ran}" -gt 0 ] && echo "[xfstests] pass rate (of run, excl. notrun): $((100*pass/ran))%"
+[ -n "${failed_list}" ] && echo "[xfstests] not passing:${failed_list}"
+exit 0


### PR DESCRIPTION
Addresses the rename portion of #597 (xfstests generic/quick breakdown). Per scope, this **ignores the feature gaps** (mmap, timestamps, inodes, exportfs) and solidifies the existing rename path with fast, focused unit tests plus the one clear semantics fix they prove.

> **Stacked PR:** branches off `append-operations` (#591), which is not yet merged to `dev`, so the diff currently shows #591's commits too. The only new content here is the top commit `test(cfs): focused rename stress + concurrency tests …`; the diff collapses to that once #591 merges.

## New test — `chimaera_cfs_rename_test` (ctest `cr_cli_cfs_rename`)
Reproduces, in seconds, the rename scenarios the slow xfstests stress tests (011/013) exercise:
- **A** basic rename keeps data, source vanishes
- **B1** rename-overwrite POSIX semantics (the generic/245 bug): file→file overwrites; file→non-empty-dir, dir→non-empty-dir, and dir/file type mismatches must fail and leave both operands intact
- **B2** renaming an *open* file (move) keeps the handle valid (TagId is stable across rename)
- **D1** many independent concurrent renames all land intact
- **D2** N renames racing one destination → exactly one survivor, every source gone, no duplicate/leftover binding
- **D3** rename racing a create on the same name → single binding
- **D4** rename racing readdir → every concurrent listing sees all N files (guards the #596 "resolvable-upward-not-forward" hazard)

## Fix — B1 rename-overwrite semantics
The filesystem `Rename` handler unconditionally `DelTag`'d the destination, silently clobbering a non-empty directory or wrong-type target. It now classifies both operands and enforces POSIX rules before touching anything: non-dir→dir = `EISDIR`, dir→non-dir = `ENOTDIR`, dir→non-empty-dir = `ENOTEMPTY`; only file-over-file and dir-over-empty-dir replace. The test proved the bug (file→non-empty-dir succeeded), then passed after the fix.

## Results
- Rename test: 5/5 stable runs, all sections green.
- Existing `chimaera_cfs_test`: unaffected.

## Deferred (noted, not in scope)
- **B2** rename *over* an open file (generic/035) is the unlinked-but-open inode feature — out of scope per "ignore new features".
- The non-atomic `DelTag(dst)` + `RenameTag(src,dst)` has a narrow N→1 orphan-tag window that is invisible to `readdir` (forward-map enumeration only) — a silent leak, candidate follow-up to make rename atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)