### PR TITLE
Per-RPC access control for private containers/methods

### DIFF
--- a/context-runtime/include/clio_runtime/config_manager.h
+++ b/context-runtime/include/clio_runtime/config_manager.h
@@ -35,6 +35,7 @@
 #define CHIMAERA_INCLUDE_CHIMAERA_MANAGERS_CONFIG_MANAGER_H_
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "clio_runtime/types.h"
@@ -52,6 +53,13 @@ struct PoolConfig {
   PoolQuery pool_query_;     /**< Pool query routing (Dynamic or Local) */
   std::string config_;       /**< Remaining YAML configuration as string */
   bool restart_ = false;     /**< If true, store compose file for crash-restart */
+  /** Default RPC visibility for the container: 0 = public (default),
+   *  1 = private. A private container rejects RPCs from external user clients
+   *  (runtime-internal callers are always allowed). */
+  u32 container_visibility_ = 0;
+  /** Per-RPC visibility overrides, keyed by RPC method NAME -> 0 public /
+   *  1 private. Methods absent here inherit container_visibility_. */
+  std::unordered_map<std::string, u32> rpc_acl_;
 
   PoolConfig() = default;
 
@@ -70,7 +78,8 @@ struct PoolConfig {
    */
   template <class Archive>
   void serialize(Archive& ar) {
-    ar(mod_name_, pool_name_, pool_id_, pool_query_, config_, restart_);
+    ar(mod_name_, pool_name_, pool_id_, pool_query_, config_, restart_,
+       container_visibility_, rpc_acl_);
   }
 };
 

--- a/context-runtime/include/clio_runtime/container.h
+++ b/context-runtime/include/clio_runtime/container.h
@@ -90,6 +90,14 @@ class Container {
  public:
   static constexpr u32 CONTAINER_PLUG = BIT_OPT(u32, 0);
 
+  /** RPC visibility, as a small bitfield. A "private" RPC rejects calls from
+   *  external user clients; runtime-internal callers are always allowed. */
+  struct MethodProperty {
+    static constexpr u32 kPrivate = BIT_OPT(u32, 0);
+    u32 bits_ = 0;
+    bool IsPrivate() const { return (bits_ & kPrivate) != 0; }
+  };
+
   PoolId pool_id_;         ///< The unique ID of this pool
   std::string pool_name_;  ///< The semantic name of this pool
   u32 container_id_;       ///< The logical ID of this container instance
@@ -108,6 +116,13 @@ class Container {
   std::vector<float> method_mape_wall_;   ///< Per-method wall clock MAPE
   std::vector<std::string> method_names_;  ///< Per-method human-readable names
   float learning_rate_ = 0.2f;      ///< SGD learning rate for model updates
+  /** Default RPC visibility for this container (from compose
+   *  container_visibility). */
+  MethodProperty container_visibility_;
+  /** Per-method visibility overrides keyed by method id (from compose
+   *  container_rpc_acl). Built once in ConfigureAcl, then read-only — no
+   *  locking needed on the enforcement hot path. */
+  std::unordered_map<u32, MethodProperty> method_acl_;
 
  public:
   Container() = default;
@@ -158,6 +173,45 @@ class Container {
    */
   void SetMethodNames(const std::vector<std::string>& names) {
     method_names_ = names;
+  }
+
+  /**
+   * Configure per-RPC access control from a compose PoolConfig. Must be called
+   * once after Init()/SetMethodNames() (so method_names_ is populated), before
+   * the container serves tasks. Translates the name-keyed ACL into a
+   * method_id-keyed map; afterwards the ACL state is read-only.
+   * @param container_visibility default visibility (0 public, 1 private)
+   * @param rpc_acl per-RPC overrides: method NAME -> 0 public / 1 private
+   */
+  void ConfigureAcl(u32 container_visibility,
+                    const std::unordered_map<std::string, u32>& rpc_acl) {
+    container_visibility_.bits_ =
+        container_visibility ? MethodProperty::kPrivate : 0u;
+    method_acl_.clear();
+    for (const auto& kv : rpc_acl) {
+      for (u32 id = 0; id < method_names_.size(); ++id) {
+        if (method_names_[id] == kv.first) {
+          method_acl_[id].bits_ = kv.second ? MethodProperty::kPrivate : 0u;
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * @return true if a caller may invoke `method_id`. Runtime-internal callers
+   * (is_external == false) are always allowed. External user clients are
+   * rejected when the method is private (per-method override if present, else
+   * the container default visibility).
+   */
+  bool IsRpcAllowed(u32 method_id, bool is_external) const {
+    if (!is_external) {
+      return true;
+    }
+    auto it = method_acl_.find(method_id);
+    const MethodProperty& mp =
+        (it != method_acl_.end()) ? it->second : container_visibility_;
+    return !mp.IsPrivate();
   }
 
   /**

--- a/context-runtime/include/clio_runtime/types.h
+++ b/context-runtime/include/clio_runtime/types.h
@@ -464,6 +464,13 @@ struct AddressHash {
   BIT_OPT(chi::u32, 8)  ///< ManyToOne: this is the synthetic aggregate task the
                         ///< neighborhood leader runs for a batch. On completion,
                         ///< its OUT is broadcast to the batched original tasks.
+#define TASK_EXTERNAL_CLIENT \
+  BIT_OPT(chi::u32, 9)  ///< Task ingressed from an external user client (set in
+                        ///< the IpcCpu2Cpu / IpcCpu2CpuZmq client-receive paths,
+                        ///< never on runtime-internal self-sends). Serialized in
+                        ///< SerializeIn so it rides a remote hop to the container
+                        ///< owner, which enforces per-RPC access control
+                        ///< (private methods reject external callers).
 
 // Bulk transfer flags are defined in clio_ctp/lightbeam/lightbeam.h:
 // - BULK_EXPOSE: Bulk is exposed (sender exposes for reading)

--- a/context-runtime/src/config_manager.cc
+++ b/context-runtime/src/config_manager.cc
@@ -359,6 +359,25 @@ void ConfigManager::ParseYAML(YAML::Node &yaml_conf) {
           pool_config.restart_ = pool_node["restart"].as<bool>();
         }
 
+        // Optional RPC access control. container_visibility sets the default
+        // visibility for every RPC (public|private, default public); a private
+        // container rejects RPCs from external user clients (runtime-internal
+        // callers are always allowed).
+        if (pool_node["container_visibility"]) {
+          std::string vis = pool_node["container_visibility"].as<std::string>();
+          pool_config.container_visibility_ = (vis == "private") ? 1u : 0u;
+        }
+        // container_rpc_acl is a map of RPC method NAME -> public|private that
+        // overrides container_visibility per method.
+        if (pool_node["container_rpc_acl"] &&
+            pool_node["container_rpc_acl"].IsMap()) {
+          for (const auto& kv : pool_node["container_rpc_acl"]) {
+            std::string name = kv.first.as<std::string>();
+            std::string v = kv.second.as<std::string>();
+            pool_config.rpc_acl_[name] = (v == "private") ? 1u : 0u;
+          }
+        }
+
         // Add to compose config
         compose_config_.pools_.push_back(pool_config);
       }

--- a/context-runtime/src/ipc/ipc_cpu2cpu.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu.cc
@@ -42,6 +42,14 @@ ctp::ipc::FullPtr<Task> IpcCpu2Cpu::RuntimeRecv(
     task_full_ptr = container->AllocLoadTask(method_id, archive);
   }
 
+  // This task came straight from an external user client (the
+  // FUTURE_COPY_FROM_CLIENT guard above), so tag it for per-RPC access control.
+  // The flag is serialized in SerializeIn, so it survives if the task is later
+  // forwarded to a remote container owner.
+  if (!task_full_ptr.IsNull()) {
+    task_full_ptr->SetFlags(TASK_EXTERNAL_CLIENT);
+  }
+
   // Update the Future's task pointer and mark as copied
   future.GetTaskPtr() = task_full_ptr;
   future_shm->flags_.SetBits(FutureShm::FUTURE_WAS_COPIED);

--- a/context-runtime/src/ipc/ipc_cpu2cpu_zmq.cc
+++ b/context-runtime/src/ipc/ipc_cpu2cpu_zmq.cc
@@ -93,6 +93,12 @@ bool IpcCpu2CpuZmq::RuntimeRecv(IpcManager *ipc, u32 &tasks_received) {
         continue;
       }
 
+      // This transport serves external user clients (TCP/IPC); runtime peers
+      // use the run2run path. Tag the task for per-RPC access control. The flag
+      // is in SerializeIn, so it rides along if the task is forwarded to a
+      // remote container owner.
+      task_ptr->SetFlags(TASK_EXTERNAL_CLIENT);
+
       // If SerializeIn copied any ZMQ-owned BULK_XFER input into a fresh
       // CHI buffer, the task now owns that buffer. Promote the count to
       // TASK_DATA_OWNER so the task destructor frees it (mirrors admin

--- a/context-runtime/src/pool_manager.cc
+++ b/context-runtime/src/pool_manager.cc
@@ -611,10 +611,13 @@ TaskResume PoolManager::CreatePool(FullPtr<Task> task, RunContext* run_ctx) {
          "Creating container for pool {} on node {} with container_id={}",
          target_pool_id, node_id, node_id);
 
-    // Check if this is a restart scenario (compose mode with restart flag)
+    // Check if this is a restart scenario (compose mode with restart flag).
+    // The compose PoolConfig also carries optional per-RPC access control
+    // (container_visibility / container_rpc_acl), applied after Init below.
     bool is_restart = false;
+    chi::PoolConfig pool_config;
     if (create_task->do_compose_) {
-      chi::PoolConfig pool_config =
+      pool_config =
           chi::Task::Deserialize<chi::PoolConfig>(create_task->chimod_params_);
       is_restart = pool_config.restart_;
     }
@@ -626,6 +629,12 @@ TaskResume PoolManager::CreatePool(FullPtr<Task> task, RunContext* run_ctx) {
     } else {
       container->Init(target_pool_id, pool_name, node_id);
     }
+
+    // Apply per-RPC access control now that the module's Init has populated the
+    // method-name table (via SetMethodNames). Defaults (public, no overrides)
+    // make this a no-op for pools that don't opt in.
+    container->ConfigureAcl(pool_config.container_visibility_,
+                            pool_config.rpc_acl_);
 
     HLOG(kInfo,
          "Container initialized with pool ID {}, name {}, and container ID {}",

--- a/context-runtime/src/worker.cc
+++ b/context-runtime/src/worker.cc
@@ -43,6 +43,7 @@
 #ifndef __NVCOMPILER
 #include <coroutine>
 #endif
+#include <cerrno>
 #include <cstdlib>
 #include <iostream>
 #include <unordered_set>
@@ -940,6 +941,27 @@ void Worker::ExecTask(const FullPtr<Task> &task_ptr, RunContext *run_ctx,
       pool_manager->GetContainer(task_ptr->pool_id_, container_id, is_plugged);
   if (exec_container && !is_plugged) {
     run_ctx->container_ = exec_container;
+  }
+
+  // Per-RPC access control. This is the owning host (the container is resolved
+  // locally and the method is about to run) and the only place reached exactly
+  // once per locally-executed task — including remote-forwarded ones, which
+  // re-enter here on arrival with TASK_EXTERNAL_CLIENT preserved across the hop.
+  // Reject an external user client's call to a private method before the
+  // handler runs; deliver EACCES through the normal completion path. Internal
+  // callers and public methods pass through. Only on first execution (resumes
+  // of an already-admitted task carry no new authorization decision).
+  if (!is_started && exec_container &&
+      !exec_container->IsRpcAllowed(
+          task_ptr->method_,
+          task_ptr->task_flags_.Any(TASK_EXTERNAL_CLIENT))) {
+    HLOG(kWarning,
+         "Worker {}: denying external client call to private method {} on "
+         "pool {}",
+         worker_id_, task_ptr->method_, task_ptr->pool_id_);
+    task_ptr->SetReturnCode(EACCES);
+    EndTask(task_ptr, run_ctx, /*can_resched=*/false);
+    return;
   }
 
   // Start CPU and wall timers before execution

--- a/context-runtime/test/unit/cli/CMakeLists.txt
+++ b/context-runtime/test/unit/cli/CMakeLists.txt
@@ -208,6 +208,43 @@ if(CLIO_CORE_ENABLE_TESTS)
     )
   endif()
 
+  # Per-RPC access-control test (private containers/methods). Composes ram bdev
+  # pools marked private (whole-container and per-RPC) and asserts an external
+  # client's direct Write/AllocateBlocks is rejected with EACCES while a public
+  # control pool succeeds. Spawns its own daemon on port 10606 — serialize with
+  # the other live-runtime tests.
+  add_executable(chimaera_bdev_acl_test test_bdev_acl.cc)
+  target_include_directories(chimaera_bdev_acl_test PRIVATE
+    ${CLIO_RUN_ROOT}/include
+    ${CLIO_RUN_ROOT}/test
+  )
+  target_link_libraries(chimaera_bdev_acl_test
+    clio_bdev_client
+    clio_admin_client
+    chimaera_cxx
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+  target_compile_definitions(chimaera_bdev_acl_test PRIVATE
+    CLIO_RUN_EXE="$<TARGET_FILE:clio_run>")
+  add_dependencies(chimaera_bdev_acl_test clio_run clio_bdev_runtime)
+  set_target_properties(chimaera_bdev_acl_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  add_test(
+    NAME cr_cli_bdev_acl
+    COMMAND chimaera_bdev_acl_test
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_cli_bdev_acl PROPERTIES
+    ENVIRONMENT "${_cli_live_env}"
+    RESOURCE_LOCK "chimaera_runtime_port"
+    TIMEOUT 120
+    LABELS "msan_skip"
+  )
+
   # RestartLog unit test: pure file-level WAL behavior (no daemon).
   add_executable(chimaera_restart_log_test test_restart_log.cc)
   target_include_directories(chimaera_restart_log_test PRIVATE

--- a/context-runtime/test/unit/cli/test_bdev_acl.cc
+++ b/context-runtime/test/unit/cli/test_bdev_acl.cc
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved. BSD 3-Clause license.
+ */
+
+/**
+ * Per-RPC access-control test. A compose file marks bdev containers (or
+ * specific RPCs) private; an external user client's direct call to a private
+ * operation must be rejected with EACCES, while the same call to a public
+ * container/RPC succeeds. This is what stops users from writing directly to a
+ * block device that a filesystem owns.
+ *
+ * Three composed bdev pools (IDs chosen to avoid the daemon's default-config
+ * pools — the bundled compose already owns bdev 301.0):
+ *   701.0  container_visibility: private   -> AllocateBlocks AND Write rejected
+ *   702.0  (public, control)               -> AllocateBlocks AND Write succeed
+ *   703.0  container_rpc_acl: {Write:private} -> AllocateBlocks ok, Write rejected
+ */
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/bdev/bdev_client.h>
+
+#include "runtime_server.h"
+#include "simple_test.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+int RunCliTimed(const std::vector<std::string>& args, int timeout_sec) {
+  std::vector<std::string> full;
+  full.push_back(CLIO_RUN_EXE);
+  full.insert(full.end(), args.begin(), args.end());
+  std::vector<char*> argv;
+  for (auto& a : full) argv.push_back(a.data());
+  argv.push_back(nullptr);
+  pid_t pid = fork();
+  if (pid < 0) return -1;
+  if (pid == 0) {
+    int n = open("/dev/null", O_WRONLY);
+    if (n >= 0) { dup2(n, 1); dup2(n, 2); close(n); }
+    execv(argv[0], argv.data());
+    _exit(127);
+  }
+  auto deadline = std::chrono::steady_clock::now() +
+                  std::chrono::seconds(timeout_sec);
+  int status = 0;
+  while (true) {
+    pid_t r = waitpid(pid, &status, WNOHANG);
+    if (r == pid) return WIFEXITED(status) ? WEXITSTATUS(status) : -2;
+    if (std::chrono::steady_clock::now() >= deadline) {
+      kill(pid, SIGKILL); waitpid(pid, &status, 0); return -3;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}
+
+chi::priv::vector<clio::run::bdev::Block> WrapBlock(
+    const clio::run::bdev::Block& block) {
+  chi::priv::vector<clio::run::bdev::Block> blocks(CTP_MALLOC);
+  blocks.push_back(block);
+  return blocks;
+}
+}  // namespace
+
+TEST_CASE("Bdev - per-RPC access control rejects external private calls",
+          "[cli][bdev][acl]") {
+  constexpr unsigned kPort = 10606;
+  const fs::path work = fs::temp_directory_path() / "bdev_acl_test";
+  fs::remove_all(work);
+  fs::create_directories(work);
+
+  const fs::path yaml = work / "compose.yaml";
+  {
+    std::ofstream f(yaml);
+    f << "compose:\n"
+         "  - mod_name: clio_bdev\n"
+         "    pool_name: \"ram::acl_private\"\n"
+         "    pool_query: local\n"
+         "    pool_id: \"701.0\"\n"
+         "    bdev_type: ram\n"
+         "    capacity: \"64mb\"\n"
+         "    container_visibility: private\n"
+         "  - mod_name: clio_bdev\n"
+         "    pool_name: \"ram::acl_public\"\n"
+         "    pool_query: local\n"
+         "    pool_id: \"702.0\"\n"
+         "    bdev_type: ram\n"
+         "    capacity: \"64mb\"\n"
+         "  - mod_name: clio_bdev\n"
+         "    pool_name: \"ram::acl_wronly\"\n"
+         "    pool_query: local\n"
+         "    pool_id: \"703.0\"\n"
+         "    bdev_type: ram\n"
+         "    capacity: \"64mb\"\n"
+         "    container_rpc_acl:\n"
+         "      Write: private\n";
+  }
+
+  setenv("CLIO_WAIT_SERVER", "15", 1);
+  setenv("CLIO_BIND_ADDR", "127.0.0.1", 1);
+
+  clio::run::test::RuntimeServer server;
+  REQUIRE(server.Start(kPort));
+  REQUIRE(server.WaitForReady());
+  REQUIRE(RunCliTimed({"compose", "start", yaml.string()}, 60) == 0);
+
+  REQUIRE(chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, false));
+  auto* ipc = CLIO_IPC;
+  REQUIRE(ipc != nullptr);
+
+  const auto local = chi::PoolQuery::Local();
+  constexpr chi::u64 kN = 4096;
+
+  clio::run::bdev::Client priv(chi::PoolId(701, 0));
+  clio::run::bdev::Client pub(chi::PoolId(702, 0));
+  clio::run::bdev::Client wronly(chi::PoolId(703, 0));
+
+  auto write_buf = [&](const chi::priv::vector<clio::run::bdev::Block>& blocks,
+                       clio::run::bdev::Client& c) {
+    ctp::ipc::FullPtr<char> wb = ipc->AllocateBuffer(kN);
+    memset(wb.ptr_, 'z', kN);
+    auto w = c.AsyncWrite(local, blocks, wb.shm_.template Cast<void>(), kN);
+    w.Wait();
+    int rc = static_cast<int>(w->GetReturnCode());
+    ipc->FreeBuffer(wb);
+    return rc;
+  };
+
+  // ---- Control: public pool 702 — allocate + write both succeed. ----
+  clio::run::bdev::Block pub_block;
+  {
+    auto a = pub.AsyncAllocateBlocks(local, kN);
+    a.Wait();
+    REQUIRE(a->GetReturnCode() == 0);
+    REQUIRE_FALSE(a->blocks_.empty());
+    pub_block = a->blocks_[0];
+    REQUIRE(write_buf(WrapBlock(pub_block), pub) == 0);
+  }
+
+  // ---- Private container 701 — every RPC rejected for the external client. ----
+  {
+    auto a = priv.AsyncAllocateBlocks(local, kN);
+    a.Wait();
+    REQUIRE(static_cast<int>(a->GetReturnCode()) == EACCES);  // allocate private
+    // Write (reusing a valid block) is rejected before the handler runs.
+    REQUIRE(write_buf(WrapBlock(pub_block), priv) == EACCES);
+  }
+
+  // ---- Per-RPC override 703 — AllocateBlocks public, Write private. ----
+  {
+    auto a = wronly.AsyncAllocateBlocks(local, kN);
+    a.Wait();
+    REQUIRE(a->GetReturnCode() == 0);  // AllocateBlocks stays public
+    REQUIRE_FALSE(a->blocks_.empty());
+    REQUIRE(write_buf(WrapBlock(a->blocks_[0]), wronly) == EACCES);  // Write private
+  }
+
+  RunCliTimed({"stop", "--grace-period", "2000"}, 90);
+  for (int i = 0; i < 200 && server.IsRunning(); ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  server.Stop();
+  fs::remove_all(work);
+}
+
+SIMPLE_TEST_MAIN()


### PR DESCRIPTION
## Protecting Individual RPCs

Block devices expose raw storage that filesystems are built on top of. A user writing to a bdev directly corrupts whatever storage stack owns it. Today there is **no access control** — any client can call any RPC on any container. This PR adds an opt-in, compose-driven ACL so a pool (or specific RPCs) can be marked **private**: external user clients are rejected with `EACCES`, while runtime-internal callers (e.g. the filesystem chimod calling bdev) still work.

**Model:** a request is allowed iff it is **internal**, OR the target method is **public**. `private` only blocks external clients. Enforcement happens on the **host that owns the container**, so the "external" signal is a task flag that survives a cross-node hop.

## Changes

### Compose schema → `PoolConfig`
Two optional keywords, parsed in `ConfigManager::ParseYAML` and serialized into the create task:
- `container_visibility: public|private` — per-pool default (default `public`).
- `container_rpc_acl: { Write: private, ... }` — per-method override keyed by RPC **name**.

### `Container` carries the ACL (read-only after construction)
- `struct MethodProperty` (bitfield, `kPrivate`).
- `ConfigureAcl(...)` translates ACL names → method ids via the already-populated `method_names_` table, called from `PoolManager::CreatePool` right after `Init()`.
- `IsRpcAllowed(method_id, is_external)` — `if (!is_external) return true;` then check the per-method override, falling back to the container default. Built once, never mutated → no locking on the hot path.

### External-client task flag
- `TASK_EXTERNAL_CLIENT` (bit 9) set at the two client ingress points: `IpcCpu2Cpu::RuntimeRecv` (SHM) and `IpcCpu2CpuZmq::RuntimeRecv` (TCP/IPC). It is part of `Task::SerializeIn`, so it propagates when a task is forwarded to a remote container's owning host. Internal (`IpcCpu2Self`) and peer (run2run) paths are untouched.

### Enforcement
- In `Worker::ExecTask`, after the container is resolved and before the coroutine starts (first execution only): reject a private call from an external client with `EACCES` through the normal `EndTask` completion path — the handler never runs.

## Tests
New `cr_cli_bdev_acl` composes ram bdev pools:
- `701.0` `container_visibility: private` → `AllocateBlocks` **and** `Write` rejected (`EACCES`).
- `702.0` public control → both succeed.
- `703.0` `container_rpc_acl: { Write: private }` → `AllocateBlocks` allowed, `Write` rejected.

Regressions pass: `cr_cli_cfs` (filesystem→bdev internal path stays allowed), `cr_all_bdev_tests` and `cr_bdev_explicit_backend_shm` (public/internal bdev calls unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)