### PR TITLE
feat(bdev/gcs): production-quality GCS cloud bdev adapter (#539)

### DIFF
--- a/context-runtime/config/chimaera_default.yaml
+++ b/context-runtime/config/chimaera_default.yaml
@@ -75,8 +75,119 @@ compose:
   #   pool_name: "/mnt/nvme/chi_bdev"
   #   pool_query: local
   #   pool_id: "302.0"
-  #   bdev_type: file                    # Options: file, ram, hbm, pinned, noop
+  #   bdev_type: file                    # Options: file, ram, hbm, pinned, noop, s3, gcs
   #   capacity: "100GB"
+
+  # === Block Device (S3 object store) — prototype ===
+  # Requires building with -DCLIO_CORE_ENABLE_S3=ON (libcurl + OpenSSL SigV4).
+  # pool_name encodes the bucket + key prefix: s3://<bucket>/<prefix>.
+  # The endpoint, region, and credentials come from the environment (NOT this
+  # file, so no secrets are serialized): S3_ENDPOINT (or AWS_ENDPOINT_URL),
+  # AWS_REGION (default us-east-1), AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY.
+  # Each allocator block maps to one object keyed by byte offset (s3backer
+  # model); capacity is required (the object store has no device size to stat).
+  # Example against a local MinIO:
+  #   export S3_ENDPOINT=http://127.0.0.1:9000
+  #   export AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin
+  # - mod_name: clio_bdev
+  #   pool_name: "s3://clio-bdev/pool0"
+  #   pool_query: local
+  #   pool_id: "303.0"
+  #   bdev_type: s3                      # Options: file, ram, hbm, pinned, noop, s3, gcs
+  #   capacity: "10GB"
+
+  # === Block Device (Google Cloud Storage) ===
+  # Requires building with -DCLIO_CORE_ENABLE_GCS=ON (libcurl + OpenSSL +
+  # nlohmann/json). pool_name encodes the bucket + key prefix: gcs://<bucket>/
+  # <prefix>. Endpoint, project, credentials, and tuning come from the
+  # environment (NOT this file, so no secrets are serialized):
+  #   GCS_ENDPOINT    (default https://storage.googleapis.com; point at a
+  #                    fake-gcs-server, e.g. http://127.0.0.1:4443, to emulate)
+  #   GCS_PROJECT_ID  (default clio-prototype; only used to create the bucket)
+  # Auth resolves via the Application Default Credentials precedence chain, and
+  # the bearer token is cached + refreshed before expiry, shared across workers:
+  #   1. GCS_ACCESS_TOKEN                (verbatim bearer token)
+  #   2. GOOGLE_APPLICATION_CREDENTIALS  (service-account JSON -> RS256 JWT, or a
+  #                                       gcloud authorized_user refresh token)
+  #   3. gcloud ADC file (~/.config/gcloud/application_default_credentials.json)
+  #   4. GCE/GKE metadata server         (also GKE Workload Identity)
+  #   5. anonymous                       (fake-gcs-server / public objects)
+  # Optional tuning knobs (all default to safe production values):
+  #   GCS_MAX_RETRIES (5) / GCS_RETRY_BASE_MS (100) / GCS_RETRY_MAX_MS (30000)
+  #        exponential-backoff retry on HTTP 429/5xx + transient network errors
+  #   GCS_RESUMABLE_THRESHOLD (8388608)  writes >= N bytes use a resumable
+  #        upload; block writes are smaller, so media upload is the normal path
+  #   GCS_CONNECT_TIMEOUT_S (10) / GCS_FORCE_HTTP11 (unset => HTTP/2) / GCS_CA_BUNDLE
+  #   GCS_DISABLE_METADATA               skip the off-GCP metadata probe
+  # Uses the GCS JSON API (media/resumable upload + alt=media download); same
+  # s3backer block->object mapping as kS3. capacity is required.
+  # Example against a local fake-gcs-server (anonymous):
+  #   export GCS_ENDPOINT=http://127.0.0.1:4443 GCS_PROJECT_ID=clio-prototype
+  # - mod_name: clio_bdev
+  #   pool_name: "gcs://clio-bdev/pool0"
+  #   pool_query: local
+  #   pool_id: "304.0"
+  #   bdev_type: gcs                     # Options: file, ram, hbm, pinned, noop, s3, gcs
+  #   capacity: "10GB"
+
+  # === Block Device (Azure Blob storage) — prototype ===
+  # Requires building with -DCLIO_CORE_ENABLE_AZURE=ON (libcurl + OpenSSL
+  # Shared Key signing). pool_name encodes the container + key prefix:
+  # azure://<container>/<prefix>. The endpoint, account, and access key come
+  # from the environment (NOT this file, so no secrets are serialized):
+  #   AZURE_BLOB_ENDPOINT   (e.g. http://127.0.0.1:10000 for Azurite, or
+  #                          https://<account>.blob.core.windows.net for Azure)
+  #   AZURE_STORAGE_ACCOUNT (storage account name; "devstoreaccount1" on Azurite)
+  #   AZURE_STORAGE_KEY     (base64 account access key)
+  # Addressing style is auto-detected: account-in-host -> virtual-hosted,
+  # otherwise account-as-first-path-segment (the Azurite emulator convention).
+  # Two backends are provided:
+  #   bdev_type: azure       -> Block Blob. One immutable blob per allocator
+  #                             block, keyed by byte offset (s3backer model;
+  #                             whole-object PUT/GET, like kS3).
+  #   bdev_type: azure_page  -> Page Blob. The WHOLE device is one page blob
+  #                             written in-place at 512-byte-aligned byte
+  #                             offsets (Put Page) — the cloud primitive that
+  #                             matches the bdev's flat-device offset model.
+  # capacity is required (it sizes the heap allocator and, for page blobs, the
+  # page blob's virtual length).
+  # Example against a local Azurite (well-known dev account):
+  #   export AZURE_BLOB_ENDPOINT=http://127.0.0.1:10000
+  #   export AZURE_STORAGE_ACCOUNT=devstoreaccount1
+  #   export AZURE_STORAGE_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+  # - mod_name: clio_bdev
+  #   pool_name: "azure://clio-bdev/pool0"
+  #   pool_query: local
+  #   pool_id: "305.0"
+  #   bdev_type: azure                   # or azure_page (in-place Page Blob)
+  #   capacity: "10GB"
+
+  # === Block Device (Alibaba Cloud OSS) — prototype ===
+  # Requires building with -DCLIO_CORE_ENABLE_OSS=ON (libcurl + OpenSSL). The
+  # genuinely OSS-specific part is the native V1 signer: HMAC-SHA1 over a
+  # canonicalized request, "Authorization: OSS <AccessKeyId>:<Signature>", an
+  # RFC-1123 Date header, and x-oss-* canonical headers (structurally different
+  # from AWS SigV4). pool_name encodes the bucket + key prefix:
+  # oss://<bucket>/<prefix>. Endpoint/region/credentials come from the
+  # environment (NOT this file, so no secrets are serialized):
+  #   OSS_ENDPOINT          (e.g. https://oss-cn-hangzhou.aliyuncs.com, or
+  #                          http://127.0.0.1:9000 for a local S3 emulator)
+  #   OSS_REGION            (default cn-hangzhou; us-east-1 for MinIO s3-compat)
+  #   OSS_ACCESS_KEY_ID     (AccessKeyId; AWS_ACCESS_KEY_ID also accepted)
+  #   OSS_ACCESS_KEY_SECRET (AccessKeySecret; AWS_SECRET_ACCESS_KEY accepted)
+  #   OSS_SIGNATURE         (v1 = native OSS [default]; s3 = AWS SigV4 for OSS's
+  #                          S3-compatible endpoint or an S3 emulator like MinIO)
+  # Each allocator block maps to one object keyed by byte offset (s3backer
+  # model; whole-object PUT/GET, like kS3); capacity is required.
+  # Example against real OSS (native V1 signing):
+  #   export OSS_ENDPOINT=https://oss-cn-hangzhou.aliyuncs.com
+  #   export OSS_ACCESS_KEY_ID=...  OSS_ACCESS_KEY_SECRET=...
+  # - mod_name: clio_bdev
+  #   pool_name: "oss://clio-bdev/pool0"
+  #   pool_query: local
+  #   pool_id: "306.0"
+  #   bdev_type: oss
+  #   capacity: "10GB"
 
   # === Context Assimilation Engine (CAE) ===
   # Assimilation / discovery entrypoint at its own pool 400.0

--- a/context-runtime/modules/bdev/CMakeLists.txt
+++ b/context-runtime/modules/bdev/CMakeLists.txt
@@ -14,6 +14,74 @@ elseif(CLIO_CORE_ENABLE_ROCM)
   list(APPEND BDEV_GPU_LIBS ctp::rocm_cxx)
 endif()
 
+# Collect optional S3 backend dependency (kS3 bdev type, prototype).
+# Hand-rolled S3 client: libcurl for HTTP + OpenSSL for SigV4 signing.
+set(BDEV_S3_LIBS "")
+set(BDEV_RUNTIME_EXTRA_SOURCES "")
+if(CLIO_CORE_ENABLE_S3)
+  find_package(CURL REQUIRED)
+  find_package(OpenSSL REQUIRED)
+  list(APPEND BDEV_S3_LIBS CURL::libcurl OpenSSL::Crypto)
+  list(APPEND BDEV_RUNTIME_EXTRA_SOURCES src/s3_client.cc)
+  message(STATUS "bdev: S3 backend enabled (libcurl + OpenSSL SigV4)")
+endif()
+
+# Production GCS client (kGcs bdev type): libcurl (HTTP/2 + TLS) for the GCS
+# JSON API, OpenSSL for the OAuth2 service-account JWT (RSA-SHA256) auth path,
+# and nlohmann/json (header-only, system) for robust token/key-file parsing.
+# gcs_credentials.cc owns the ADC token lifecycle (cache/refresh/metadata) and
+# gcs_retry.cc the transient-failure backoff policy.
+if(CLIO_CORE_ENABLE_GCS)
+  find_package(CURL REQUIRED)
+  find_package(OpenSSL REQUIRED)
+  find_package(nlohmann_json QUIET)
+  list(APPEND BDEV_S3_LIBS CURL::libcurl OpenSSL::Crypto)
+  if(TARGET nlohmann_json::nlohmann_json)
+    list(APPEND BDEV_S3_LIBS nlohmann_json::nlohmann_json)
+  endif()
+  list(APPEND BDEV_RUNTIME_EXTRA_SOURCES
+    src/gcs_client.cc
+    src/gcs_credentials.cc
+    src/gcs_retry.cc)
+  message(STATUS "bdev: GCS backend enabled (libcurl + OpenSSL OAuth2/JWT + nlohmann_json)")
+endif()
+
+# Hand-rolled Azure Blob client (kAzure / kAzurePage bdev types, prototype):
+# libcurl for HTTP + OpenSSL for the Shared Key signer (HMAC-SHA256, base64).
+if(CLIO_CORE_ENABLE_AZURE)
+  find_package(CURL REQUIRED)
+  find_package(OpenSSL REQUIRED)
+  list(APPEND BDEV_S3_LIBS CURL::libcurl OpenSSL::Crypto)
+  list(APPEND BDEV_RUNTIME_EXTRA_SOURCES src/azure_blob_client.cc)
+  message(STATUS "bdev: Azure Blob backend enabled (libcurl + OpenSSL Shared Key)")
+endif()
+
+# Hand-rolled Alibaba Cloud OSS client (kOss bdev type, prototype): libcurl for
+# HTTP + OpenSSL for the native OSS V1 signer (HMAC-SHA1, base64) plus a SigV4
+# path (HMAC-SHA256) for OSS's S3-compatible endpoint / local emulators.
+if(CLIO_CORE_ENABLE_OSS)
+  find_package(CURL REQUIRED)
+  find_package(OpenSSL REQUIRED)
+  list(APPEND BDEV_S3_LIBS CURL::libcurl OpenSSL::Crypto)
+  list(APPEND BDEV_RUNTIME_EXTRA_SOURCES src/oss_client.cc)
+  message(STATUS "bdev: OSS backend enabled (libcurl + OpenSSL OSS V1 HMAC-SHA1)")
+endif()
+
+# Shared cloud seam (compiled whenever ANY cloud provider is enabled): the
+# provider-agnostic ObjectStoreClient factory, the curl-multi transport base,
+# and the de-duplicated crypto helpers. These unify the four provider clients
+# behind one interface (the C++ factory-pattern prototype).
+set(BDEV_ANY_CLOUD OFF)
+if(CLIO_CORE_ENABLE_S3 OR CLIO_CORE_ENABLE_GCS OR CLIO_CORE_ENABLE_AZURE OR
+   CLIO_CORE_ENABLE_OSS)
+  set(BDEV_ANY_CLOUD ON)
+  list(APPEND BDEV_RUNTIME_EXTRA_SOURCES
+    src/cloud_crypto.cc
+    src/http_object_store_client.cc
+    src/object_store_factory.cc)
+  message(STATUS "bdev: cloud object-store seam enabled (factory + shared transport)")
+endif()
+
 # Client library — ctp::aio provides async I/O headers via its INTERFACE includes.
 # LIB_NAME pins the library to `clio_bdev_client` (the new brand-aligned
 # name); ALIAS keeps `chimaera_bdev_client` working as a CMake target for
@@ -35,13 +103,36 @@ add_clio_module_runtime(
   SOURCES
     src/bdev_runtime.cc
     src/autogen/bdev_lib_exec.cc
+    ${BDEV_RUNTIME_EXTRA_SOURCES}
   LINK_LIBRARIES
     clio_admin_runtime
     ctp::aio
     ${BDEV_OPTIONAL_LIBS}
     ${BDEV_GPU_LIBS}
+    ${BDEV_S3_LIBS}
 )
 add_library(chimaera_bdev_runtime ALIAS clio_bdev_runtime)
+
+# Compile the kS3 backend (and its conditional Runtime members) into the
+# runtime target only when S3 is enabled. PRIVATE keeps the macro/ABI scoped
+# to the runtime library's translation units (bdev_runtime.cc + autogen).
+if(CLIO_CORE_ENABLE_S3 AND TARGET clio_bdev_runtime)
+  target_compile_definitions(clio_bdev_runtime PRIVATE CLIO_BDEV_S3_ENABLED=1)
+endif()
+if(CLIO_CORE_ENABLE_GCS AND TARGET clio_bdev_runtime)
+  target_compile_definitions(clio_bdev_runtime PRIVATE CLIO_BDEV_GCS_ENABLED=1)
+endif()
+if(CLIO_CORE_ENABLE_AZURE AND TARGET clio_bdev_runtime)
+  target_compile_definitions(clio_bdev_runtime PRIVATE CLIO_BDEV_AZURE_ENABLED=1)
+endif()
+if(CLIO_CORE_ENABLE_OSS AND TARGET clio_bdev_runtime)
+  target_compile_definitions(clio_bdev_runtime PRIVATE CLIO_BDEV_OSS_ENABLED=1)
+endif()
+# Aggregate guard: the runtime + factory + shared transport are provider-
+# agnostic and only need to know that SOME cloud backend is compiled in.
+if(BDEV_ANY_CLOUD AND TARGET clio_bdev_runtime)
+  target_compile_definitions(clio_bdev_runtime PRIVATE CLIO_BDEV_ANY_CLOUD_ENABLED=1)
+endif()
 
 # SYCL HBM bdev support: a separate task. Adding -fsycl to
 # clio_bdev_runtime conflicts with the runtime's precompiled

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_runtime.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_runtime.h
@@ -46,6 +46,14 @@
 #include <memory>
 #include <mutex>
 
+#if defined(CLIO_BDEV_ANY_CLOUD_ENABLED)
+// Cloud object-store backends (kS3/kGcs/kAzure/kAzurePage/kOss) are unified
+// behind one ObjectStoreClient interface + a factory; the concrete provider
+// clients are pulled in only by object_store_factory.cc.
+#include "object_store_client.h"
+#include "object_store_factory.h"
+#endif
+
 /**
  * Runtime container for bdev ChiMod
  *
@@ -402,6 +410,17 @@ class Runtime : public chi::Container {
 
   // kHbm / kPinned removed — see WriteToRam comment above.
 
+#if defined(CLIO_BDEV_ANY_CLOUD_ENABLED)
+  // Cloud object-store storage (kS3/kGcs/kAzure/kAzurePage/kOss). One client is
+  // owned per worker because a curl multi handle is not safe to share across
+  // threads. The pool name captured at Create lets the factory reconstruct the
+  // per-worker client lazily; the offset->object mapping (block->object vs
+  // in-place page blob) lives inside the concrete ObjectStoreClient, so the
+  // runtime stays fully provider-agnostic.
+  std::string cloud_pool_name_;
+  std::vector<std::unique_ptr<ObjectStoreClient>> worker_cloud_clients_;
+#endif
+
   // New allocator components
   GlobalBlockMap global_block_map_;              // Global block cache with per-worker locking
   Heap heap_;                                     // Heap allocator for new blocks
@@ -491,6 +510,27 @@ class Runtime : public chi::Container {
    */
   void WriteToRam(ctp::ipc::FullPtr<WriteTask> task);
   void ReadFromRam(ctp::ipc::FullPtr<ReadTask> task);
+
+#if defined(CLIO_BDEV_ANY_CLOUD_ENABLED)
+  /**
+   * Backend-specific cloud object-store operations (coroutines that yield while
+   * the async PUT/GET is in flight, mirroring WriteToFile/ReadFromFile). One
+   * pair serves every cloud BdevType; the per-provider request construction and
+   * the offset->object mapping (block->object vs in-place page blob) live behind
+   * the ObjectStoreClient interface, so these are fully provider-agnostic.
+   */
+  chi::TaskResume WriteToCloud(ctp::ipc::FullPtr<WriteTask> task,
+                               chi::RunContext &ctx);
+  chi::TaskResume ReadFromCloud(ctp::ipc::FullPtr<ReadTask> task,
+                                chi::RunContext &ctx);
+
+  /**
+   * Get (lazily creating) the cloud object-store client for the given worker.
+   * @param worker_id Worker ID.
+   * @return Pointer to the worker's client, or nullptr on failure.
+   */
+  ObjectStoreClient *GetWorkerCloudClient(size_t worker_id);
+#endif
 
   // BdevType::kHbm / BdevType::kPinned tiers were removed. PutBlob /
   // GetBlob with HBM-resident ShmPtr data buffers route through kRam

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
@@ -83,7 +83,12 @@ enum class BdevType : chi::u32 {
   kRam = 1,     // RAM-based block device
   kHbm = 2,     // GPU High-Bandwidth Memory via cudaMalloc (device memory)
   kPinned = 3,  // Pinned host memory via cudaMallocHost
-  kNoop = 4     // No-op backend for latency testing (no actual I/O)
+  kNoop = 4,    // No-op backend for latency testing (no actual I/O)
+  kS3 = 5,      // S3 object-store backend (prototype; libcurl + SigV4)
+  kGcs = 6,     // Google Cloud Storage backend (prototype; JSON API + OAuth2)
+  kAzure = 7,   // Azure Block Blob backend (prototype; libcurl + Shared Key)
+  kAzurePage = 8,  // Azure Page Blob backend (prototype; in-place 512B writes)
+  kOss = 9        // Alibaba Cloud OSS backend (prototype; libcurl + OSS V1 HMAC-SHA1)
 };
 
 /**
@@ -256,6 +261,40 @@ struct CreateParams {
         bdev_type_ = BdevType::kPinned;
       } else if (type_str == "noop") {
         bdev_type_ = BdevType::kNoop;
+      } else if (type_str == "s3") {
+        // S3 object-store backend. Bucket/prefix come from pool_name
+        // (s3://bucket/prefix); endpoint/region/credentials are read from
+        // the S3_ENDPOINT / AWS_REGION / AWS_ACCESS_KEY_ID /
+        // AWS_SECRET_ACCESS_KEY environment variables at Create time.
+        bdev_type_ = BdevType::kS3;
+      } else if (type_str == "gcs") {
+        // Google Cloud Storage backend. Bucket/prefix come from pool_name
+        // (gcs://bucket/prefix); endpoint/project/credentials are read from
+        // the GCS_ENDPOINT / GCS_PROJECT_ID / GOOGLE_APPLICATION_CREDENTIALS
+        // (or GCS_ACCESS_TOKEN) environment variables at Create time.
+        bdev_type_ = BdevType::kGcs;
+      } else if (type_str == "azure") {
+        // Azure Block Blob backend. Container/prefix come from pool_name
+        // (azure://container/prefix); endpoint/account/credentials are read
+        // from the AZURE_BLOB_ENDPOINT / AZURE_STORAGE_ACCOUNT /
+        // AZURE_STORAGE_KEY environment variables at Create time. Each
+        // allocator block maps to one block blob keyed by byte offset
+        // (s3backer model; whole-object PUT/GET).
+        bdev_type_ = BdevType::kAzure;
+      } else if (type_str == "azure_page") {
+        // Azure Page Blob backend. Same pool_name/env contract as "azure",
+        // but the whole device maps to ONE page blob that supports 512-byte
+        // aligned in-place writes (Put Page) at byte offsets — the cloud
+        // primitive matching the bdev's flat-device, in-place-offset model.
+        bdev_type_ = BdevType::kAzurePage;
+      } else if (type_str == "oss") {
+        // Alibaba Cloud OSS backend. Bucket/prefix come from pool_name
+        // (oss://bucket/prefix); endpoint/region/credentials are read from
+        // the OSS_ENDPOINT / OSS_REGION / OSS_ACCESS_KEY_ID /
+        // OSS_ACCESS_KEY_SECRET environment variables at Create time. The
+        // native OSS V1 (HMAC-SHA1) signer is the default; OSS_SIGNATURE=s3
+        // selects AWS SigV4 for OSS's S3-compatible endpoint / emulators.
+        bdev_type_ = BdevType::kOss;
       }
     }
 

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/cloud_crypto.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/cloud_crypto.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_BDEV_CLOUD_CRYPTO_H_
+#define CLIO_BDEV_CLOUD_CRYPTO_H_
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace clio::run::bdev::cloud {
+
+/**
+ * Shared crypto + encoding helpers for the cloud object-store adapters.
+ *
+ * Every HTTP object-store client (S3 SigV4, OSS V1/SigV4, Azure Shared Key)
+ * needs the same handful of primitives — hex/base64 encoding, HMAC, SHA-256,
+ * RFC-3986 URI encoding, and an RFC-1123 GMT clock. Each prototype originally
+ * carried its own `static` copy of these (themes X1/X5 in the prototype notes);
+ * factoring them here is the concrete de-duplication those notes called for.
+ * The functions are pure (no shared state) so they stay reusable across the
+ * per-worker clients without any synchronization.
+ */
+
+/** SHA-256 of empty content — the payload hash for body-less SigV4 requests. */
+extern const char *kEmptyPayloadSha256;
+
+/**
+ * Hex-encode raw bytes in lowercase.
+ * @param data Input bytes.
+ * @param len Number of input bytes.
+ * @return Lowercase hex string of length 2*len.
+ */
+std::string HexEncode(const unsigned char *data, size_t len);
+
+/**
+ * Compute the lowercase hex SHA-256 of a buffer (the SigV4 payload hash).
+ * @param data Input bytes (may be null when len==0).
+ * @param len Number of input bytes.
+ * @return 64-character lowercase hex digest.
+ */
+std::string Sha256Hex(const void *data, size_t len);
+
+/**
+ * Compute a raw HMAC-SHA256 (SigV4 key derivation, Azure Shared Key).
+ * @param key HMAC key bytes.
+ * @param key_len Key length.
+ * @param data Message bytes.
+ * @param data_len Message length.
+ * @return Raw 32-byte MAC.
+ */
+std::vector<unsigned char> HmacSha256(const unsigned char *key, size_t key_len,
+                                      const void *data, size_t data_len);
+
+/**
+ * Compute a raw HMAC-SHA1 (the native OSS V1 signing primitive).
+ * @param key HMAC key bytes (the AccessKeySecret).
+ * @param key_len Key length.
+ * @param data Message bytes (the string-to-sign).
+ * @param data_len Message length.
+ * @return Raw 20-byte MAC.
+ */
+std::vector<unsigned char> HmacSha1(const unsigned char *key, size_t key_len,
+                                    const void *data, size_t data_len);
+
+/**
+ * Base64-encode raw bytes (standard alphabet, '=' padding).
+ * @param data Input bytes.
+ * @param len Number of input bytes.
+ * @return The base64 text ("" when len==0).
+ */
+std::string Base64Encode(const unsigned char *data, size_t len);
+
+/**
+ * Base64-decode text into raw bytes (ignores '=' padding and whitespace).
+ * @param in Base64 text (e.g. an Azure account key).
+ * @return The decoded bytes (empty on malformed input).
+ */
+std::vector<unsigned char> Base64Decode(const std::string &in);
+
+/**
+ * RFC 3986 URI-encode per AWS/OSS rules (unreserved chars pass through).
+ * @param value String to encode.
+ * @param encode_slash When false, '/' is left literal (used for object paths).
+ * @return The percent-encoded string.
+ */
+std::string AwsUriEncode(const std::string &value, bool encode_slash);
+
+/**
+ * Format the current UTC time as an RFC 1123 GMT timestamp.
+ * Used for the OSS `Date` header and Azure `x-ms-date` header.
+ * @return e.g. "Mon, 15 Jun 2026 16:11:17 GMT".
+ */
+std::string Rfc1123GmtNow();
+
+/** ASCII-lowercase a string. */
+std::string ToLower(const std::string &s);
+
+/**
+ * Read an environment variable, returning a default when unset/empty.
+ * @param name Variable name.
+ * @param def Fallback value.
+ * @return The value or `def`.
+ */
+std::string EnvOr(const char *name, const std::string &def);
+
+}  // namespace clio::run::bdev::cloud
+
+#endif  // CLIO_BDEV_CLOUD_CRYPTO_H_

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/gcs_client.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/gcs_client.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_BDEV_GCS_CLIENT_H_
+#define CLIO_BDEV_GCS_CLIENT_H_
+
+#include <curl/curl.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "gcs_credentials.h"
+#include "http_object_store_client.h"
+
+namespace clio::run::bdev {
+
+/**
+ * Connection + addressing + auth configuration for one GCS endpoint.
+ *
+ * Bucket and key prefix are parsed from the bdev pool name
+ * (`gcs://bucket/prefix`). The endpoint and project come from the environment;
+ * the credential *source* is resolved at Create time (see FromEnvAndPoolName)
+ * so no secrets travel through serialized task fields.
+ *
+ * Unlike S3's per-request SigV4 signing, GCS's JSON API authenticates with a
+ * single `Authorization: Bearer <token>` header. The token is supplied by a
+ * shared, TTL-aware GcsTokenProvider (see gcs_credentials.h): the curl
+ * transport stays per-worker, but the token cache is shared across workers and
+ * refreshed before expiry — a fundamentally different auth model that the bdev
+ * seam accommodates alongside request-signing.
+ */
+struct GcsConfig {
+  std::string endpoint;      /**< Base endpoint, e.g. "https://storage.googleapis.com" */
+  std::string scheme;        /**< "http" or "https" */
+  std::string host;          /**< host[:port] portion of the endpoint */
+  std::string bucket;        /**< Target bucket name */
+  std::string prefix;        /**< Optional key prefix (no leading/trailing '/') */
+  std::string project_id;    /**< GCP project id (needed only to create buckets) */
+  /** Shared OAuth2 token provider (auth state is shared; transport per-worker). */
+  std::shared_ptr<GcsTokenProvider> token_provider;
+  size_t resumable_threshold = 8ull * 1024 * 1024; /**< Writes >= this go resumable */
+  long connect_timeout_s = 10;  /**< curl connect timeout in seconds */
+  bool http2 = true;            /**< Prefer HTTP/2 (false => force HTTP/1.1) */
+  std::string ca_bundle;        /**< Optional CA bundle path (else curl default) */
+  bool valid = false;        /**< True when all required fields were resolved */
+
+  /**
+   * Build a config from a `gcs://bucket/prefix` pool name and the environment.
+   *
+   * Reads GCS_ENDPOINT (default "https://storage.googleapis.com") and
+   * GCS_PROJECT_ID, and binds a shared GcsTokenProvider for the credential
+   * source resolved by the ADC precedence chain (ResolveGcsCredentials():
+   * explicit token -> service-account JWT -> gcloud ADC -> GCE/GKE metadata ->
+   * anonymous). See gcs_credentials.h.
+   *
+   * @param pool_name The bdev pool name (expected form "gcs://bucket/prefix").
+   * @return A populated GcsConfig (check `.valid`).
+   */
+  static GcsConfig FromEnvAndPoolName(const std::string &pool_name);
+};
+
+/** Backward-compatible alias for the unified result type. */
+using GcsResult = ObjectStoreResult;
+
+/**
+ * Minimal async Google Cloud Storage client over libcurl's multi interface,
+ * speaking the GCS JSON API. The libcurl-multi transport and poll loop live in
+ * the HttpObjectStoreClient base; this subclass adds only GCS's request
+ * construction and OAuth2 bearer auth. One instance is owned per bdev worker
+ * because a CURLM handle is not safe to share across threads.
+ *
+ * Object mapping is the s3backer model (same as kS3): each allocator block
+ * maps to one object keyed by its byte offset (see KeyForOffset). Writes use a
+ * simple media upload (POST .../o?uploadType=media&name=KEY); reads use
+ * GET .../o/KEY?alt=media; a 404 read is treated as a zero (sparse) block.
+ */
+class GcsClient : public HttpObjectStoreClient {
+ public:
+  /**
+   * @param config Resolved endpoint/bucket/token for this client.
+   */
+  explicit GcsClient(const GcsConfig &config);
+
+  /** @return true when the config is valid and the curl multi handle exists. */
+  bool IsValid() const override { return config_.valid && MultiOk(); }
+
+  /** Create the target bucket (idempotent). @param capacity Unused. */
+  bool Bootstrap(uint64_t capacity) override;
+
+  /** Submit an async media upload for the block at `offset`. */
+  void *WriteAsync(uint64_t offset, const void *buf, size_t len) override;
+
+  /** Submit an async media download for the block at `offset`. */
+  void *ReadAsync(uint64_t offset, void *buf, size_t len) override;
+
+  /** GCS objects are immutable/whole-object; never-written blocks 404. */
+  ReadFill GetReadFill() const override { return ReadFill::kSparse404; }
+
+  /**
+   * Synchronously create the target bucket (idempotent).
+   * @return true on HTTP 200 (created) or 409 (already exists).
+   */
+  bool EnsureBucket();
+
+  /**
+   * Map a block byte offset to a stable object name (prefix + "blk_<offset>").
+   * @param offset Block offset within the logical device.
+   * @return The full (unencoded) object name for that block.
+   */
+  std::string KeyForOffset(uint64_t offset) const;
+
+ protected:
+  const char *LogTag() const override { return "Gcs"; }
+
+  /** Invalidate the shared token so an auth-retry carries a fresh bearer. */
+  void OnAuthError() override;
+
+ private:
+  /**
+   * Build the request header list (bearer auth + given content type).
+   * @param content_type Value for the Content-Type header (may be empty).
+   * @return A curl_slist the caller owns and must free after the transfer.
+   */
+  curl_slist *BuildHeaders(const std::string &content_type) const;
+
+  /**
+   * Apply the common production transport options to an easy handle:
+   * HTTP/2 (or forced 1.1), TCP keep-alive, a connect timeout, a stall guard,
+   * and TLS peer/host verification (with an optional CA bundle override).
+   * @param easy The curl easy handle to configure.
+   */
+  void ApplyTransportOpts(CURL *easy) const;
+
+  /**
+   * Begin a resumable upload session and return its session URI (synchronous;
+   * one short round-trip, used only for writes >= resumable_threshold).
+   * @param key The object name.
+   * @param len Total bytes that will be uploaded.
+   * @return The session URI, or "" on failure (caller falls back to media).
+   */
+  std::string InitiateResumable(const std::string &key, size_t len) const;
+
+  /**
+   * (Re)build the curl easy handle + headers for a media-upload write. Used for
+   * the initial submit and for each retry re-arm, so a retried request always
+   * carries a freshly-minted bearer token. @param op The op to configure.
+   */
+  void ConfigureWriteEasy(Op *op) const;
+
+  /**
+   * (Re)build the curl easy handle + headers for an alt=media download. Used for
+   * the initial submit and for each retry re-arm. @param op The op to configure.
+   */
+  void ConfigureReadEasy(Op *op) const;
+
+  GcsConfig config_;
+};
+
+}  // namespace clio::run::bdev
+
+#endif  // CLIO_BDEV_GCS_CLIENT_H_

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/gcs_credentials.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/gcs_credentials.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_BDEV_GCS_CREDENTIALS_H_
+#define CLIO_BDEV_GCS_CREDENTIALS_H_
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace clio::run::bdev {
+
+/** Which credential source backs a GcsTokenProvider (ADC precedence order). */
+enum class GcsCredKind {
+  kAnonymous,       /**< No auth (fake-gcs-server / public objects) */
+  kExplicitToken,   /**< GCS_ACCESS_TOKEN used verbatim */
+  kServiceAccount,  /**< Service-account JSON key -> RS256 JWT-bearer exchange */
+  kAuthorizedUser,  /**< gcloud user ADC -> refresh_token grant */
+  kMetadata         /**< GCE/GKE metadata server (also GKE Workload Identity) */
+};
+
+/**
+ * Resolved credential descriptor — *what* source to authenticate with and the
+ * material needed to do so, but not a live token. Produced by
+ * ResolveGcsCredentials() once at pool-create time; the actual token is fetched
+ * (and refreshed) lazily by GcsTokenProvider. Holding only the source here keeps
+ * secrets out of serialized task fields (theme X3) and lets one provider be
+ * shared by all per-worker clients that resolve to the same Identity().
+ */
+struct GcsCredentials {
+  GcsCredKind kind = GcsCredKind::kAnonymous;
+  std::string explicit_token;  /**< kExplicitToken: the bearer token */
+  std::string client_email;    /**< kServiceAccount: SA email (JWT `iss`) */
+  std::string private_key;     /**< kServiceAccount: PEM RSA private key */
+  std::string token_uri;       /**< SA/AuthorizedUser: OAuth2 token endpoint */
+  std::string client_id;       /**< kAuthorizedUser: OAuth client id */
+  std::string client_secret;   /**< kAuthorizedUser: OAuth client secret */
+  std::string refresh_token;   /**< kAuthorizedUser: long-lived refresh token */
+  std::string metadata_base;   /**< kMetadata: metadata server base URL */
+  std::string scope =
+      "https://www.googleapis.com/auth/devstorage.read_write"; /**< OAuth scope */
+
+  /** @return A stable key identifying this source (for provider sharing). */
+  std::string Identity() const;
+};
+
+//===========================================================================
+// Pure helpers (no network / no shared state) — unit-tested offline.
+//===========================================================================
+
+/**
+ * Base64url-encode raw bytes (RFC 7515: '+'->'-', '/'->'_', no '=' padding).
+ * @param data Input bytes.
+ * @param len Number of input bytes.
+ * @return The base64url string.
+ */
+std::string Base64UrlEncode(const unsigned char *data, size_t len);
+
+/** Convenience overload taking a std::string payload. */
+std::string Base64UrlEncode(const std::string &s);
+
+/**
+ * RSA-SHA256-sign a message with a PEM private key (the RS256 JWT signature).
+ * @param pem PEM-encoded RSA private key.
+ * @param msg Message bytes to sign (the JWT signing input).
+ * @return Raw signature bytes, or "" on failure (bad key / OpenSSL error).
+ */
+std::string RsaSignSha256(const std::string &pem, const std::string &msg);
+
+/**
+ * Build a complete signed RS256 JWT bearer assertion (`hdr.claims.sig`).
+ * @param client_email Service-account email (JWT `iss`/`sub`).
+ * @param scope Space-delimited OAuth scope(s).
+ * @param token_uri Token endpoint (JWT `aud`).
+ * @param iat Issued-at epoch seconds.
+ * @param exp Expiry epoch seconds.
+ * @param private_key_pem PEM RSA private key used to sign.
+ * @return The compact JWS, or "" if signing failed.
+ */
+std::string BuildJwtAssertion(const std::string &client_email,
+                              const std::string &scope,
+                              const std::string &token_uri, int64_t iat,
+                              int64_t exp, const std::string &private_key_pem);
+
+/** Parsed OAuth2 token-endpoint response. */
+struct GcsTokenResponse {
+  std::string access_token;  /**< The bearer token */
+  long expires_in = 0;       /**< Lifetime in seconds (0 if absent) */
+  bool ok = false;           /**< True when a non-empty access_token was found */
+};
+
+/**
+ * Parse a token-endpoint JSON response (`access_token` + `expires_in`).
+ * @param json Response body.
+ * @return The parsed response (check `.ok`).
+ */
+GcsTokenResponse ParseTokenResponse(const std::string &json);
+
+/** Parsed service-account JSON key fields used by the JWT-bearer flow. */
+struct GcsServiceAccountKey {
+  std::string type;          /**< Should be "service_account" */
+  std::string client_email;  /**< SA email */
+  std::string private_key;   /**< PEM RSA private key (un-escaped) */
+  std::string token_uri;     /**< Token endpoint (defaulted if absent) */
+  bool ok = false;           /**< True when email + private_key were present */
+};
+
+/**
+ * Parse a service-account JSON key file's contents.
+ * @param json The key file contents.
+ * @return The parsed key (check `.ok`).
+ */
+GcsServiceAccountKey ParseServiceAccountKey(const std::string &json);
+
+/** Parsed gcloud "authorized_user" application-default-credentials JSON. */
+struct GcsAuthorizedUserKey {
+  std::string client_id;     /**< OAuth client id */
+  std::string client_secret; /**< OAuth client secret */
+  std::string refresh_token; /**< Long-lived refresh token */
+  std::string token_uri;     /**< Token endpoint (defaulted if absent) */
+  bool ok = false;           /**< True when all three OAuth fields were present */
+};
+
+/**
+ * Parse a gcloud ADC "authorized_user" JSON document.
+ * @param json The ADC file contents.
+ * @return The parsed credential (check `.ok`).
+ */
+GcsAuthorizedUserKey ParseAuthorizedUserKey(const std::string &json);
+
+/**
+ * Resolve the credential source via the Application Default Credentials
+ * precedence chain, WITHOUT fetching a token:
+ *   1. GCS_ACCESS_TOKEN (verbatim)            -> kExplicitToken
+ *   2. GOOGLE_APPLICATION_CREDENTIALS file     -> kServiceAccount / kAuthorizedUser
+ *   3. gcloud ADC well-known file              -> kAuthorizedUser / kServiceAccount
+ *   4. GCE/GKE metadata server (if reachable)  -> kMetadata
+ *   else                                       -> kAnonymous
+ * Reads env + files only; the metadata arm does a short reachability probe and
+ * is also selectable directly via GCE_METADATA_HOST / GCS_METADATA_BASE so it
+ * never hangs off-GCP.
+ * @return The resolved credential descriptor.
+ */
+GcsCredentials ResolveGcsCredentials();
+
+//===========================================================================
+// Token provider — shared, TTL-aware, refreshable.
+//===========================================================================
+
+/**
+ * Caches and refreshes one OAuth2 bearer token for a single credential source.
+ *
+ * Production resolution of theme X8: a bearer token has a ~1 h TTL and must be
+ * acquired once and refreshed before expiry, so a *shared* provider (one per
+ * credential Identity) feeds every per-worker GcsClient. The curl transport
+ * stays per-worker (theme X4); only this token state is shared and mutex-guarded.
+ * GetToken() returns a still-valid token (refreshing under the lock if it is
+ * within the skew margin of expiry), and Invalidate() forces a refresh after a
+ * 401/403 so an expired token self-heals on the next request.
+ */
+class GcsTokenProvider {
+ public:
+  /** @param creds The resolved credential source this provider serves. */
+  explicit GcsTokenProvider(GcsCredentials creds);
+
+  /**
+   * @return A valid bearer token ("" for anonymous), refreshing if near expiry.
+   */
+  std::string GetToken();
+
+  /** Mark the cached token stale so the next GetToken() refreshes (on 401). */
+  void Invalidate();
+
+  /** @return The credential source descriptor. */
+  const GcsCredentials &credentials() const { return creds_; }
+
+ private:
+  /** Fetch a fresh token for creds_.kind. Caller must hold mu_. @return ok. */
+  bool Refresh();
+
+  GcsCredentials creds_;
+  std::mutex mu_;
+  std::string token_;
+  std::chrono::steady_clock::time_point expiry_{};
+  bool have_token_ = false;
+};
+
+/**
+ * Return the process-wide shared provider for a credential source, creating it
+ * on first use. Providers are keyed by GcsCredentials::Identity() so all workers
+ * (and all pools) that resolve to the same credentials share one token cache.
+ * @param creds The resolved credential descriptor.
+ * @return A shared provider (never null).
+ */
+std::shared_ptr<GcsTokenProvider> GetSharedGcsTokenProvider(
+    const GcsCredentials &creds);
+
+}  // namespace clio::run::bdev
+
+#endif  // CLIO_BDEV_GCS_CREDENTIALS_H_

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/gcs_retry.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/gcs_retry.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_BDEV_GCS_RETRY_H_
+#define CLIO_BDEV_GCS_RETRY_H_
+
+#include <cstdint>
+#include <string>
+
+namespace clio::run::bdev {
+
+/**
+ * Transient-failure retry policy for HTTP object-store operations.
+ *
+ * Cloud object stores return transient failures — HTTP 429 (rate limited) and
+ * 5xx (server/gateway), plus network-level curl errors — that a well-behaved
+ * client retries with exponential backoff + jitter rather than surfacing as a
+ * hard I/O error. This policy is a small, pure value object so its decisions are
+ * unit-testable with no network: ShouldRetry() classifies an outcome and
+ * BackoffCeilingMs()/NextDelayMs() compute the wait.
+ *
+ * The transport base (HttpObjectStoreClient) owns one of these and consults it
+ * inside its poll loop, so retry is invisible to the bdev coroutine — it only
+ * changes how long IsComplete() keeps reporting "not done yet". The default
+ * (max_attempts == 1) is a no-op: every operation is attempted exactly once,
+ * which preserves the behavior of providers that do not opt in.
+ *
+ * 401/403 authentication failures are handled separately (see retry_on_auth_err
+ * and HttpObjectStoreClient::OnAuthError); they are NOT classified by
+ * ShouldRetry, and HTTP 404 (the sparse-read sentinel) is never retried.
+ */
+struct RetryPolicy {
+  int max_attempts = 1;        /**< Total attempts incl. the first (1 = no retry) */
+  double base_ms = 100.0;      /**< Backoff base; ceiling = base * 2^(attempt-1) */
+  double max_ms = 30000.0;     /**< Upper cap on the backoff ceiling (ms) */
+  bool retry_on_auth_err = false; /**< Retry once on 401/403 after re-auth */
+
+  /**
+   * Build a policy from the GCS_MAX_RETRIES / GCS_RETRY_BASE_MS /
+   * GCS_RETRY_MAX_MS environment variables, falling back to production
+   * defaults (5 attempts, 100 ms base, 30 s cap, auth-retry on).
+   * @return A populated RetryPolicy.
+   */
+  static RetryPolicy FromEnv();
+
+  /**
+   * Decide whether a completed-but-failed operation should be retried.
+   * Considers only transient signals: retryable curl transport errors and
+   * HTTP 429/500/502/503/504. Returns false once attempts are exhausted, and
+   * never retries success, 404, or non-transient 4xx (incl. 401/403, which the
+   * caller routes through the auth-error path instead).
+   * @param http_status HTTP status code (0 if the transport failed first).
+   * @param curl_code The libcurl CURLcode for the transfer (0 == CURLE_OK).
+   * @param attempt Zero-based index of the attempt that just finished.
+   * @return true if another attempt is warranted.
+   */
+  bool ShouldRetry(long http_status, int curl_code, int attempt) const;
+
+  /**
+   * Deterministic (un-jittered) backoff ceiling for a given attempt.
+   * @param attempt One-based index of the upcoming attempt (>=1).
+   * @return min(max_ms, base_ms * 2^(attempt-1)); >= 0.
+   */
+  double BackoffCeilingMs(int attempt) const;
+
+  /**
+   * Jittered backoff delay in [0, BackoffCeilingMs(attempt)] (full jitter).
+   * Uses a process-local RNG; for the upcoming attempt index (>=1).
+   * @param attempt One-based index of the upcoming attempt.
+   * @return A randomized delay in milliseconds within the ceiling.
+   */
+  double NextDelayMs(int attempt) const;
+};
+
+/**
+ * @return true if `curl_code` (a CURLcode value) is a transient transport
+ * error worth retrying (connect/timeout/recv/send/resolve/partial). Exposed
+ * for unit testing without pulling in <curl/curl.h> at the call site.
+ * @param curl_code The integer CURLcode.
+ */
+bool IsTransientCurlError(int curl_code);
+
+}  // namespace clio::run::bdev
+
+#endif  // CLIO_BDEV_GCS_RETRY_H_

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/http_object_store_client.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/http_object_store_client.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_BDEV_HTTP_OBJECT_STORE_CLIENT_H_
+#define CLIO_BDEV_HTTP_OBJECT_STORE_CLIENT_H_
+
+#include <curl/curl.h>
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "gcs_retry.h"  // RetryPolicy (provider-agnostic, despite the file name)
+#include "object_store_client.h"
+
+namespace clio::run::bdev {
+
+/**
+ * Shared libcurl-multi transport for every HTTP object-store client.
+ *
+ * The four cloud prototypes (S3, GCS, Azure, OSS) differ only in how they build
+ * and sign a request; the transport machinery — a per-worker curl multi handle,
+ * the in-flight op bookkeeping, the streaming read/write callbacks, and the
+ * drive/drain/cleanup poll loop in IsComplete() — was byte-for-byte identical
+ * across all four (theme X2 in the prototype notes). This base owns that
+ * machinery exactly once. A concrete client only has to: construct an Op,
+ * configure the request on op->easy (URL + verb + signed headers), wire the
+ * shared callbacks, and call Submit(). The provider-specific signing/addressing
+ * stays in the subclass so the signed bytes are unchanged.
+ *
+ * The base also owns a transient-failure retry loop (RetryPolicy + the Op
+ * `rebuild` closure + the OnAuthError() hook). Retry is opt-in: the default
+ * policy is a single attempt and the default OnAuthError() is a no-op, so a
+ * subclass that sets neither (S3/Azure/OSS) behaves exactly as before. A
+ * subclass that opts in (GCS) inherits exponential-backoff retries and a
+ * 401-driven token refresh with no change to the bdev coroutine, which only
+ * sees IsComplete() keep returning false until the operation truly settles.
+ */
+class HttpObjectStoreClient : public ObjectStoreClient {
+ public:
+  HttpObjectStoreClient();
+  ~HttpObjectStoreClient() override;
+  HttpObjectStoreClient(const HttpObjectStoreClient &) = delete;
+  HttpObjectStoreClient &operator=(const HttpObjectStoreClient &) = delete;
+
+  /**
+   * Drive in-flight transfers and report whether `token`'s op has finished.
+   * Provider-agnostic: HTTP status, latency, byte count, and 404 handling are
+   * identical across providers; the only per-provider inputs are LogTag(),
+   * OnAuthError(), and the op's `rebuild` closure used for retries.
+   */
+  bool IsComplete(void *token, ObjectStoreResult &out) override;
+
+ protected:
+  /** Per-request state for one in-flight async operation. */
+  struct Op {
+    CURL *easy = nullptr;            /**< Owning curl easy handle */
+    curl_slist *headers = nullptr;   /**< Signed request headers (owned) */
+    bool is_get = false;            /**< true for GET, false for PUT */
+    bool finished = false;          /**< Set when the transfer completes */
+    CURLcode curl_code = CURLE_OK;  /**< Transport-level result */
+    std::string key;                /**< Object key (for logging) */
+    std::string op_label;           /**< "PUT"/"GET"/"PUT-PAGE" for logging */
+    // PUT source
+    const char *src = nullptr;
+    size_t len = 0;
+    size_t sent = 0;
+    // GET destination
+    char *dst = nullptr;
+    size_t cap = 0;
+    size_t written = 0;
+    std::chrono::high_resolution_clock::time_point start;
+    // Retry bookkeeping (inert unless the subclass installs `rebuild`).
+    int attempt = 0;                /**< 0-based count of attempts already made */
+    bool pending_retry = false;     /**< Parked in a backoff window */
+    bool auth_retried = false;      /**< A 401/403 auth-retry was already spent */
+    std::chrono::high_resolution_clock::time_point next_earliest; /**< Re-arm at */
+    /** Reconfigure easy + headers for a fresh attempt (subclass-supplied). */
+    std::function<void(Op *)> rebuild;
+  };
+
+  /** libcurl read callback: stream the PUT body out of op->src. */
+  static size_t ReadCb(char *ptr, size_t size, size_t nmemb, void *userdata);
+  /** libcurl write callback: capture the GET body into op->dst (bounded). */
+  static size_t WriteCb(char *ptr, size_t size, size_t nmemb, void *userdata);
+
+  /**
+   * Register a fully-configured op on the multi handle and start it.
+   * @param op An op whose easy handle has its URL/verb/headers/callbacks set.
+   * @return The op token (== op), to be polled with IsComplete().
+   */
+  void *Submit(Op *op);
+
+  /** @return true when the curl multi handle was created successfully. */
+  bool MultiOk() const { return multi_ != nullptr; }
+
+  /** @return A short provider tag for log lines ("S3"/"Gcs"/"Azure"/"OSS"). */
+  virtual const char *LogTag() const = 0;
+
+  /**
+   * Invoked once before an auth-retry when a request returns 401/403. The base
+   * default is a no-op; a subclass (GCS) overrides it to invalidate/refresh its
+   * cached credential so the retried request carries a fresh token.
+   */
+  virtual void OnAuthError() {}
+
+  RetryPolicy retry_policy_;  /**< Default: 1 attempt (retries disabled) */
+
+ private:
+  /** Tear down a finished transfer but keep the op parked for another attempt. */
+  void ScheduleRetry(Op *op, bool immediate, long status);
+  /** Rebuild a parked op's easy/headers and re-submit. @return false on failure. */
+  bool RearmOp(Op *op);
+  /** Populate `out`, log, free the op's resources, and delete it. */
+  void FinalizeOp(Op *op, ObjectStoreResult &out, long status);
+
+  CURLM *multi_ = nullptr;
+  std::unordered_map<CURL *, Op *> inflight_;  /**< easy handle -> op */
+  std::unordered_set<Op *> parked_;            /**< ops in a backoff window */
+};
+
+}  // namespace clio::run::bdev
+
+#endif  // CLIO_BDEV_HTTP_OBJECT_STORE_CLIENT_H_

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/object_store_client.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/object_store_client.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_BDEV_OBJECT_STORE_CLIENT_H_
+#define CLIO_BDEV_OBJECT_STORE_CLIENT_H_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace clio::run::bdev {
+
+/** Outcome of a completed async object-store operation (provider-agnostic). */
+struct ObjectStoreResult {
+  long http_status = 0;    /**< HTTP status code (0 if the transport failed) */
+  size_t bytes = 0;        /**< Bytes transferred (PUT body or GET payload) */
+  bool not_found = false;  /**< True when a GET returned HTTP 404 */
+  bool ok = false;         /**< True on a 2xx response with no transport error */
+};
+
+/**
+ * Provider-agnostic async object-store client.
+ *
+ * This is the seam that unifies the cloud bdev backends (S3, GCS, Azure Blob,
+ * Alibaba OSS) behind one interface. It is deliberately **offset-oriented**:
+ * the bdev allocator hands out byte offsets into a flat logical device, and
+ * each concrete client maps an offset onto its own object model internally —
+ * either one object per block keyed by offset (Mapping A; S3/GCS/OSS, Azure
+ * Block Blob) or an in-place write into a single device blob at that offset
+ * (Mapping D; Azure Page Blob). Pushing that mapping behind the vtable lets the
+ * bdev runtime drive every cloud backend with a single Write/Read coroutine
+ * pair, with no per-provider branching.
+ *
+ * The submit/poll surface mirrors ctp::AsyncIO so the bdev coroutines can
+ * yield-while-polling exactly as the file backend does: WriteAsync/ReadAsync
+ * return an opaque token, and IsComplete() drives the transport and reports
+ * completion. Concrete clients are produced by MakeObjectStoreClient() and are
+ * owned one-per-worker (a curl multi handle is not safe to share across
+ * threads).
+ */
+class ObjectStoreClient {
+ public:
+  /**
+   * How the bdev read coroutine should treat a successful but short read.
+   *  - kSparse404 : never-written blocks 404 (handled via not_found); a short
+   *                 successful read advances by the bytes actually returned.
+   *                 Used by whole-object backends (S3/GCS/OSS, Azure Block).
+   *  - kZeroFilled: the backing object always exists (e.g. an Azure page blob),
+   *                 so unwritten ranges read back as zeros; a short read has its
+   *                 tail client-zero-filled and advances by the full block size.
+   */
+  enum class ReadFill { kSparse404, kZeroFilled };
+
+  virtual ~ObjectStoreClient() = default;
+
+  /** @return true when the client is fully configured and ready for I/O. */
+  virtual bool IsValid() const = 0;
+
+  /**
+   * Synchronously prepare the backing store (idempotent). Covers bucket /
+   * container creation and, where applicable, pre-creating a device blob of
+   * `capacity` bytes (Azure Page Blob). Providers that need no capacity ignore
+   * the argument.
+   * @param capacity Logical device capacity in bytes.
+   * @return true on success.
+   */
+  virtual bool Bootstrap(uint64_t capacity) = 0;
+
+  /**
+   * Submit an async write of `len` bytes from `buf` to byte `offset`.
+   * The caller must keep `buf` alive until IsComplete() returns true.
+   * @return Opaque op token to poll with IsComplete(), or nullptr on failure.
+   */
+  virtual void *WriteAsync(uint64_t offset, const void *buf, size_t len) = 0;
+
+  /**
+   * Submit an async read of `len` bytes at byte `offset` into `buf`.
+   * @return Opaque op token to poll with IsComplete(), or nullptr on failure.
+   */
+  virtual void *ReadAsync(uint64_t offset, void *buf, size_t len) = 0;
+
+  /**
+   * Drive in-flight transfers and report whether `token`'s op has finished.
+   * On a true return, `out` is populated and the op is freed (token invalid).
+   * @param token An op token from WriteAsync/ReadAsync.
+   * @param out Filled with the result when the op completes.
+   * @return true if the op completed this call; false if still in flight.
+   */
+  virtual bool IsComplete(void *token, ObjectStoreResult &out) = 0;
+
+  /** @return The short-read discipline the bdev read coroutine must apply. */
+  virtual ReadFill GetReadFill() const = 0;
+};
+
+}  // namespace clio::run::bdev
+
+#endif  // CLIO_BDEV_OBJECT_STORE_CLIENT_H_

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/object_store_factory.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/object_store_factory.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CLIO_BDEV_OBJECT_STORE_FACTORY_H_
+#define CLIO_BDEV_OBJECT_STORE_FACTORY_H_
+
+#include <memory>
+#include <string>
+
+#include "bdev_tasks.h"
+#include "object_store_client.h"
+
+namespace clio::run::bdev {
+
+/**
+ * Construct the cloud object-store client for a given bdev type + pool name.
+ *
+ * This is the factory seam that unifies the cloud backends: the runtime asks
+ * for an ObjectStoreClient by BdevType (kS3/kGcs/kAzure/kAzurePage/kOss) and
+ * gets back a concrete provider client with its config resolved from the pool
+ * name and environment. Provider construction is the ONLY place that needs the
+ * per-provider compile guards (CLIO_BDEV_*_ENABLED); a disabled provider's
+ * case is preprocessed away and its header is never included, so the runtime
+ * stays fully provider-agnostic.
+ *
+ * @param type The cloud bdev type to construct a client for.
+ * @param pool_name The bdev pool name (e.g. "s3://bucket/prefix"); parsed by
+ *                  the provider's FromEnvAndPoolName.
+ * @return A new client, or nullptr if `type` is not a cloud type or its
+ *         provider was not compiled in.
+ */
+std::unique_ptr<ObjectStoreClient> MakeObjectStoreClient(
+    BdevType type, const std::string &pool_name);
+
+}  // namespace clio::run::bdev
+
+#endif  // CLIO_BDEV_OBJECT_STORE_FACTORY_H_

--- a/context-runtime/modules/bdev/src/bdev_runtime.cc
+++ b/context-runtime/modules/bdev/src/bdev_runtime.cc
@@ -528,6 +528,49 @@ chi::TaskResume Runtime::Create(ctp::ipc::FullPtr<CreateTask> task,
   // are kFile / kRam / kNoop. PutBlob/GetBlob with HBM-resident
   // ShmPtr data buffers route through kRam (or kFile) and the bdev
   // staging path uses ctp::DeviceAwareMemcpy / IsDevicePointer.
+  } else if (bdev_type_ == BdevType::kS3 || bdev_type_ == BdevType::kGcs ||
+             bdev_type_ == BdevType::kAzure ||
+             bdev_type_ == BdevType::kAzurePage ||
+             bdev_type_ == BdevType::kOss) {
+#if defined(CLIO_BDEV_ANY_CLOUD_ENABLED)
+    // Cloud object-store backend (S3/GCS/Azure Block+Page/OSS). capacity is
+    // required (the object store has no intrinsic device size to stat, and the
+    // heap allocator needs a bound). The factory resolves the provider client
+    // from the pool name + environment; Bootstrap creates the bucket/container
+    // (and, for an Azure page blob, the device blob) up front with a temporary
+    // synchronous client so the first I/O doesn't race.
+    if (params.total_size_ == 0) {
+      HLOG(kError, "Cloud bdev '{}' requires a non-zero capacity", pool_name);
+      task->return_code_ = 4;
+      CLIO_CO_RETURN;
+    }
+    {
+      auto setup_client = MakeObjectStoreClient(bdev_type_, pool_name);
+      if (!setup_client || !setup_client->IsValid()) {
+        task->return_code_ = 5;
+        CLIO_CO_RETURN;
+      }
+      if (!setup_client->Bootstrap(params.total_size_)) {
+        HLOG(kError, "Failed to initialize cloud store for '{}'", pool_name);
+        task->return_code_ = 6;
+        CLIO_CO_RETURN;
+      }
+    }
+    // Per-worker clients are created lazily on first I/O (one CURLM each); the
+    // captured pool name lets the factory reconstruct them.
+    cloud_pool_name_ = pool_name;
+    chi::WorkOrchestrator *wo = CLIO_WORK_ORCHESTRATOR;
+    size_t num_workers = wo ? wo->GetWorkerCount() : 16;
+    worker_cloud_clients_.resize(num_workers);
+    file_size_ = params.total_size_;
+    HLOG(kInfo, "Cloud bdev ready: pool='{}' capacity={}", pool_name,
+         file_size_);
+#else
+    HLOG(kError, "Cloud bdev '{}' requested but built without cloud support",
+         pool_name);
+    task->return_code_ = 7;
+    CLIO_CO_RETURN;
+#endif
   } else if (bdev_type_ == BdevType::kNoop) {
     // Noop backend: no storage buffer, just track allocatable size
     if (params.total_size_ == 0) {
@@ -737,6 +780,18 @@ chi::TaskResume Runtime::Write(ctp::ipc::FullPtr<WriteTask> task,
       task->return_code_ = 0;
       task->bytes_written_ = task->length_;
       break;
+    case BdevType::kS3:
+    case BdevType::kGcs:
+    case BdevType::kAzure:
+    case BdevType::kAzurePage:
+    case BdevType::kOss:
+#if defined(CLIO_BDEV_ANY_CLOUD_ENABLED)
+      CLIO_CO_AWAIT(WriteToCloud(task, rctx));
+#else
+      task->return_code_ = 1;
+      task->bytes_written_ = 0;
+#endif
+      break;
     default:
       task->return_code_ = 1;
       task->bytes_written_ = 0;
@@ -766,6 +821,18 @@ chi::TaskResume Runtime::Read(ctp::ipc::FullPtr<ReadTask> task,
     case BdevType::kNoop:
       task->return_code_ = 0;
       task->bytes_read_ = task->length_;
+      break;
+    case BdevType::kS3:
+    case BdevType::kGcs:
+    case BdevType::kAzure:
+    case BdevType::kAzurePage:
+    case BdevType::kOss:
+#if defined(CLIO_BDEV_ANY_CLOUD_ENABLED)
+      CLIO_CO_AWAIT(ReadFromCloud(task, rctx));
+#else
+      task->return_code_ = 1;
+      task->bytes_read_ = 0;
+#endif
       break;
     default:
       task->return_code_ = 1;
@@ -937,6 +1004,199 @@ chi::TaskResume Runtime::ReadFromFile(ctp::ipc::FullPtr<ReadTask> task,
   CLIO_CO_RETURN;
   CLIO_TASK_BODY_END
 }
+
+#if defined(CLIO_BDEV_ANY_CLOUD_ENABLED)
+ObjectStoreClient *Runtime::GetWorkerCloudClient(size_t worker_id) {
+  if (worker_id >= worker_cloud_clients_.size()) {
+    HLOG(kWarning, "Cloud worker ID {} exceeds pre-allocated size {}",
+         worker_id, worker_cloud_clients_.size());
+    return nullptr;
+  }
+  auto &slot = worker_cloud_clients_[worker_id];
+  if (!slot) {
+    // Lazy per-worker init: the factory rebuilds the provider client from the
+    // pool name captured at Create. Each client owns its own curl multi handle.
+    slot = MakeObjectStoreClient(bdev_type_, cloud_pool_name_);
+    if (!slot || !slot->IsValid()) {
+      HLOG(kError, "Failed to initialize cloud client for worker {}",
+           worker_id);
+      slot.reset();
+      return nullptr;
+    }
+  }
+  return slot.get();
+}
+
+chi::TaskResume Runtime::WriteToCloud(ctp::ipc::FullPtr<WriteTask> task,
+                                      chi::RunContext &ctx) {
+  chi::RunContext &rctx = ctx;
+  CLIO_TASK_BODY_BEGIN
+  size_t worker_id = GetWorkerID(rctx);
+  ObjectStoreClient *client = GetWorkerCloudClient(worker_id);
+
+  auto *ipc_mgr = CLIO_IPC;
+  ctp::ipc::FullPtr<char> data_ptr =
+      ipc_mgr->ToFullPtr(task->data_).Cast<char>();
+
+  // Stage device-USM data through a host buffer (libcurl reads host memory).
+  bool data_on_device = ctp::IsDevicePointer(data_ptr.ptr_);
+  std::vector<char> staging;
+  if (data_on_device) {
+    staging.resize(task->length_);
+    ctp::DeviceAwareMemcpy(staging.data(), data_ptr.ptr_, task->length_);
+  }
+
+  chi::u64 total_bytes_written = 0;
+  chi::u64 data_offset = 0;
+
+  for (size_t i = 0; i < task->blocks_.size(); ++i) {
+    const Block &block = task->blocks_[i];
+    chi::u64 remaining = task->length_ - total_bytes_written;
+    if (remaining == 0) break;
+    chi::u64 block_write_size = std::min(remaining, block.size_);
+
+    void *block_data = data_on_device
+                           ? static_cast<void *>(staging.data() + data_offset)
+                           : static_cast<void *>(data_ptr.ptr_ + data_offset);
+
+    if (client == nullptr) {
+      HLOG(kError, "WriteToCloud called with invalid cloud client");
+      task->return_code_ = 1;
+      task->bytes_written_ = total_bytes_written;
+      CLIO_CO_RETURN;
+    }
+
+    // Offset-oriented submit: the client maps the offset onto its own object
+    // model (block->object, or in-place page) internally.
+    void *token = client->WriteAsync(block.offset_, block_data,
+                                     static_cast<size_t>(block_write_size));
+    if (token == nullptr) {
+      HLOG(kError, "Failed to submit cloud write: offset={}, size={}",
+           block.offset_, block_write_size);
+      task->return_code_ = 2;
+      task->bytes_written_ = total_bytes_written;
+      CLIO_CO_RETURN;
+    }
+
+    // Yield while the (high-latency) write is in flight.
+    ObjectStoreResult result;
+    while (!client->IsComplete(token, result)) {
+      CLIO_CO_AWAIT(chi::yield(100.0));
+    }
+    if (!result.ok) {
+      HLOG(kError, "Cloud write failed: offset={}, http={}", block.offset_,
+           result.http_status);
+      task->return_code_ = 4;
+      task->bytes_written_ = total_bytes_written;
+      CLIO_CO_RETURN;
+    }
+
+    // A 2xx whole-object PUT (or Put Page) stores exactly block_write_size user
+    // bytes, so advance by that — byte-identical across all providers.
+    total_bytes_written += block_write_size;
+    data_offset += block_write_size;
+  }
+
+  task->return_code_ = 0;
+  task->bytes_written_ = total_bytes_written;
+  total_writes_.fetch_add(1);
+  total_bytes_written_.fetch_add(task->bytes_written_);
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+chi::TaskResume Runtime::ReadFromCloud(ctp::ipc::FullPtr<ReadTask> task,
+                                       chi::RunContext &ctx) {
+  chi::RunContext &rctx = ctx;
+  CLIO_TASK_BODY_BEGIN
+  size_t worker_id = GetWorkerID(rctx);
+  ObjectStoreClient *client = GetWorkerCloudClient(worker_id);
+
+  auto *ipc_mgr = CLIO_IPC;
+  ctp::ipc::FullPtr<char> data_ptr =
+      ipc_mgr->ToFullPtr(task->data_).Cast<char>();
+
+  bool data_on_device = ctp::IsDevicePointer(data_ptr.ptr_);
+  std::vector<char> staging;
+  if (data_on_device) {
+    staging.resize(task->length_);
+  }
+
+  chi::u64 total_bytes_read = 0;
+  chi::u64 data_offset = 0;
+
+  for (size_t i = 0; i < task->blocks_.size(); ++i) {
+    const Block &block = task->blocks_[i];
+    chi::u64 remaining = task->length_ - total_bytes_read;
+    if (remaining == 0) break;
+    chi::u64 block_read_size = std::min(remaining, block.size_);
+
+    void *block_data = data_on_device
+                           ? static_cast<void *>(staging.data() + data_offset)
+                           : static_cast<void *>(data_ptr.ptr_ + data_offset);
+
+    if (client == nullptr) {
+      HLOG(kError, "ReadFromCloud called with invalid cloud client");
+      task->return_code_ = 1;
+      task->bytes_read_ = total_bytes_read;
+      CLIO_CO_RETURN;
+    }
+
+    void *token = client->ReadAsync(block.offset_, block_data,
+                                    static_cast<size_t>(block_read_size));
+    if (token == nullptr) {
+      HLOG(kError, "Failed to submit cloud read: offset={}, size={}",
+           block.offset_, block_read_size);
+      task->return_code_ = 2;
+      task->bytes_read_ = total_bytes_read;
+      CLIO_CO_RETURN;
+    }
+
+    ObjectStoreResult result;
+    while (!client->IsComplete(token, result)) {
+      CLIO_CO_AWAIT(chi::yield(100.0));
+    }
+
+    chi::u64 advance = 0;
+    if (result.not_found) {
+      // Never-written block reads as zeros (sparse semantics, s3backer model).
+      std::memset(block_data, 0, static_cast<size_t>(block_read_size));
+      advance = block_read_size;
+    } else if (!result.ok) {
+      HLOG(kError, "Cloud read failed: offset={}, http={}", block.offset_,
+           result.http_status);
+      task->return_code_ = 4;
+      task->bytes_read_ = total_bytes_read;
+      CLIO_CO_RETURN;
+    } else if (client->GetReadFill() ==
+               ObjectStoreClient::ReadFill::kZeroFilled) {
+      // The backing object always exists (e.g. an Azure page blob): zero-fill
+      // any short-read tail and advance by the full block.
+      if (result.bytes < block_read_size) {
+        std::memset(static_cast<char *>(block_data) + result.bytes, 0,
+                    static_cast<size_t>(block_read_size - result.bytes));
+      }
+      advance = block_read_size;
+    } else {
+      // Whole-object backends: advance by the bytes actually returned.
+      advance = std::min(static_cast<chi::u64>(result.bytes), block_read_size);
+    }
+    total_bytes_read += advance;
+    data_offset += advance;
+  }
+
+  if (data_on_device && total_bytes_read > 0) {
+    ctp::DeviceAwareMemcpy(data_ptr.ptr_, staging.data(), total_bytes_read);
+  }
+
+  task->return_code_ = 0;
+  task->bytes_read_ = total_bytes_read;
+  total_reads_.fetch_add(1);
+  total_bytes_read_.fetch_add(total_bytes_read);
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+#endif  // CLIO_BDEV_ANY_CLOUD_ENABLED
 
 chi::TaskResume Runtime::Update(ctp::ipc::FullPtr<UpdateTask> task,
                                 chi::RunContext &ctx) {

--- a/context-runtime/modules/bdev/src/cloud_crypto.cc
+++ b/context-runtime/modules/bdev/src/cloud_crypto.cc
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <clio_runtime/bdev/cloud_crypto.h>
+
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+
+namespace clio::run::bdev::cloud {
+
+const char *kEmptyPayloadSha256 =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+/** Standard base64 alphabet. */
+static const char *kB64Chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+std::string HexEncode(const unsigned char *data, size_t len) {
+  static const char *hex = "0123456789abcdef";
+  std::string out;
+  out.resize(len * 2);
+  for (size_t i = 0; i < len; ++i) {
+    out[2 * i] = hex[(data[i] >> 4) & 0xF];
+    out[2 * i + 1] = hex[data[i] & 0xF];
+  }
+  return out;
+}
+
+std::string Sha256Hex(const void *data, size_t len) {
+  unsigned char digest[SHA256_DIGEST_LENGTH];
+  SHA256(reinterpret_cast<const unsigned char *>(data), len, digest);
+  return HexEncode(digest, SHA256_DIGEST_LENGTH);
+}
+
+std::vector<unsigned char> HmacSha256(const unsigned char *key, size_t key_len,
+                                      const void *data, size_t data_len) {
+  unsigned char out[EVP_MAX_MD_SIZE];
+  unsigned int out_len = 0;
+  HMAC(EVP_sha256(), key, static_cast<int>(key_len),
+       reinterpret_cast<const unsigned char *>(data), data_len, out, &out_len);
+  return std::vector<unsigned char>(out, out + out_len);
+}
+
+std::vector<unsigned char> HmacSha1(const unsigned char *key, size_t key_len,
+                                    const void *data, size_t data_len) {
+  unsigned char out[EVP_MAX_MD_SIZE];
+  unsigned int out_len = 0;
+  HMAC(EVP_sha1(), key, static_cast<int>(key_len),
+       reinterpret_cast<const unsigned char *>(data), data_len, out, &out_len);
+  return std::vector<unsigned char>(out, out + out_len);
+}
+
+std::string Base64Encode(const unsigned char *data, size_t len) {
+  std::string out;
+  out.reserve(((len + 2) / 3) * 4);
+  size_t i = 0;
+  for (; i + 3 <= len; i += 3) {
+    uint32_t n = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+    out.push_back(kB64Chars[(n >> 18) & 0x3F]);
+    out.push_back(kB64Chars[(n >> 12) & 0x3F]);
+    out.push_back(kB64Chars[(n >> 6) & 0x3F]);
+    out.push_back(kB64Chars[n & 0x3F]);
+  }
+  if (len - i == 1) {
+    uint32_t n = data[i] << 16;
+    out.push_back(kB64Chars[(n >> 18) & 0x3F]);
+    out.push_back(kB64Chars[(n >> 12) & 0x3F]);
+    out.append("==");
+  } else if (len - i == 2) {
+    uint32_t n = (data[i] << 16) | (data[i + 1] << 8);
+    out.push_back(kB64Chars[(n >> 18) & 0x3F]);
+    out.push_back(kB64Chars[(n >> 12) & 0x3F]);
+    out.push_back(kB64Chars[(n >> 6) & 0x3F]);
+    out.push_back('=');
+  }
+  return out;
+}
+
+std::vector<unsigned char> Base64Decode(const std::string &in) {
+  int rev[256];
+  for (int i = 0; i < 256; ++i) rev[i] = -1;
+  for (int i = 0; i < 64; ++i) rev[static_cast<unsigned char>(kB64Chars[i])] = i;
+  std::vector<unsigned char> out;
+  out.reserve((in.size() / 4) * 3);
+  uint32_t buf = 0;
+  int bits = 0;
+  for (unsigned char c : in) {
+    if (c == '=' || c == '\n' || c == '\r' || c == ' ') continue;
+    int v = rev[c];
+    if (v < 0) continue;
+    buf = (buf << 6) | static_cast<uint32_t>(v);
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out.push_back(static_cast<unsigned char>((buf >> bits) & 0xFF));
+    }
+  }
+  return out;
+}
+
+std::string AwsUriEncode(const std::string &value, bool encode_slash) {
+  static const char *hex = "0123456789ABCDEF";
+  std::string out;
+  out.reserve(value.size() * 3);
+  for (unsigned char c : value) {
+    bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                      (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+                      c == '.' || c == '~';
+    if (unreserved || (c == '/' && !encode_slash)) {
+      out.push_back(static_cast<char>(c));
+    } else {
+      out.push_back('%');
+      out.push_back(hex[(c >> 4) & 0xF]);
+      out.push_back(hex[c & 0xF]);
+    }
+  }
+  return out;
+}
+
+std::string Rfc1123GmtNow() {
+  std::time_t now = std::time(nullptr);
+  std::tm tmv{};
+  gmtime_r(&now, &tmv);
+  char buf[40];
+  // Locale-independent weekday/month abbreviations are required; the process
+  // runs in the C locale so strftime emits English abbreviations.
+  std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &tmv);
+  return std::string(buf);
+}
+
+std::string ToLower(const std::string &s) {
+  std::string out = s;
+  std::transform(out.begin(), out.end(), out.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return out;
+}
+
+std::string EnvOr(const char *name, const std::string &def) {
+  const char *v = std::getenv(name);
+  return (v && *v) ? std::string(v) : def;
+}
+
+}  // namespace clio::run::bdev::cloud

--- a/context-runtime/modules/bdev/src/gcs_client.cc
+++ b/context-runtime/modules/bdev/src/gcs_client.cc
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <clio_runtime/bdev/gcs_client.h>
+
+#include <cctype>
+#include <chrono>
+#include <cstdlib>
+#include <string>
+
+#include "clio_ctp/util/logging.h"
+#include "clio_runtime/bdev/cloud_crypto.h"
+#include "clio_runtime/bdev/gcs_credentials.h"
+#include "clio_runtime/bdev/gcs_retry.h"
+
+namespace clio::run::bdev {
+
+//===========================================================================
+// Encoding helpers (GCS-specific; shared crypto lives in cloud_crypto.h, and
+// the OAuth2/JWT auth path lives in gcs_credentials.h)
+//===========================================================================
+
+/**
+ * Percent-encode every character that is not RFC 3986 "unreserved".
+ * Used for object names that become a single URL path segment / query value,
+ * so embedded '/' is encoded as %2F (GCS treats the object name as opaque).
+ * @param value String to encode.
+ * @return The fully percent-encoded string.
+ */
+static std::string UrlEncode(const std::string &value) {
+  static const char *hex = "0123456789ABCDEF";
+  std::string out;
+  out.reserve(value.size() * 3);
+  for (unsigned char c : value) {
+    bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                      (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+                      c == '.' || c == '~';
+    if (unreserved) {
+      out.push_back(static_cast<char>(c));
+    } else {
+      out.push_back('%');
+      out.push_back(hex[(c >> 4) & 0xF]);
+      out.push_back(hex[c & 0xF]);
+    }
+  }
+  return out;
+}
+
+/** libcurl write callback that discards the body (upload JSON response). */
+static size_t GcsDiscardCb(char *, size_t size, size_t nmemb, void *) {
+  return size * nmemb;
+}
+
+/** libcurl header callback that captures the `Location:` value (session URI). */
+static size_t CaptureLocationCb(char *ptr, size_t size, size_t nmemb,
+                                void *ud) {
+  size_t n = size * nmemb;
+  auto *out = static_cast<std::string *>(ud);
+  const std::string key = "location:";
+  if (n >= key.size()) {
+    std::string head(ptr, key.size());
+    for (char &c : head) c = static_cast<char>(std::tolower((unsigned char)c));
+    if (head == key) {
+      std::string val(ptr + key.size(), n - key.size());
+      size_t b = val.find_first_not_of(" \t");
+      size_t e = val.find_last_not_of("\r\n \t");
+      if (b != std::string::npos && e != std::string::npos && e >= b) {
+        *out = val.substr(b, e - b + 1);
+      }
+    }
+  }
+  return n;
+}
+
+//===========================================================================
+// GcsConfig
+//===========================================================================
+
+GcsConfig GcsConfig::FromEnvAndPoolName(const std::string &pool_name) {
+  GcsConfig cfg;
+  const std::string scheme_pfx = "gcs://";
+  if (pool_name.rfind(scheme_pfx, 0) != 0) {
+    HLOG(kError, "GCS pool_name '{}' must start with 'gcs://'", pool_name);
+    return cfg;
+  }
+  std::string rest = pool_name.substr(scheme_pfx.size());
+  size_t slash = rest.find('/');
+  cfg.bucket = (slash == std::string::npos) ? rest : rest.substr(0, slash);
+  cfg.prefix = (slash == std::string::npos) ? "" : rest.substr(slash + 1);
+  while (!cfg.prefix.empty() && cfg.prefix.back() == '/') cfg.prefix.pop_back();
+  if (cfg.bucket.empty()) {
+    HLOG(kError, "GCS pool_name '{}' has an empty bucket", pool_name);
+    return cfg;
+  }
+
+  cfg.endpoint = cloud::EnvOr("GCS_ENDPOINT", "https://storage.googleapis.com");
+  cfg.project_id = cloud::EnvOr("GCS_PROJECT_ID", "clio-prototype");
+  // Resolve the credential source once and bind the process-wide shared token
+  // provider for it (token state is shared across workers; see X8).
+  cfg.token_provider = GetSharedGcsTokenProvider(ResolveGcsCredentials());
+
+  // Transport + resumable knobs (resolved once at Create).
+  cfg.resumable_threshold = static_cast<size_t>(std::strtoull(
+      cloud::EnvOr("GCS_RESUMABLE_THRESHOLD", "8388608").c_str(), nullptr, 10));
+  cfg.connect_timeout_s = std::strtol(
+      cloud::EnvOr("GCS_CONNECT_TIMEOUT_S", "10").c_str(), nullptr, 10);
+  cfg.http2 = cloud::EnvOr("GCS_FORCE_HTTP11", "").empty();
+  cfg.ca_bundle = cloud::EnvOr("GCS_CA_BUNDLE", "");
+
+  // Split endpoint into scheme + host[:port].
+  size_t pos = cfg.endpoint.find("://");
+  if (pos == std::string::npos) {
+    cfg.scheme = "https";
+    cfg.host = cfg.endpoint;
+  } else {
+    cfg.scheme = cfg.endpoint.substr(0, pos);
+    cfg.host = cfg.endpoint.substr(pos + 3);
+  }
+  while (!cfg.host.empty() && cfg.host.back() == '/') cfg.host.pop_back();
+  cfg.endpoint = cfg.scheme + "://" + cfg.host;
+  cfg.valid = true;
+  return cfg;
+}
+
+//===========================================================================
+// GcsClient lifecycle
+//===========================================================================
+
+GcsClient::GcsClient(const GcsConfig &config) : config_(config) {
+  // Opt into the transport base's transient-failure retry loop. The base
+  // default is a single attempt (no-op), so only GCS gets backoff retries.
+  retry_policy_ = RetryPolicy::FromEnv();
+}
+
+void GcsClient::OnAuthError() {
+  // A 401/403 means the bearer token expired or was revoked; drop it so the
+  // shared provider re-mints one for the retried request (theme X8).
+  if (config_.token_provider) config_.token_provider->Invalidate();
+}
+
+std::string GcsClient::KeyForOffset(uint64_t offset) const {
+  std::string key = "blk_" + std::to_string(offset);
+  return config_.prefix.empty() ? key : (config_.prefix + "/" + key);
+}
+
+curl_slist *GcsClient::BuildHeaders(const std::string &content_type) const {
+  curl_slist *headers = nullptr;
+  if (config_.token_provider) {
+    std::string token = config_.token_provider->GetToken();
+    if (!token.empty()) {
+      headers = curl_slist_append(
+          headers, ("Authorization: Bearer " + token).c_str());
+    }
+  }
+  if (!content_type.empty()) {
+    headers =
+        curl_slist_append(headers, ("Content-Type: " + content_type).c_str());
+  }
+  headers = curl_slist_append(headers, "Expect:");  // suppress 100-continue
+  return headers;
+}
+
+//===========================================================================
+// Bucket creation (synchronous)
+//===========================================================================
+
+bool GcsClient::Bootstrap(uint64_t /*capacity*/) { return EnsureBucket(); }
+
+bool GcsClient::EnsureBucket() {
+  if (!IsValid()) return false;
+  CURL *easy = curl_easy_init();
+  if (easy == nullptr) return false;
+  std::string url = config_.endpoint + "/storage/v1/b?project=" +
+                    UrlEncode(config_.project_id);
+  std::string body = "{\"name\":\"" + config_.bucket + "\"}";
+  curl_slist *headers = BuildHeaders("application/json");
+  ApplyTransportOpts(easy);
+  curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(easy, CURLOPT_HTTPHEADER, headers);
+  curl_easy_setopt(easy, CURLOPT_POSTFIELDS, body.c_str());
+  curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, GcsDiscardCb);
+
+  CURLcode rc = curl_easy_perform(easy);
+  long status = 0;
+  curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &status);
+  curl_slist_free_all(headers);
+  curl_easy_cleanup(easy);
+
+  bool ok = (rc == CURLE_OK) && (status == 200 || status == 409);
+  if (!ok) {
+    HLOG(kError, "GCS EnsureBucket '{}' failed: curl={} http={}", config_.bucket,
+         static_cast<int>(rc), status);
+  } else {
+    HLOG(kInfo, "GCS bucket '{}' ready (http={})", config_.bucket, status);
+  }
+  return ok;
+}
+
+//===========================================================================
+// Async submit (offset-oriented; poll via the shared base IsComplete)
+//===========================================================================
+
+void GcsClient::ApplyTransportOpts(CURL *easy) const {
+  // Prefer HTTP/2 over TLS (curl transparently falls back to 1.1 if the server
+  // declines); allow forcing 1.1 for misbehaving proxies.
+  curl_easy_setopt(easy, CURLOPT_HTTP_VERSION,
+                   config_.http2 ? CURL_HTTP_VERSION_2TLS
+                                 : CURL_HTTP_VERSION_1_1);
+  curl_easy_setopt(easy, CURLOPT_TCP_KEEPALIVE, 1L);
+  curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT, config_.connect_timeout_s);
+  // Stall guard: abort a transfer stuck below 1 B/s for 60 s (catches hangs
+  // without killing slow-but-progressing transfers).
+  curl_easy_setopt(easy, CURLOPT_LOW_SPEED_LIMIT, 1L);
+  curl_easy_setopt(easy, CURLOPT_LOW_SPEED_TIME, 60L);
+  // TLS peer + host verification on (curl's default; set explicitly).
+  curl_easy_setopt(easy, CURLOPT_SSL_VERIFYPEER, 1L);
+  curl_easy_setopt(easy, CURLOPT_SSL_VERIFYHOST, 2L);
+  if (!config_.ca_bundle.empty()) {
+    curl_easy_setopt(easy, CURLOPT_CAINFO, config_.ca_bundle.c_str());
+  }
+}
+
+std::string GcsClient::InitiateResumable(const std::string &key,
+                                         size_t len) const {
+  CURL *easy = curl_easy_init();
+  if (easy == nullptr) return "";
+  std::string url = config_.endpoint + "/upload/storage/v1/b/" + config_.bucket +
+                    "/o?uploadType=resumable&name=" + UrlEncode(key);
+  curl_slist *headers = BuildHeaders("application/octet-stream");
+  headers = curl_slist_append(
+      headers, ("X-Upload-Content-Length: " + std::to_string(len)).c_str());
+  headers = curl_slist_append(headers,
+                              "X-Upload-Content-Type: application/octet-stream");
+  std::string location;
+  ApplyTransportOpts(easy);
+  curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(easy, CURLOPT_HTTPHEADER, headers);
+  curl_easy_setopt(easy, CURLOPT_POST, 1L);
+  curl_easy_setopt(easy, CURLOPT_POSTFIELDS, "");
+  curl_easy_setopt(easy, CURLOPT_POSTFIELDSIZE, 0L);
+  curl_easy_setopt(easy, CURLOPT_HEADERFUNCTION, CaptureLocationCb);
+  curl_easy_setopt(easy, CURLOPT_HEADERDATA, &location);
+  curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, GcsDiscardCb);
+  CURLcode rc = curl_easy_perform(easy);
+  long status = 0;
+  curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &status);
+  curl_slist_free_all(headers);
+  curl_easy_cleanup(easy);
+  if (rc != CURLE_OK || status != 200 || location.empty()) {
+    HLOG(kError, "GCS resumable initiate '{}' failed: curl={} http={}", key,
+         static_cast<int>(rc), status);
+    return "";
+  }
+  return location;
+}
+
+void GcsClient::ConfigureWriteEasy(Op *op) const {
+  op->easy = curl_easy_init();
+  if (op->easy == nullptr) return;
+  // Large writes use a resumable session (one extra round-trip); small/block
+  // writes (the common bdev case) use a single simple media upload.
+  if (op->len >= config_.resumable_threshold) {
+    std::string uri = InitiateResumable(op->key, op->len);
+    if (!uri.empty()) {
+      op->op_label = "PUT-RESUMABLE";
+      op->headers = BuildHeaders("application/octet-stream");
+      std::string range = "Content-Range: bytes 0-" +
+                          std::to_string(op->len - 1) + "/" +
+                          std::to_string(op->len);
+      op->headers = curl_slist_append(op->headers, range.c_str());
+      ApplyTransportOpts(op->easy);
+      curl_easy_setopt(op->easy, CURLOPT_URL, uri.c_str());
+      curl_easy_setopt(op->easy, CURLOPT_HTTPHEADER, op->headers);
+      curl_easy_setopt(op->easy, CURLOPT_UPLOAD, 1L);
+      curl_easy_setopt(op->easy, CURLOPT_INFILESIZE_LARGE,
+                       static_cast<curl_off_t>(op->len));
+      curl_easy_setopt(op->easy, CURLOPT_READFUNCTION,
+                       &HttpObjectStoreClient::ReadCb);
+      curl_easy_setopt(op->easy, CURLOPT_READDATA, op);
+      curl_easy_setopt(op->easy, CURLOPT_WRITEFUNCTION, GcsDiscardCb);
+      return;
+    }
+    HLOG(kWarning, "GCS resumable initiate failed for {}; using media upload",
+         op->key);
+  }
+  // Simple media upload: POST .../o?uploadType=media&name=<encoded key>.
+  op->op_label = "PUT";
+  std::string url = config_.endpoint + "/upload/storage/v1/b/" + config_.bucket +
+                    "/o?uploadType=media&name=" + UrlEncode(op->key);
+  op->headers = BuildHeaders("application/octet-stream");
+  ApplyTransportOpts(op->easy);
+  curl_easy_setopt(op->easy, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(op->easy, CURLOPT_HTTPHEADER, op->headers);
+  curl_easy_setopt(op->easy, CURLOPT_POST, 1L);
+  curl_easy_setopt(op->easy, CURLOPT_POSTFIELDSIZE_LARGE,
+                   static_cast<curl_off_t>(op->len));
+  curl_easy_setopt(op->easy, CURLOPT_READFUNCTION,
+                   &HttpObjectStoreClient::ReadCb);
+  curl_easy_setopt(op->easy, CURLOPT_READDATA, op);
+  curl_easy_setopt(op->easy, CURLOPT_WRITEFUNCTION, GcsDiscardCb);
+}
+
+void GcsClient::ConfigureReadEasy(Op *op) const {
+  op->easy = curl_easy_init();
+  if (op->easy == nullptr) return;
+  // Media download: GET .../o/<encoded key>?alt=media.
+  std::string url = config_.endpoint + "/storage/v1/b/" + config_.bucket +
+                    "/o/" + UrlEncode(op->key) + "?alt=media";
+  op->headers = BuildHeaders("");
+  ApplyTransportOpts(op->easy);
+  curl_easy_setopt(op->easy, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(op->easy, CURLOPT_HTTPHEADER, op->headers);
+  curl_easy_setopt(op->easy, CURLOPT_HTTPGET, 1L);
+  curl_easy_setopt(op->easy, CURLOPT_WRITEFUNCTION,
+                   &HttpObjectStoreClient::WriteCb);
+  curl_easy_setopt(op->easy, CURLOPT_WRITEDATA, op);
+}
+
+void *GcsClient::WriteAsync(uint64_t offset, const void *buf, size_t len) {
+  if (!IsValid()) return nullptr;
+  auto *op = new Op();
+  op->is_get = false;
+  op->op_label = "PUT";
+  op->key = KeyForOffset(offset);
+  op->src = static_cast<const char *>(buf);
+  op->len = len;
+  op->start = std::chrono::high_resolution_clock::now();
+  // Closure re-runs on every retry so a re-issued request gets a fresh token.
+  op->rebuild = [this](Op *o) { ConfigureWriteEasy(o); };
+  op->rebuild(op);
+  if (op->easy == nullptr) {
+    delete op;
+    return nullptr;
+  }
+  return Submit(op);
+}
+
+void *GcsClient::ReadAsync(uint64_t offset, void *buf, size_t len) {
+  if (!IsValid()) return nullptr;
+  auto *op = new Op();
+  op->is_get = true;
+  op->op_label = "GET";
+  op->key = KeyForOffset(offset);
+  op->dst = static_cast<char *>(buf);
+  op->cap = len;
+  op->start = std::chrono::high_resolution_clock::now();
+  op->rebuild = [this](Op *o) { ConfigureReadEasy(o); };
+  op->rebuild(op);
+  if (op->easy == nullptr) {
+    delete op;
+    return nullptr;
+  }
+  return Submit(op);
+}
+
+}  // namespace clio::run::bdev

--- a/context-runtime/modules/bdev/src/gcs_credentials.cc
+++ b/context-runtime/modules/bdev/src/gcs_credentials.cc
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <clio_runtime/bdev/gcs_credentials.h>
+
+#include <curl/curl.h>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+
+#include <ctime>
+#include <fstream>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include "clio_ctp/util/logging.h"
+#include "clio_runtime/bdev/cloud_crypto.h"
+
+namespace clio::run::bdev {
+
+namespace {
+
+constexpr const char *kDefaultTokenUri = "https://oauth2.googleapis.com/token";
+
+/** libcurl write callback that appends the response body to a std::string. */
+size_t StringWriteCb(char *ptr, size_t size, size_t nmemb, void *ud) {
+  auto *s = static_cast<std::string *>(ud);
+  s->append(ptr, size * nmemb);
+  return size * nmemb;
+}
+
+/** Read a whole file into a string ("" if it cannot be opened). */
+std::string ReadFile(const std::string &path) {
+  std::ifstream f(path);
+  if (!f) return "";
+  std::stringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+/** Extract a string field from a parsed JSON object (type-checked, safe). */
+std::string JStr(const nlohmann::json &j, const char *key) {
+  auto it = j.find(key);
+  if (it != j.end() && it->is_string()) return it->get<std::string>();
+  return "";
+}
+
+/** Extract an integer field from a parsed JSON object (0 if absent/non-num). */
+long JLong(const nlohmann::json &j, const char *key) {
+  auto it = j.find(key);
+  if (it != j.end() && it->is_number()) return it->get<long>();
+  return 0;
+}
+
+/**
+ * POST an x-www-form-urlencoded body and capture the response body + status.
+ * @return true if the transfer completed at the transport level (any status).
+ */
+bool HttpPostForm(const std::string &url, const std::string &body,
+                  std::string &resp, long &status) {
+  CURL *easy = curl_easy_init();
+  if (easy == nullptr) return false;
+  curl_slist *hdr = curl_slist_append(
+      nullptr, "Content-Type: application/x-www-form-urlencoded");
+  curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(easy, CURLOPT_HTTPHEADER, hdr);
+  curl_easy_setopt(easy, CURLOPT_POSTFIELDS, body.c_str());
+  curl_easy_setopt(easy, CURLOPT_POSTFIELDSIZE, static_cast<long>(body.size()));
+  curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, StringWriteCb);
+  curl_easy_setopt(easy, CURLOPT_WRITEDATA, &resp);
+  curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT, 10L);
+  curl_easy_setopt(easy, CURLOPT_TIMEOUT, 30L);
+  CURLcode rc = curl_easy_perform(easy);
+  status = 0;
+  curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &status);
+  curl_slist_free_all(hdr);
+  curl_easy_cleanup(easy);
+  return rc == CURLE_OK;
+}
+
+/**
+ * GET a metadata-server URL (adds the required `Metadata-Flavor: Google`).
+ * @param timeout_ms Both connect and total timeout (keeps probes from hanging).
+ * @return true if the transfer completed at the transport level.
+ */
+bool HttpGetMetadata(const std::string &url, std::string &resp, long &status,
+                     long timeout_ms) {
+  CURL *easy = curl_easy_init();
+  if (easy == nullptr) return false;
+  curl_slist *hdr = curl_slist_append(nullptr, "Metadata-Flavor: Google");
+  curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(easy, CURLOPT_HTTPHEADER, hdr);
+  curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, StringWriteCb);
+  curl_easy_setopt(easy, CURLOPT_WRITEDATA, &resp);
+  curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS, timeout_ms);
+  curl_easy_setopt(easy, CURLOPT_TIMEOUT_MS, timeout_ms);
+  CURLcode rc = curl_easy_perform(easy);
+  status = 0;
+  curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &status);
+  curl_slist_free_all(hdr);
+  curl_easy_cleanup(easy);
+  return rc == CURLE_OK;
+}
+
+/** @return The metadata server base URL (honoring GCE_METADATA_HOST / test). */
+std::string MetadataBase() {
+  std::string host = cloud::EnvOr("GCE_METADATA_HOST", "");
+  if (!host.empty()) return "http://" + host;
+  std::string base = cloud::EnvOr("GCS_METADATA_BASE", "");
+  if (!base.empty()) return base;
+  return "http://metadata.google.internal";
+}
+
+/** @return true if the metadata server answers a short, bounded probe. */
+bool MetadataReachable(const std::string &base) {
+  std::string resp;
+  long status = 0;
+  bool ok = HttpGetMetadata(base + "/computeMetadata/v1/", resp, status, 300);
+  return ok && status == 200;
+}
+
+/** @return The gcloud ADC well-known credentials file path ("" if no HOME). */
+std::string GcloudAdcPath() {
+  std::string cfg = cloud::EnvOr("CLOUDSDK_CONFIG", "");
+  if (!cfg.empty()) return cfg + "/application_default_credentials.json";
+  std::string home = cloud::EnvOr("HOME", "");
+  if (home.empty()) return "";
+  return home + "/.config/gcloud/application_default_credentials.json";
+}
+
+/**
+ * Populate a GcsCredentials from a key-file JSON (service-account first, then
+ * authorized_user). @return true if either form parsed successfully.
+ */
+bool FillFromKeyJson(const std::string &json, GcsCredentials &c) {
+  GcsServiceAccountKey sa = ParseServiceAccountKey(json);
+  if (sa.ok) {
+    c.kind = GcsCredKind::kServiceAccount;
+    c.client_email = sa.client_email;
+    c.private_key = sa.private_key;
+    c.token_uri = sa.token_uri;
+    HLOG(kInfo, "GCS auth: service-account JWT flow for {}", sa.client_email);
+    return true;
+  }
+  GcsAuthorizedUserKey au = ParseAuthorizedUserKey(json);
+  if (au.ok) {
+    c.kind = GcsCredKind::kAuthorizedUser;
+    c.client_id = au.client_id;
+    c.client_secret = au.client_secret;
+    c.refresh_token = au.refresh_token;
+    c.token_uri = au.token_uri;
+    HLOG(kInfo, "GCS auth: authorized_user refresh-token flow");
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+//===========================================================================
+// Pure helpers
+//===========================================================================
+
+std::string Base64UrlEncode(const unsigned char *data, size_t len) {
+  static const char *tbl =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  std::string out;
+  out.reserve((len + 2) / 3 * 4);
+  for (size_t i = 0; i < len; i += 3) {
+    unsigned v = data[i] << 16;
+    int n = 1;
+    if (i + 1 < len) {
+      v |= data[i + 1] << 8;
+      n = 2;
+    }
+    if (i + 2 < len) {
+      v |= data[i + 2];
+      n = 3;
+    }
+    out.push_back(tbl[(v >> 18) & 0x3F]);
+    out.push_back(tbl[(v >> 12) & 0x3F]);
+    if (n >= 2) out.push_back(tbl[(v >> 6) & 0x3F]);
+    if (n >= 3) out.push_back(tbl[v & 0x3F]);
+  }
+  return out;
+}
+
+std::string Base64UrlEncode(const std::string &s) {
+  return Base64UrlEncode(reinterpret_cast<const unsigned char *>(s.data()),
+                         s.size());
+}
+
+std::string RsaSignSha256(const std::string &pem, const std::string &msg) {
+  std::string sig;
+  BIO *bio = BIO_new_mem_buf(pem.data(), static_cast<int>(pem.size()));
+  if (bio == nullptr) return sig;
+  EVP_PKEY *pkey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
+  BIO_free(bio);
+  if (pkey == nullptr) {
+    HLOG(kError, "GCS auth: failed to parse service-account private key");
+    return sig;
+  }
+  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+  size_t slen = 0;
+  if (ctx != nullptr &&
+      EVP_DigestSignInit(ctx, nullptr, EVP_sha256(), nullptr, pkey) == 1 &&
+      EVP_DigestSign(ctx, nullptr, &slen,
+                     reinterpret_cast<const unsigned char *>(msg.data()),
+                     msg.size()) == 1) {
+    std::vector<unsigned char> buf(slen);
+    if (EVP_DigestSign(ctx, buf.data(), &slen,
+                       reinterpret_cast<const unsigned char *>(msg.data()),
+                       msg.size()) == 1) {
+      sig.assign(reinterpret_cast<char *>(buf.data()), slen);
+    }
+  }
+  if (ctx != nullptr) EVP_MD_CTX_free(ctx);
+  EVP_PKEY_free(pkey);
+  return sig;
+}
+
+std::string BuildJwtAssertion(const std::string &client_email,
+                              const std::string &scope,
+                              const std::string &token_uri, int64_t iat,
+                              int64_t exp, const std::string &private_key_pem) {
+  std::string header = R"({"alg":"RS256","typ":"JWT"})";
+  std::ostringstream claims;
+  claims << "{\"iss\":\"" << client_email << "\",\"scope\":\"" << scope
+         << "\",\"aud\":\"" << token_uri << "\",\"iat\":" << iat
+         << ",\"exp\":" << exp << "}";
+  std::string signing_input =
+      Base64UrlEncode(header) + "." + Base64UrlEncode(claims.str());
+  std::string sig = RsaSignSha256(private_key_pem, signing_input);
+  if (sig.empty()) return "";
+  return signing_input + "." + Base64UrlEncode(sig);
+}
+
+GcsTokenResponse ParseTokenResponse(const std::string &json) {
+  GcsTokenResponse r;
+  auto j = nlohmann::json::parse(json, nullptr, /*allow_exceptions=*/false);
+  if (j.is_discarded() || !j.is_object()) return r;
+  r.access_token = JStr(j, "access_token");
+  r.expires_in = JLong(j, "expires_in");
+  r.ok = !r.access_token.empty();
+  return r;
+}
+
+GcsServiceAccountKey ParseServiceAccountKey(const std::string &json) {
+  GcsServiceAccountKey k;
+  auto j = nlohmann::json::parse(json, nullptr, /*allow_exceptions=*/false);
+  if (j.is_discarded() || !j.is_object()) return k;
+  k.type = JStr(j, "type");
+  k.client_email = JStr(j, "client_email");
+  k.private_key = JStr(j, "private_key");
+  k.token_uri = JStr(j, "token_uri");
+  if (k.token_uri.empty()) k.token_uri = kDefaultTokenUri;
+  k.ok = !k.client_email.empty() && !k.private_key.empty();
+  return k;
+}
+
+GcsAuthorizedUserKey ParseAuthorizedUserKey(const std::string &json) {
+  GcsAuthorizedUserKey k;
+  auto j = nlohmann::json::parse(json, nullptr, /*allow_exceptions=*/false);
+  if (j.is_discarded() || !j.is_object()) return k;
+  k.client_id = JStr(j, "client_id");
+  k.client_secret = JStr(j, "client_secret");
+  k.refresh_token = JStr(j, "refresh_token");
+  k.token_uri = JStr(j, "token_uri");
+  if (k.token_uri.empty()) k.token_uri = kDefaultTokenUri;
+  k.ok = !k.client_id.empty() && !k.client_secret.empty() &&
+         !k.refresh_token.empty();
+  return k;
+}
+
+//===========================================================================
+// Credential resolution (ADC chain) + identity
+//===========================================================================
+
+std::string GcsCredentials::Identity() const {
+  switch (kind) {
+    case GcsCredKind::kExplicitToken:
+      return "explicit";  // only one GCS_ACCESS_TOKEN per process
+    case GcsCredKind::kServiceAccount:
+      return "sa:" + client_email + ":" + token_uri + ":" + scope;
+    case GcsCredKind::kAuthorizedUser:
+      return "au:" + client_id + ":" + token_uri;
+    case GcsCredKind::kMetadata:
+      return "md:" + metadata_base + ":" + scope;
+    case GcsCredKind::kAnonymous:
+    default:
+      return "anon";
+  }
+}
+
+GcsCredentials ResolveGcsCredentials() {
+  GcsCredentials c;
+  // 1. Explicit bearer token.
+  std::string tok = cloud::EnvOr("GCS_ACCESS_TOKEN", "");
+  if (!tok.empty()) {
+    c.kind = GcsCredKind::kExplicitToken;
+    c.explicit_token = tok;
+    HLOG(kInfo, "GCS auth: using GCS_ACCESS_TOKEN (explicit bearer)");
+    return c;
+  }
+  // 2. GOOGLE_APPLICATION_CREDENTIALS key file.
+  std::string gac = cloud::EnvOr("GOOGLE_APPLICATION_CREDENTIALS", "");
+  if (!gac.empty()) {
+    std::string j = ReadFile(gac);
+    if (j.empty()) {
+      HLOG(kError, "GCS auth: cannot read GOOGLE_APPLICATION_CREDENTIALS '{}'",
+           gac);
+    } else if (FillFromKeyJson(j, c)) {
+      return c;
+    }
+  }
+  // 3. gcloud ADC well-known file.
+  std::string adc_path = GcloudAdcPath();
+  if (!adc_path.empty()) {
+    std::string j = ReadFile(adc_path);
+    if (!j.empty() && FillFromKeyJson(j, c)) {
+      HLOG(kInfo, "GCS auth: using gcloud ADC file '{}'", adc_path);
+      return c;
+    }
+  }
+  // 4. GCE/GKE metadata server. Selected when explicitly pointed at one (env),
+  //    else via a short reachability probe so this never hangs off-GCP.
+  //    GCS_DISABLE_METADATA skips the probe (but honors an explicit selection).
+  std::string base = MetadataBase();
+  bool forced = !cloud::EnvOr("GCE_METADATA_HOST", "").empty() ||
+                !cloud::EnvOr("GCS_METADATA_BASE", "").empty();
+  bool probe_disabled = !cloud::EnvOr("GCS_DISABLE_METADATA", "").empty();
+  if (forced || (!probe_disabled && MetadataReachable(base))) {
+    c.kind = GcsCredKind::kMetadata;
+    c.metadata_base = base;
+    HLOG(kInfo, "GCS auth: using GCE/GKE metadata server at {}", base);
+    return c;
+  }
+  // 5. Anonymous.
+  c.kind = GcsCredKind::kAnonymous;
+  HLOG(kInfo, "GCS auth: no credentials resolved — anonymous access");
+  return c;
+}
+
+//===========================================================================
+// GcsTokenProvider
+//===========================================================================
+
+GcsTokenProvider::GcsTokenProvider(GcsCredentials creds)
+    : creds_(std::move(creds)) {}
+
+std::string GcsTokenProvider::GetToken() {
+  if (creds_.kind == GcsCredKind::kAnonymous) return "";
+  std::lock_guard<std::mutex> lock(mu_);
+  auto now = std::chrono::steady_clock::now();
+  const auto skew = std::chrono::seconds(60);  // refresh this long before expiry
+  if (have_token_ && now + skew < expiry_) return token_;
+  if (!Refresh()) {
+    HLOG(kError, "GCS auth: token refresh failed (kind={})",
+         static_cast<int>(creds_.kind));
+    return have_token_ ? token_ : "";  // best effort: reuse a stale token
+  }
+  return token_;
+}
+
+void GcsTokenProvider::Invalidate() {
+  std::lock_guard<std::mutex> lock(mu_);
+  have_token_ = false;
+  expiry_ = std::chrono::steady_clock::time_point{};
+}
+
+bool GcsTokenProvider::Refresh() {
+  auto store = [&](const GcsTokenResponse &r) {
+    token_ = r.access_token;
+    long ttl = r.expires_in > 0 ? r.expires_in : 3600;
+    expiry_ = std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
+    have_token_ = true;
+  };
+  switch (creds_.kind) {
+    case GcsCredKind::kExplicitToken: {
+      token_ = cloud::EnvOr("GCS_ACCESS_TOKEN", creds_.explicit_token);
+      have_token_ = !token_.empty();
+      // Lifetime unknown; assume ~1 h and let a 401 force re-read via Invalidate.
+      expiry_ = std::chrono::steady_clock::now() + std::chrono::seconds(3600);
+      return have_token_;
+    }
+    case GcsCredKind::kServiceAccount: {
+      auto now = static_cast<int64_t>(std::time(nullptr));
+      std::string jwt = BuildJwtAssertion(creds_.client_email, creds_.scope,
+                                          creds_.token_uri, now, now + 3600,
+                                          creds_.private_key);
+      if (jwt.empty()) return false;
+      std::string body =
+          "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" +
+          jwt;
+      std::string resp;
+      long status = 0;
+      if (!HttpPostForm(creds_.token_uri, body, resp, status) || status != 200) {
+        HLOG(kError, "GCS auth: SA token exchange failed (http={})", status);
+        return false;
+      }
+      GcsTokenResponse r = ParseTokenResponse(resp);
+      if (!r.ok) return false;
+      store(r);
+      HLOG(kInfo, "GCS auth: obtained SA access token (expires_in={}s)",
+           r.expires_in);
+      return true;
+    }
+    case GcsCredKind::kAuthorizedUser: {
+      std::string body =
+          "client_id=" + cloud::AwsUriEncode(creds_.client_id, true) +
+          "&client_secret=" + cloud::AwsUriEncode(creds_.client_secret, true) +
+          "&refresh_token=" + cloud::AwsUriEncode(creds_.refresh_token, true) +
+          "&grant_type=refresh_token";
+      std::string resp;
+      long status = 0;
+      if (!HttpPostForm(creds_.token_uri, body, resp, status) || status != 200) {
+        HLOG(kError, "GCS auth: refresh_token exchange failed (http={})", status);
+        return false;
+      }
+      GcsTokenResponse r = ParseTokenResponse(resp);
+      if (!r.ok) return false;
+      store(r);
+      HLOG(kInfo, "GCS auth: refreshed user access token (expires_in={}s)",
+           r.expires_in);
+      return true;
+    }
+    case GcsCredKind::kMetadata: {
+      std::string url =
+          creds_.metadata_base +
+          "/computeMetadata/v1/instance/service-accounts/default/token";
+      std::string resp;
+      long status = 0;
+      if (!HttpGetMetadata(url, resp, status, 3000) || status != 200) {
+        HLOG(kError, "GCS auth: metadata token fetch failed (http={})", status);
+        return false;
+      }
+      GcsTokenResponse r = ParseTokenResponse(resp);
+      if (!r.ok) return false;
+      store(r);
+      HLOG(kInfo, "GCS auth: obtained metadata access token (expires_in={}s)",
+           r.expires_in);
+      return true;
+    }
+    case GcsCredKind::kAnonymous:
+    default:
+      token_.clear();
+      have_token_ = true;
+      expiry_ = std::chrono::steady_clock::now() + std::chrono::hours(24 * 365);
+      return true;
+  }
+}
+
+std::shared_ptr<GcsTokenProvider> GetSharedGcsTokenProvider(
+    const GcsCredentials &creds) {
+  // Process-wide registry: one provider per credential Identity, shared across
+  // all per-worker clients so the token is acquired/refreshed exactly once.
+  // Entries are weak_ptr so the provider — and the credential material it
+  // copies (e.g. a PEM private key) — is released once the last GcsClient using
+  // it is destroyed, rather than accumulating for the life of the process.
+  static std::mutex reg_mu;
+  static std::map<std::string, std::weak_ptr<GcsTokenProvider>> registry;
+  std::lock_guard<std::mutex> lock(reg_mu);
+  std::string id = creds.Identity();
+  auto it = registry.find(id);
+  if (it != registry.end()) {
+    if (auto sp = it->second.lock()) return sp;
+    registry.erase(it);  // stale entry: the last user was destroyed
+  }
+  auto provider = std::make_shared<GcsTokenProvider>(creds);
+  registry[id] = provider;
+  return provider;
+}
+
+}  // namespace clio::run::bdev

--- a/context-runtime/modules/bdev/src/gcs_retry.cc
+++ b/context-runtime/modules/bdev/src/gcs_retry.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <clio_runtime/bdev/gcs_retry.h>
+
+#include <curl/curl.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <random>
+
+#include "clio_runtime/bdev/cloud_crypto.h"
+
+namespace clio::run::bdev {
+
+bool IsTransientCurlError(int curl_code) {
+  switch (curl_code) {
+    case CURLE_COULDNT_CONNECT:
+    case CURLE_OPERATION_TIMEDOUT:
+    case CURLE_RECV_ERROR:
+    case CURLE_SEND_ERROR:
+    case CURLE_GOT_NOTHING:
+    case CURLE_COULDNT_RESOLVE_HOST:
+    case CURLE_PARTIAL_FILE:
+    case CURLE_SSL_CONNECT_ERROR:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Parse a positive integer environment variable, falling back to a default.
+ * @param name Variable name.
+ * @param def Fallback value when unset/empty/non-numeric.
+ * @return The parsed value, or `def`.
+ */
+static double EnvNum(const char *name, double def) {
+  std::string v = cloud::EnvOr(name, "");
+  if (v.empty()) return def;
+  char *end = nullptr;
+  double parsed = std::strtod(v.c_str(), &end);
+  return (end != v.c_str() && parsed >= 0.0) ? parsed : def;
+}
+
+RetryPolicy RetryPolicy::FromEnv() {
+  RetryPolicy p;
+  p.max_attempts = std::max(1, static_cast<int>(EnvNum("GCS_MAX_RETRIES", 5)));
+  p.base_ms = EnvNum("GCS_RETRY_BASE_MS", 100.0);
+  p.max_ms = EnvNum("GCS_RETRY_MAX_MS", 30000.0);
+  p.retry_on_auth_err = true;
+  return p;
+}
+
+bool RetryPolicy::ShouldRetry(long http_status, int curl_code,
+                              int attempt) const {
+  // No attempts left after the one that just finished (0-based `attempt`).
+  if (attempt + 1 >= max_attempts) return false;
+  // Transport-level failure: retry the transient class only.
+  if (curl_code != CURLE_OK) return IsTransientCurlError(curl_code);
+  // HTTP-level transient failures (rate limit + server/gateway errors).
+  switch (http_status) {
+    case 429:
+    case 500:
+    case 502:
+    case 503:
+    case 504:
+      return true;
+    default:
+      return false;
+  }
+}
+
+double RetryPolicy::BackoffCeilingMs(int attempt) const {
+  if (attempt < 1) attempt = 1;
+  // base * 2^(attempt-1), saturating at max_ms (and guarding overflow).
+  double ceiling = base_ms * std::ldexp(1.0, attempt - 1);
+  if (!std::isfinite(ceiling) || ceiling > max_ms) ceiling = max_ms;
+  return ceiling < 0.0 ? 0.0 : ceiling;
+}
+
+double RetryPolicy::NextDelayMs(int attempt) const {
+  double ceiling = BackoffCeilingMs(attempt);
+  if (ceiling <= 0.0) return 0.0;
+  // Full jitter: uniform in [0, ceiling]. A thread-local engine keeps this
+  // cheap and lock-free across the per-worker clients.
+  static thread_local std::mt19937_64 rng(std::random_device{}());
+  std::uniform_real_distribution<double> dist(0.0, ceiling);
+  return dist(rng);
+}
+
+}  // namespace clio::run::bdev

--- a/context-runtime/modules/bdev/src/http_object_store_client.cc
+++ b/context-runtime/modules/bdev/src/http_object_store_client.cc
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <clio_runtime/bdev/http_object_store_client.h>
+
+#include <algorithm>
+#include <cstring>
+
+#include "clio_ctp/util/logging.h"
+
+namespace clio::run::bdev {
+
+size_t HttpObjectStoreClient::ReadCb(char *ptr, size_t size, size_t nmemb,
+                                     void *userdata) {
+  auto *op = static_cast<Op *>(userdata);
+  size_t want = size * nmemb;
+  size_t remaining = op->len - op->sent;
+  size_t n = std::min(want, remaining);
+  if (n > 0) {
+    std::memcpy(ptr, op->src + op->sent, n);
+    op->sent += n;
+  }
+  return n;
+}
+
+size_t HttpObjectStoreClient::WriteCb(char *ptr, size_t size, size_t nmemb,
+                                      void *userdata) {
+  auto *op = static_cast<Op *>(userdata);
+  size_t n = size * nmemb;
+  size_t space = (op->written < op->cap) ? (op->cap - op->written) : 0;
+  size_t c = std::min(n, space);
+  if (c > 0) {
+    std::memcpy(op->dst + op->written, ptr, c);
+    op->written += c;
+  }
+  return n;  // Always consume everything so curl doesn't abort on overflow.
+}
+
+HttpObjectStoreClient::HttpObjectStoreClient() {
+  multi_ = curl_multi_init();
+  if (multi_ == nullptr) {
+    HLOG(kError, "Failed to create curl multi handle for object-store client");
+  }
+}
+
+HttpObjectStoreClient::~HttpObjectStoreClient() {
+  for (auto &kv : inflight_) {
+    Op *op = kv.second;
+    if (multi_ && op->easy) curl_multi_remove_handle(multi_, op->easy);
+    if (op->easy) curl_easy_cleanup(op->easy);
+    if (op->headers) curl_slist_free_all(op->headers);
+    delete op;
+  }
+  inflight_.clear();
+  // Ops parked in a backoff window are not in inflight_ (their easy handle was
+  // already torn down); free them here so shutdown leaks nothing.
+  for (Op *op : parked_) {
+    if (op->headers) curl_slist_free_all(op->headers);
+    delete op;
+  }
+  parked_.clear();
+  if (multi_) curl_multi_cleanup(multi_);
+}
+
+void *HttpObjectStoreClient::Submit(Op *op) {
+  curl_multi_add_handle(multi_, op->easy);
+  inflight_[op->easy] = op;
+  return op;
+}
+
+void HttpObjectStoreClient::ScheduleRetry(Op *op, bool immediate, long status) {
+  // Tear down the just-finished transfer but keep the op for another attempt.
+  CURL *old = op->easy;
+  if (old != nullptr) {
+    curl_multi_remove_handle(multi_, old);
+    inflight_.erase(old);
+    curl_easy_cleanup(old);
+  }
+  op->easy = nullptr;
+  if (op->headers != nullptr) {
+    curl_slist_free_all(op->headers);
+    op->headers = nullptr;
+  }
+  double delay_ms = immediate ? 0.0 : retry_policy_.NextDelayMs(op->attempt);
+  op->next_earliest = std::chrono::high_resolution_clock::now() +
+                      std::chrono::duration_cast<
+                          std::chrono::high_resolution_clock::duration>(
+                          std::chrono::duration<double, std::milli>(delay_ms));
+  op->pending_retry = true;
+  parked_.insert(op);
+  HLOG(kWarning, "{} op={} key={} http={} curl={} — retry {}/{} in {}ms",
+       LogTag(), op->op_label, op->key, status, static_cast<int>(op->curl_code),
+       op->attempt, retry_policy_.max_attempts - 1, delay_ms);
+}
+
+bool HttpObjectStoreClient::RearmOp(Op *op) {
+  parked_.erase(op);
+  op->sent = 0;
+  op->written = 0;
+  op->finished = false;
+  op->curl_code = CURLE_OK;
+  op->pending_retry = false;
+  if (op->rebuild) op->rebuild(op);  // builds a fresh easy + headers
+  if (op->easy == nullptr) return false;
+  curl_multi_add_handle(multi_, op->easy);
+  inflight_[op->easy] = op;
+  return true;
+}
+
+void HttpObjectStoreClient::FinalizeOp(Op *op, ObjectStoreResult &out,
+                                       long status) {
+  double ms = std::chrono::duration<double, std::milli>(
+                  std::chrono::high_resolution_clock::now() - op->start)
+                  .count();
+  out.http_status = status;
+  out.not_found = (status == 404);
+  out.bytes = op->is_get ? op->written : op->sent;
+  out.ok = (op->curl_code == CURLE_OK) && (status >= 200 && status < 300);
+
+  HLOG(kInfo, "{} op={} key={} bytes={} http={} latency_ms={}", LogTag(),
+       op->op_label, op->key, out.bytes, status, ms);
+  if (op->curl_code != CURLE_OK) {
+    HLOG(kError, "{} op={} key={} transport error curl={}", LogTag(),
+         op->op_label, op->key, static_cast<int>(op->curl_code));
+  }
+
+  if (op->easy != nullptr) {
+    curl_multi_remove_handle(multi_, op->easy);
+    inflight_.erase(op->easy);  // erase while the pointer key is still valid
+    curl_easy_cleanup(op->easy);
+  }
+  if (op->headers != nullptr) curl_slist_free_all(op->headers);
+  delete op;
+}
+
+bool HttpObjectStoreClient::IsComplete(void *token, ObjectStoreResult &out) {
+  auto *target = static_cast<Op *>(token);
+  if (target == nullptr || multi_ == nullptr) return true;
+
+  int running = 0;
+  curl_multi_perform(multi_, &running);
+
+  // Drain completion messages and mark the matching ops finished.
+  CURLMsg *msg = nullptr;
+  int in_queue = 0;
+  while ((msg = curl_multi_info_read(multi_, &in_queue)) != nullptr) {
+    if (msg->msg != CURLMSG_DONE) continue;
+    auto it = inflight_.find(msg->easy_handle);
+    if (it != inflight_.end()) {
+      it->second->finished = true;
+      it->second->curl_code = msg->data.result;
+    }
+  }
+
+  // Parked in a backoff window: re-arm once the delay elapses.
+  if (target->pending_retry) {
+    if (std::chrono::high_resolution_clock::now() < target->next_earliest) {
+      return false;
+    }
+    if (!RearmOp(target)) {
+      FinalizeOp(target, out, 0);  // rebuild failed -> terminal error
+      return true;
+    }
+    return false;
+  }
+
+  if (!target->finished) return false;
+
+  long status = 0;
+  curl_easy_getinfo(target->easy, CURLINFO_RESPONSE_CODE, &status);
+
+  // Auth failure: refresh the credential and retry once (opt-in).
+  bool is_auth = (status == 401 || status == 403);
+  if (is_auth && retry_policy_.retry_on_auth_err && !target->auth_retried &&
+      target->rebuild) {
+    OnAuthError();
+    target->auth_retried = true;
+    ScheduleRetry(target, /*immediate=*/true, status);
+    return false;
+  }
+
+  // Transient failure: exponential-backoff retry (opt-in via policy + rebuild).
+  if (target->rebuild &&
+      retry_policy_.ShouldRetry(status, static_cast<int>(target->curl_code),
+                                target->attempt)) {
+    target->attempt += 1;
+    ScheduleRetry(target, /*immediate=*/false, status);
+    return false;
+  }
+
+  FinalizeOp(target, out, status);
+  return true;
+}
+
+}  // namespace clio::run::bdev

--- a/context-runtime/modules/bdev/src/object_store_factory.cc
+++ b/context-runtime/modules/bdev/src/object_store_factory.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <clio_runtime/bdev/object_store_factory.h>
+
+#if defined(CLIO_BDEV_S3_ENABLED)
+#include <clio_runtime/bdev/s3_client.h>
+#endif
+#if defined(CLIO_BDEV_GCS_ENABLED)
+#include <clio_runtime/bdev/gcs_client.h>
+#endif
+#if defined(CLIO_BDEV_AZURE_ENABLED)
+#include <clio_runtime/bdev/azure_blob_client.h>
+#endif
+#if defined(CLIO_BDEV_OSS_ENABLED)
+#include <clio_runtime/bdev/oss_client.h>
+#endif
+
+namespace clio::run::bdev {
+
+std::unique_ptr<ObjectStoreClient> MakeObjectStoreClient(
+    BdevType type, const std::string &pool_name) {
+  // Guarded switch: a disabled provider's case (and its header above) is
+  // preprocessed away, so its symbols are never referenced or linked. This is
+  // the only site in the bdev module that needs the per-provider guards.
+  switch (type) {
+#if defined(CLIO_BDEV_S3_ENABLED)
+    case BdevType::kS3:
+      return std::make_unique<S3Client>(
+          S3Config::FromEnvAndPoolName(pool_name));
+#endif
+#if defined(CLIO_BDEV_GCS_ENABLED)
+    case BdevType::kGcs:
+      return std::make_unique<GcsClient>(
+          GcsConfig::FromEnvAndPoolName(pool_name));
+#endif
+#if defined(CLIO_BDEV_AZURE_ENABLED)
+    case BdevType::kAzure:
+      return std::make_unique<AzureBlobClient>(
+          AzureConfig::FromEnvAndPoolName(pool_name), /*is_page=*/false);
+    case BdevType::kAzurePage:
+      return std::make_unique<AzureBlobClient>(
+          AzureConfig::FromEnvAndPoolName(pool_name), /*is_page=*/true);
+#endif
+#if defined(CLIO_BDEV_OSS_ENABLED)
+    case BdevType::kOss:
+      return std::make_unique<OssClient>(
+          OssConfig::FromEnvAndPoolName(pool_name));
+#endif
+    default:
+      return nullptr;
+  }
+}
+
+}  // namespace clio::run::bdev

--- a/context-runtime/modules/bdev/test/CMakeLists.txt
+++ b/context-runtime/modules/bdev/test/CMakeLists.txt
@@ -166,6 +166,193 @@ add_custom_target(test_bdev_error
   COMMENT "Running Chimaera bdev error handling tests"
 )
 
+# S3 backend roundtrip test (prototype) — built only when S3 is enabled.
+# Self-skips at runtime unless S3_ENDPOINT is set, so it is safe in CI.
+if(CLIO_CORE_ENABLE_S3)
+  set(BDEV_S3_TEST_TARGET chimaera_bdev_s3_tests)
+  add_executable(${BDEV_S3_TEST_TARGET} test_bdev_s3.cc)
+  target_include_directories(${BDEV_S3_TEST_TARGET} PRIVATE
+    ${CLIO_RUN_ROOT}/include
+    ${CLIO_RUN_ROOT}/test
+    ${CLIO_RUN_ROOT}/modules/admin/include
+    ${CLIO_RUN_ROOT}/modules/bdev/include
+  )
+  target_link_libraries(${BDEV_S3_TEST_TARGET}
+    clio_admin_runtime
+    clio_admin_client
+    clio_bdev_runtime
+    clio_bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+  set_target_properties(${BDEV_S3_TEST_TARGET} PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  add_test(
+    NAME cr_bdev_s3_tests
+    COMMAND ${BDEV_S3_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_bdev_s3_tests PROPERTIES
+    TIMEOUT 300
+    LABELS "msan_skip"
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHIMAERA_TEST_MODE=1;CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
+  )
+  install(TARGETS ${BDEV_S3_TEST_TARGET} RUNTIME DESTINATION bin)
+endif()
+
+# GCS backend roundtrip test (prototype) — built only when GCS is enabled.
+# Self-skips at runtime unless GCS_ENDPOINT is set, so it is safe in CI.
+if(CLIO_CORE_ENABLE_GCS)
+  set(BDEV_GCS_TEST_TARGET chimaera_bdev_gcs_tests)
+  add_executable(${BDEV_GCS_TEST_TARGET} test_bdev_gcs.cc)
+  target_include_directories(${BDEV_GCS_TEST_TARGET} PRIVATE
+    ${CLIO_RUN_ROOT}/include
+    ${CLIO_RUN_ROOT}/test
+    ${CLIO_RUN_ROOT}/modules/admin/include
+    ${CLIO_RUN_ROOT}/modules/bdev/include
+  )
+  target_link_libraries(${BDEV_GCS_TEST_TARGET}
+    clio_admin_runtime
+    clio_admin_client
+    clio_bdev_runtime
+    clio_bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+  set_target_properties(${BDEV_GCS_TEST_TARGET} PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  add_test(
+    NAME cr_bdev_gcs_tests
+    COMMAND ${BDEV_GCS_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_bdev_gcs_tests PROPERTIES
+    TIMEOUT 300
+    LABELS "msan_skip"
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHIMAERA_TEST_MODE=1;CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
+  )
+  install(TARGETS ${BDEV_GCS_TEST_TARGET} RUNTIME DESTINATION bin)
+
+  # Offline GCS unit tests (JWT signer, JSON parsing, ADC precedence, retry
+  # policy). No network and no runtime init, so this ALWAYS runs (unlike the
+  # endpoint-gated trace test above) — it is the primary correctness proof for
+  # the auth/retry code real GCS exercises.
+  set(BDEV_GCS_UNIT_TARGET chimaera_bdev_gcs_unit_tests)
+  add_executable(${BDEV_GCS_UNIT_TARGET} test_gcs_unit.cc)
+  target_include_directories(${BDEV_GCS_UNIT_TARGET} PRIVATE
+    ${CLIO_RUN_ROOT}/include
+    ${CLIO_RUN_ROOT}/test
+    ${CLIO_RUN_ROOT}/modules/admin/include
+    ${CLIO_RUN_ROOT}/modules/bdev/include
+  )
+  target_link_libraries(${BDEV_GCS_UNIT_TARGET}
+    clio_admin_runtime
+    clio_admin_client
+    clio_bdev_runtime
+    clio_bdev_client
+    ctp::cxx
+    CURL::libcurl
+    OpenSSL::Crypto
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+  set_target_properties(${BDEV_GCS_UNIT_TARGET} PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  add_test(
+    NAME cr_bdev_gcs_unit_tests
+    COMMAND ${BDEV_GCS_UNIT_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_bdev_gcs_unit_tests PROPERTIES
+    TIMEOUT 120
+    LABELS "msan_skip"
+  )
+  install(TARGETS ${BDEV_GCS_UNIT_TARGET} RUNTIME DESTINATION bin)
+endif()
+
+# Azure Blob backend roundtrip test (prototype) — built only when Azure is
+# enabled. Self-skips at runtime unless AZURE_BLOB_ENDPOINT is set (CI-safe).
+if(CLIO_CORE_ENABLE_AZURE)
+  set(BDEV_AZURE_TEST_TARGET chimaera_bdev_azure_tests)
+  add_executable(${BDEV_AZURE_TEST_TARGET} test_bdev_azure.cc)
+  target_include_directories(${BDEV_AZURE_TEST_TARGET} PRIVATE
+    ${CLIO_RUN_ROOT}/include
+    ${CLIO_RUN_ROOT}/test
+    ${CLIO_RUN_ROOT}/modules/admin/include
+    ${CLIO_RUN_ROOT}/modules/bdev/include
+  )
+  target_link_libraries(${BDEV_AZURE_TEST_TARGET}
+    clio_admin_runtime
+    clio_admin_client
+    clio_bdev_runtime
+    clio_bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+  set_target_properties(${BDEV_AZURE_TEST_TARGET} PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  add_test(
+    NAME cr_bdev_azure_tests
+    COMMAND ${BDEV_AZURE_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_bdev_azure_tests PROPERTIES
+    TIMEOUT 300
+    LABELS "msan_skip"
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHIMAERA_TEST_MODE=1;CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10500"
+  )
+  install(TARGETS ${BDEV_AZURE_TEST_TARGET} RUNTIME DESTINATION bin)
+endif()
+
+# Alibaba Cloud OSS backend test (prototype) — built only when OSS is enabled.
+# The native OSS V1 signer test-vector case always runs (no network); the
+# data-plane roundtrip/sparse cases self-skip unless OSS_ENDPOINT is set.
+if(CLIO_CORE_ENABLE_OSS)
+  set(BDEV_OSS_TEST_TARGET chimaera_bdev_oss_tests)
+  add_executable(${BDEV_OSS_TEST_TARGET} test_bdev_oss.cc)
+  target_include_directories(${BDEV_OSS_TEST_TARGET} PRIVATE
+    ${CLIO_RUN_ROOT}/include
+    ${CLIO_RUN_ROOT}/test
+    ${CLIO_RUN_ROOT}/modules/admin/include
+    ${CLIO_RUN_ROOT}/modules/bdev/include
+  )
+  target_link_libraries(${BDEV_OSS_TEST_TARGET}
+    clio_admin_runtime
+    clio_admin_client
+    clio_bdev_runtime
+    clio_bdev_client
+    ctp::cxx
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+  set_target_properties(${BDEV_OSS_TEST_TARGET} PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  add_test(
+    NAME cr_bdev_oss_tests
+    COMMAND ${BDEV_OSS_TEST_TARGET}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+  set_tests_properties(cr_bdev_oss_tests PROPERTIES
+    TIMEOUT 300
+    LABELS "msan_skip"
+    ENVIRONMENT "CHI_REPO_PATH=${CMAKE_BINARY_DIR}/bin;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/bin:$ENV{LD_LIBRARY_PATH};CHIMAERA_TEST_MODE=1;CLIO_BIND_ADDR=127.0.0.1;CLIO_PORT=10502"
+  )
+  install(TARGETS ${BDEV_OSS_TEST_TARGET} RUNTIME DESTINATION bin)
+endif()
+
 # Install test executable
 install(TARGETS ${BDEV_TEST_TARGET}
   RUNTIME DESTINATION bin

--- a/context-runtime/modules/bdev/test/test_bdev_gcs.cc
+++ b/context-runtime/modules/bdev/test/test_bdev_gcs.cc
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Prototype roundtrip test for the kGcs bdev backend. Validates read/write
+// traces against a GCS-compatible endpoint (e.g. a local fake-gcs-server). The
+// test self-skips when GCS_ENDPOINT is not set so it is safe to run without one.
+//
+// Build: requires -DCLIO_CORE_ENABLE_GCS=ON (this file is only compiled then).
+// Run (against fake-gcs-server, anonymous):
+//   export GCS_ENDPOINT=http://127.0.0.1:4443
+//   export GCS_PROJECT_ID=clio-prototype
+//   ./chimaera_bdev_gcs_tests
+// For real GCS, also set GOOGLE_APPLICATION_CREDENTIALS (service-account JSON)
+// or GCS_ACCESS_TOKEN.
+
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+using namespace std::chrono_literals;
+
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/pool_query.h>
+#include <clio_runtime/singletons.h>
+#include <clio_runtime/types.h>
+
+#include <clio_runtime/bdev/bdev_client.h>
+#include <clio_runtime/bdev/bdev_tasks.h>
+
+namespace {
+
+bool g_initialized = false;
+const chi::u64 k4KB = 4096;
+
+/** Wrap a single block in the chi::priv::vector the client API expects. */
+inline chi::priv::vector<clio::run::bdev::Block> WrapBlock(
+    const clio::run::bdev::Block& block) {
+  chi::priv::vector<clio::run::bdev::Block> blocks(CTP_MALLOC);
+  blocks.push_back(block);
+  return blocks;
+}
+
+/** Initialize the runtime once for the whole suite. */
+void EnsureInit() {
+  if (g_initialized) return;
+  bool success = chi::CHIMAERA_INIT(chi::ChimaeraMode::kClient, true);
+  if (success) {
+    g_initialized = true;
+    SimpleTest::g_test_finalize = chi::CHIMAERA_FINALIZE;
+    std::this_thread::sleep_for(500ms);
+  }
+}
+
+/** Bucket for the trace test; override with GCS_TEST_BUCKET for real GCS.
+ *  Defaults to the local fake-gcs-server bucket name used in CI. */
+inline std::string TestBucket() {
+  const char* b = std::getenv("GCS_TEST_BUCKET");
+  return (b && *b) ? std::string(b) : std::string("clio-gcs-test");
+}
+
+/** @return true if no GCS endpoint is configured (test should skip). */
+bool ShouldSkip() {
+  const char* ep = std::getenv("GCS_ENDPOINT");
+  bool have = (ep && *ep);
+  if (!have) {
+    HLOG(kInfo, "GCS_ENDPOINT not set — skipping GCS bdev test");
+  }
+  return !have;
+}
+
+}  // namespace
+
+TEST_CASE("bdev_gcs_allocation_and_io", "[bdev][gcs][io]") {
+  if (ShouldSkip()) return;
+  EnsureInit();
+  REQUIRE(g_initialized);
+  std::this_thread::sleep_for(100ms);
+
+  chi::PoolId custom_pool_id(8105, 0);
+  clio::run::bdev::Client bdev_client(custom_pool_id);
+
+  // 4 MiB logical capacity; bucket/prefix encoded in pool_name.
+  const chi::u64 gcs_capacity = 4 * 1024 * 1024;
+  std::string pool_name =
+      "gcs://" + TestBucket() + "/clio-validation/pool_" + std::to_string(getpid());
+  auto create_task = bdev_client.AsyncCreate(
+      chi::PoolQuery::Dynamic(), pool_name, custom_pool_id,
+      clio::run::bdev::BdevType::kGcs, gcs_capacity);
+  create_task.Wait();
+  bdev_client.pool_id_ = create_task->new_pool_id_;
+  REQUIRE(create_task->GetReturnCode() == 0);
+  std::this_thread::sleep_for(100ms);
+
+  // Roundtrip several blocks: allocate -> write -> read -> verify -> free.
+  for (int i = 0; i < 8; ++i) {
+    auto pool_query = chi::PoolQuery::DirectHash(i);
+
+    auto alloc_task = bdev_client.AsyncAllocateBlocks(pool_query, k4KB);
+    alloc_task.Wait();
+    REQUIRE(alloc_task->return_code_ == 0);
+    REQUIRE(alloc_task->blocks_.size() > 0);
+    clio::run::bdev::Block block = alloc_task->blocks_[0];
+    REQUIRE(block.size_ == k4KB);
+
+    // Distinct payload per iteration.
+    std::vector<ctp::u8> write_data(k4KB);
+    for (size_t j = 0; j < write_data.size(); ++j) {
+      write_data[j] = static_cast<ctp::u8>((j + 0x5A + i) % 256);
+    }
+
+    auto write_buffer = CLIO_IPC->AllocateBuffer(write_data.size());
+    REQUIRE_FALSE(write_buffer.IsNull());
+    memcpy(write_buffer.ptr_, write_data.data(), write_data.size());
+    auto write_task = bdev_client.AsyncWrite(
+        pool_query, WrapBlock(block),
+        write_buffer.shm_.template Cast<void>().template Cast<void>(),
+        write_data.size());
+    write_task.Wait();
+    REQUIRE(write_task->return_code_ == 0);
+    REQUIRE(write_task->bytes_written_ == k4KB);
+
+    auto read_buffer = CLIO_IPC->AllocateBuffer(k4KB);
+    REQUIRE_FALSE(read_buffer.IsNull());
+    auto read_task = bdev_client.AsyncRead(
+        pool_query, WrapBlock(block),
+        read_buffer.shm_.template Cast<void>().template Cast<void>(), k4KB);
+    read_task.Wait();
+    REQUIRE(read_task->return_code_ == 0);
+    REQUIRE(read_task->bytes_read_ == k4KB);
+
+    std::vector<ctp::u8> read_data(read_task->bytes_read_);
+    memcpy(read_data.data(), read_buffer.ptr_, read_task->bytes_read_);
+    bool data_matches =
+        std::equal(write_data.begin(), write_data.end(), read_data.begin());
+    REQUIRE(data_matches);
+
+    CLIO_IPC->FreeBuffer(write_buffer);
+    CLIO_IPC->FreeBuffer(read_buffer);
+
+    std::vector<clio::run::bdev::Block> free_blocks;
+    free_blocks.push_back(block);
+    auto free_task = bdev_client.AsyncFreeBlocks(pool_query, free_blocks);
+    free_task.Wait();
+    REQUIRE(free_task->return_code_ == 0);
+
+    HLOG(kInfo, "GCS iteration {}: roundtrip OK", i);
+  }
+}
+
+TEST_CASE("bdev_gcs_sparse_read_zeros", "[bdev][gcs][sparse]") {
+  if (ShouldSkip()) return;
+  EnsureInit();
+  REQUIRE(g_initialized);
+
+  chi::PoolId custom_pool_id(8106, 0);
+  clio::run::bdev::Client bdev_client(custom_pool_id);
+  const chi::u64 gcs_capacity = 4 * 1024 * 1024;
+  std::string pool_name =
+      "gcs://" + TestBucket() + "/clio-validation/sparse_" + std::to_string(getpid());
+  auto create_task = bdev_client.AsyncCreate(
+      chi::PoolQuery::Dynamic(), pool_name, custom_pool_id,
+      clio::run::bdev::BdevType::kGcs, gcs_capacity);
+  create_task.Wait();
+  bdev_client.pool_id_ = create_task->new_pool_id_;
+  REQUIRE(create_task->GetReturnCode() == 0);
+
+  auto pool_query = chi::PoolQuery::DirectHash(0);
+  auto alloc_task = bdev_client.AsyncAllocateBlocks(pool_query, k4KB);
+  alloc_task.Wait();
+  REQUIRE(alloc_task->return_code_ == 0);
+  clio::run::bdev::Block block = alloc_task->blocks_[0];
+
+  // Read a never-written block: GCS download 404 -> zero-filled buffer.
+  auto read_buffer = CLIO_IPC->AllocateBuffer(k4KB);
+  REQUIRE_FALSE(read_buffer.IsNull());
+  memset(read_buffer.ptr_, 0xFF, k4KB);  // poison so zeros are meaningful
+  auto read_task = bdev_client.AsyncRead(
+      pool_query, WrapBlock(block),
+      read_buffer.shm_.template Cast<void>().template Cast<void>(), k4KB);
+  read_task.Wait();
+  REQUIRE(read_task->return_code_ == 0);
+  REQUIRE(read_task->bytes_read_ == k4KB);
+
+  std::vector<ctp::u8> read_data(k4KB);
+  memcpy(read_data.data(), read_buffer.ptr_, k4KB);
+  bool all_zero = true;
+  for (ctp::u8 b : read_data) {
+    if (b != 0) {
+      all_zero = false;
+      break;
+    }
+  }
+  REQUIRE(all_zero);
+  CLIO_IPC->FreeBuffer(read_buffer);
+  HLOG(kInfo, "GCS sparse read returned zeros as expected");
+}
+
+SIMPLE_TEST_MAIN()

--- a/context-runtime/modules/bdev/test/test_gcs_unit.cc
+++ b/context-runtime/modules/bdev/test/test_gcs_unit.cc
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Offline unit tests for the GCS adapter's pure logic — the JWT/RS256 signer,
+// the JSON parsers, the ADC credential-resolution precedence, and the retry
+// policy. These run with NO network and NO runtime init (unlike the trace test
+// in test_bdev_gcs.cc), so they always execute and are the primary correctness
+// proof for the auth/retry code that real GCS exercises.
+
+#include <arpa/inet.h>
+#include <curl/curl.h>
+#include <netinet/in.h>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simple_test.h"
+
+#include <clio_runtime/bdev/gcs_client.h>
+#include <clio_runtime/bdev/gcs_credentials.h>
+#include <clio_runtime/bdev/gcs_retry.h>
+
+using namespace clio::run::bdev;
+
+namespace {
+
+/** Decode a base64url (no-padding) string back to raw bytes (test-only). */
+std::vector<unsigned char> B64UrlDecode(const std::string &in) {
+  int rev[256];
+  for (int i = 0; i < 256; ++i) rev[i] = -1;
+  const char *tbl =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  for (int i = 0; i < 64; ++i) rev[static_cast<unsigned char>(tbl[i])] = i;
+  std::vector<unsigned char> out;
+  uint32_t buf = 0;
+  int bits = 0;
+  for (unsigned char c : in) {
+    int v = rev[c];
+    if (v < 0) continue;
+    buf = (buf << 6) | static_cast<uint32_t>(v);
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out.push_back(static_cast<unsigned char>((buf >> bits) & 0xFF));
+    }
+  }
+  return out;
+}
+
+/** Generate a throwaway 2048-bit RSA key; @return the private-key PEM. */
+std::string GenRsaPrivatePem(EVP_PKEY **out_pkey) {
+  EVP_PKEY *pkey = nullptr;
+  EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr);
+  EVP_PKEY_keygen_init(pctx);
+  EVP_PKEY_CTX_set_rsa_keygen_bits(pctx, 2048);
+  EVP_PKEY_keygen(pctx, &pkey);
+  EVP_PKEY_CTX_free(pctx);
+  BIO *bio = BIO_new(BIO_s_mem());
+  PEM_write_bio_PrivateKey(bio, pkey, nullptr, nullptr, 0, nullptr, nullptr);
+  char *data = nullptr;
+  long n = BIO_get_mem_data(bio, &data);
+  std::string pem(data, static_cast<size_t>(n));
+  BIO_free(bio);
+  *out_pkey = pkey;
+  return pem;
+}
+
+/** Verify an RS256 signature over `msg` with the given key. */
+bool VerifyRs256(EVP_PKEY *pkey, const std::string &msg,
+                 const std::vector<unsigned char> &sig) {
+  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+  bool ok = EVP_DigestVerifyInit(ctx, nullptr, EVP_sha256(), nullptr, pkey) ==
+                1 &&
+            EVP_DigestVerify(ctx, sig.data(), sig.size(),
+                             reinterpret_cast<const unsigned char *>(msg.data()),
+                             msg.size()) == 1;
+  EVP_MD_CTX_free(ctx);
+  return ok;
+}
+
+/** Write `content` to a temp file and return its path. */
+std::string WriteTmp(const std::string &name, const std::string &content) {
+  std::string path = "/tmp/" + name;
+  std::ofstream f(path);
+  f << content;
+  f.close();
+  return path;
+}
+
+/** Clear every env var the ADC resolver consults, for hermetic precedence. */
+void ClearGcsEnv() {
+  unsetenv("GCS_ACCESS_TOKEN");
+  unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+  unsetenv("GCE_METADATA_HOST");
+  unsetenv("GCS_METADATA_BASE");
+  unsetenv("GCS_DISABLE_METADATA");
+  unsetenv("CLOUDSDK_CONFIG");
+  // Point HOME at a dir with no gcloud ADC file so step 3 is a clean miss.
+  setenv("HOME", "/tmp/gcs_unit_no_home", 1);
+}
+
+}  // namespace
+
+TEST_CASE("gcs_base64url_vectors", "[gcs][unit][b64url]") {
+  // RFC 4648 §10 vectors, base64url with no padding.
+  REQUIRE(Base64UrlEncode(std::string("")) == "");
+  REQUIRE(Base64UrlEncode(std::string("f")) == "Zg");
+  REQUIRE(Base64UrlEncode(std::string("fo")) == "Zm8");
+  REQUIRE(Base64UrlEncode(std::string("foo")) == "Zm9v");
+  REQUIRE(Base64UrlEncode(std::string("foob")) == "Zm9vYg");
+  REQUIRE(Base64UrlEncode(std::string("fooba")) == "Zm9vYmE");
+  REQUIRE(Base64UrlEncode(std::string("foobar")) == "Zm9vYmFy");
+  // URL-safe alphabet: bytes that map to '+' and '/' in std base64 -> '-','_'.
+  const unsigned char raw[] = {0xfb, 0xff, 0xbf};
+  REQUIRE(Base64UrlEncode(raw, sizeof(raw)) == "-_-_");
+}
+
+TEST_CASE("gcs_jwt_assertion_signs_and_verifies", "[gcs][unit][jwt]") {
+  EVP_PKEY *pkey = nullptr;
+  std::string pem = GenRsaPrivatePem(&pkey);
+  REQUIRE(!pem.empty());
+
+  std::string jwt = BuildJwtAssertion(
+      "sa@proj.iam.gserviceaccount.com",
+      "https://www.googleapis.com/auth/devstorage.read_write",
+      "https://oauth2.googleapis.com/token", 1700000000, 1700003600, pem);
+  REQUIRE(!jwt.empty());
+
+  // Three dot-separated segments: header.claims.signature.
+  size_t d1 = jwt.find('.');
+  size_t d2 = jwt.find('.', d1 + 1);
+  REQUIRE(d1 != std::string::npos);
+  REQUIRE(d2 != std::string::npos);
+  std::string signing_input = jwt.substr(0, d2);
+  std::string hdr_b64 = jwt.substr(0, d1);
+  std::string claims_b64 = jwt.substr(d1 + 1, d2 - d1 - 1);
+  std::string sig_b64 = jwt.substr(d2 + 1);
+
+  // Header decodes to the canonical RS256 JOSE header.
+  auto hdr = B64UrlDecode(hdr_b64);
+  std::string hdr_str(hdr.begin(), hdr.end());
+  REQUIRE(hdr_str == R"({"alg":"RS256","typ":"JWT"})");
+
+  // Claims carry the issuer + audience we asked for.
+  auto claims = B64UrlDecode(claims_b64);
+  std::string claims_str(claims.begin(), claims.end());
+  REQUIRE(claims_str.find("sa@proj.iam.gserviceaccount.com") !=
+          std::string::npos);
+  REQUIRE(claims_str.find("oauth2.googleapis.com/token") != std::string::npos);
+
+  // Signature verifies against the signing input with the matching key.
+  REQUIRE(VerifyRs256(pkey, signing_input, B64UrlDecode(sig_b64)));
+  EVP_PKEY_free(pkey);
+}
+
+TEST_CASE("gcs_parse_token_response", "[gcs][unit][json]") {
+  auto good = ParseTokenResponse(
+      R"({"access_token":"ya29.abcDEF","expires_in":3599,"token_type":"Bearer"})");
+  REQUIRE(good.ok);
+  REQUIRE(good.access_token == "ya29.abcDEF");
+  REQUIRE(good.expires_in == 3599);
+
+  auto err = ParseTokenResponse(R"({"error":"invalid_grant"})");
+  REQUIRE(!err.ok);
+
+  auto malformed = ParseTokenResponse("{not json");
+  REQUIRE(!malformed.ok);
+}
+
+TEST_CASE("gcs_parse_service_account_key", "[gcs][unit][json]") {
+  // private_key carries escaped newlines, as a real SA key file does.
+  std::string json =
+      R"({"type":"service_account","client_email":"sa@p.iam.gserviceaccount.com",)"
+      R"("private_key":"-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----\n",)"
+      R"("token_uri":"https://oauth2.googleapis.com/token"})";
+  auto k = ParseServiceAccountKey(json);
+  REQUIRE(k.ok);
+  REQUIRE(k.client_email == "sa@p.iam.gserviceaccount.com");
+  REQUIRE(k.token_uri == "https://oauth2.googleapis.com/token");
+  // The escaped \n must be un-escaped to real newlines for PEM parsing.
+  REQUIRE(k.private_key.find('\n') != std::string::npos);
+  REQUIRE(k.private_key.find("\\n") == std::string::npos);
+
+  // Missing private_key => not a usable service-account key.
+  auto bad = ParseServiceAccountKey(
+      R"({"type":"service_account","client_email":"x@y.com"})");
+  REQUIRE(!bad.ok);
+
+  // Absent token_uri defaults to the Google endpoint.
+  auto defaulted = ParseServiceAccountKey(
+      R"({"client_email":"a@b.com","private_key":"PEM"})");
+  REQUIRE(defaulted.ok);
+  REQUIRE(defaulted.token_uri == "https://oauth2.googleapis.com/token");
+}
+
+TEST_CASE("gcs_parse_authorized_user_key", "[gcs][unit][json]") {
+  auto k = ParseAuthorizedUserKey(
+      R"({"type":"authorized_user","client_id":"cid.apps.googleusercontent.com",)"
+      R"("client_secret":"secret","refresh_token":"1//refresh"})");
+  REQUIRE(k.ok);
+  REQUIRE(k.client_id == "cid.apps.googleusercontent.com");
+  REQUIRE(k.refresh_token == "1//refresh");
+  REQUIRE(k.token_uri == "https://oauth2.googleapis.com/token");
+
+  auto bad = ParseAuthorizedUserKey(
+      R"({"client_id":"cid","client_secret":"s"})");  // no refresh_token
+  REQUIRE(!bad.ok);
+}
+
+TEST_CASE("gcs_retry_should_retry_truth_table", "[gcs][unit][retry]") {
+  RetryPolicy p;
+  p.max_attempts = 5;
+  // Success / sparse / non-transient client errors are never retried.
+  REQUIRE(!p.ShouldRetry(200, CURLE_OK, 0));
+  REQUIRE(!p.ShouldRetry(404, CURLE_OK, 0));
+  REQUIRE(!p.ShouldRetry(400, CURLE_OK, 0));
+  REQUIRE(!p.ShouldRetry(401, CURLE_OK, 0));  // auth handled separately
+  REQUIRE(!p.ShouldRetry(403, CURLE_OK, 0));
+  // Transient HTTP statuses are retried.
+  REQUIRE(p.ShouldRetry(429, CURLE_OK, 0));
+  REQUIRE(p.ShouldRetry(500, CURLE_OK, 0));
+  REQUIRE(p.ShouldRetry(502, CURLE_OK, 0));
+  REQUIRE(p.ShouldRetry(503, CURLE_OK, 0));
+  REQUIRE(p.ShouldRetry(504, CURLE_OK, 0));
+  // Transient transport errors are retried; permanent ones are not.
+  REQUIRE(p.ShouldRetry(0, CURLE_COULDNT_CONNECT, 0));
+  REQUIRE(p.ShouldRetry(0, CURLE_OPERATION_TIMEDOUT, 0));
+  REQUIRE(!p.ShouldRetry(0, CURLE_UNSUPPORTED_PROTOCOL, 0));
+  // Attempt budget is honored (0-based attempt index).
+  REQUIRE(p.ShouldRetry(503, CURLE_OK, 3));
+  REQUIRE(!p.ShouldRetry(503, CURLE_OK, 4));
+  // Default policy is a no-op: a single attempt, never retried.
+  RetryPolicy noop;
+  REQUIRE(!noop.ShouldRetry(503, CURLE_OK, 0));
+}
+
+TEST_CASE("gcs_retry_backoff_ceiling_and_jitter", "[gcs][unit][retry]") {
+  RetryPolicy p;
+  p.base_ms = 100.0;
+  p.max_ms = 30000.0;
+  REQUIRE(p.BackoffCeilingMs(1) == 100.0);
+  REQUIRE(p.BackoffCeilingMs(2) == 200.0);
+  REQUIRE(p.BackoffCeilingMs(3) == 400.0);
+  REQUIRE(p.BackoffCeilingMs(4) == 800.0);
+  REQUIRE(p.BackoffCeilingMs(40) == 30000.0);  // saturates at the cap
+
+  // Full jitter: every draw lies within [0, ceiling]; spread is non-trivial.
+  double ceiling = p.BackoffCeilingMs(5);  // 1600 ms
+  double lo = ceiling, hi = 0.0;
+  for (int i = 0; i < 2000; ++i) {
+    double d = p.NextDelayMs(5);
+    REQUIRE(d >= 0.0);
+    REQUIRE(d <= ceiling);
+    if (d < lo) lo = d;
+    if (d > hi) hi = d;
+  }
+  REQUIRE(hi > lo);          // jitter actually varies
+  REQUIRE(hi > ceiling / 2);  // and reaches the upper half
+}
+
+TEST_CASE("gcs_transient_curl_classification", "[gcs][unit][retry]") {
+  REQUIRE(IsTransientCurlError(CURLE_COULDNT_CONNECT));
+  REQUIRE(IsTransientCurlError(CURLE_OPERATION_TIMEDOUT));
+  REQUIRE(IsTransientCurlError(CURLE_RECV_ERROR));
+  REQUIRE(!IsTransientCurlError(CURLE_OK));
+  REQUIRE(!IsTransientCurlError(CURLE_UNSUPPORTED_PROTOCOL));
+}
+
+TEST_CASE("gcs_adc_precedence", "[gcs][unit][adc]") {
+  // 1. Explicit token wins outright.
+  ClearGcsEnv();
+  setenv("GCS_ACCESS_TOKEN", "ya29.explicit", 1);
+  REQUIRE(ResolveGcsCredentials().kind == GcsCredKind::kExplicitToken);
+
+  // 2. Service-account key file.
+  ClearGcsEnv();
+  std::string sa = WriteTmp(
+      "gcs_unit_sa.json",
+      R"({"type":"service_account","client_email":"sa@p.iam.gserviceaccount.com",)"
+      R"("private_key":"-----BEGIN PRIVATE KEY-----\nXX\n-----END PRIVATE KEY-----\n"})");
+  setenv("GOOGLE_APPLICATION_CREDENTIALS", sa.c_str(), 1);
+  {
+    auto c = ResolveGcsCredentials();
+    REQUIRE(c.kind == GcsCredKind::kServiceAccount);
+    REQUIRE(c.client_email == "sa@p.iam.gserviceaccount.com");
+  }
+
+  // 3. Authorized-user (gcloud) ADC via GOOGLE_APPLICATION_CREDENTIALS.
+  ClearGcsEnv();
+  std::string au = WriteTmp(
+      "gcs_unit_au.json",
+      R"({"type":"authorized_user","client_id":"cid","client_secret":"s",)"
+      R"("refresh_token":"1//r"})");
+  setenv("GOOGLE_APPLICATION_CREDENTIALS", au.c_str(), 1);
+  REQUIRE(ResolveGcsCredentials().kind == GcsCredKind::kAuthorizedUser);
+
+  // 4. Metadata server, forced via the injection knob (no network/probe).
+  ClearGcsEnv();
+  setenv("GCS_METADATA_BASE", "http://169.254.169.254", 1);
+  {
+    auto c = ResolveGcsCredentials();
+    REQUIRE(c.kind == GcsCredKind::kMetadata);
+    REQUIRE(c.metadata_base == "http://169.254.169.254");
+  }
+
+  // 5. Nothing configured + metadata probe disabled => anonymous (hermetic).
+  ClearGcsEnv();
+  setenv("GCS_DISABLE_METADATA", "1", 1);
+  REQUIRE(ResolveGcsCredentials().kind == GcsCredKind::kAnonymous);
+
+  // 6. Precedence: explicit token beats a present credentials file.
+  ClearGcsEnv();
+  setenv("GCS_ACCESS_TOKEN", "ya29.explicit", 1);
+  setenv("GOOGLE_APPLICATION_CREDENTIALS", sa.c_str(), 1);
+  REQUIRE(ResolveGcsCredentials().kind == GcsCredKind::kExplicitToken);
+
+  ClearGcsEnv();
+  std::remove(sa.c_str());
+  std::remove(au.c_str());
+}
+
+TEST_CASE("gcs_token_provider_anonymous_is_empty", "[gcs][unit][token]") {
+  GcsCredentials creds;
+  creds.kind = GcsCredKind::kAnonymous;
+  GcsTokenProvider provider(creds);
+  // Anonymous never blocks on a network refresh and yields an empty token.
+  REQUIRE(provider.GetToken().empty());
+  provider.Invalidate();
+  REQUIRE(provider.GetToken().empty());
+}
+
+namespace {
+
+// Minimal loopback HTTP/1.1 server returning a scripted status per connection.
+// Drives the transport retry state machine with no external network: each curl
+// attempt opens a fresh connection (responses set Connection: close), so the
+// Nth attempt receives statuses_[N-1] (then 200 once the script is exhausted).
+class FaultServer {
+ public:
+  explicit FaultServer(std::vector<int> statuses)
+      : statuses_(std::move(statuses)) {}
+
+  /** Bind an ephemeral loopback port and start serving. @return true on ok. */
+  bool Start() {
+    listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd_ < 0) return false;
+    int yes = 1;
+    ::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    if (::bind(listen_fd_, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) <
+        0) {
+      return false;
+    }
+    socklen_t len = sizeof(addr);
+    ::getsockname(listen_fd_, reinterpret_cast<sockaddr *>(&addr), &len);
+    port_ = ntohs(addr.sin_port);
+    ::listen(listen_fd_, 8);
+    thread_ = std::thread([this] { Serve(); });
+    return true;
+  }
+
+  /** Stop serving and join the worker thread. */
+  void Stop() {
+    stop_.store(true);
+    if (listen_fd_ >= 0) ::shutdown(listen_fd_, SHUT_RDWR);
+    if (thread_.joinable()) thread_.join();
+    if (listen_fd_ >= 0) ::close(listen_fd_);
+    listen_fd_ = -1;
+  }
+
+  int port() const { return port_; }
+  int connections() const { return conns_.load(); }
+
+ private:
+  void Serve() {
+    size_t idx = 0;
+    while (!stop_.load()) {
+      int c = ::accept(listen_fd_, nullptr, nullptr);
+      if (c < 0) {
+        if (stop_.load()) break;
+        continue;
+      }
+      // Drain the request so curl's body send completes (avoids RST on close).
+      timeval tv{0, 100000};  // 100 ms
+      ::setsockopt(c, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+      char buf[4096];
+      while (::recv(c, buf, sizeof(buf), 0) > 0) {
+      }
+      int status = (idx < statuses_.size()) ? statuses_[idx] : 200;
+      ++idx;
+      const char *reason = (status / 100 == 2) ? "OK" : "Service Unavailable";
+      std::string resp = "HTTP/1.1 " + std::to_string(status) + " " + reason +
+                         "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+      (void)::send(c, resp.data(), resp.size(), 0);
+      ::shutdown(c, SHUT_WR);
+      while (::recv(c, buf, sizeof(buf), 0) > 0) {
+      }
+      ::close(c);
+      ++conns_;
+    }
+  }
+
+  std::vector<int> statuses_;
+  int listen_fd_ = -1;
+  int port_ = 0;
+  std::atomic<int> conns_{0};
+  std::atomic<bool> stop_{false};
+  std::thread thread_;
+};
+
+/** Build an anonymous GcsClient pointed at a local endpoint for retry tests. */
+GcsClient MakeClientForEndpoint(const std::string &endpoint) {
+  ClearGcsEnv();
+  setenv("GCS_DISABLE_METADATA", "1", 1);  // anonymous, no token network
+  setenv("GCS_ENDPOINT", endpoint.c_str(), 1);
+  setenv("GCS_MAX_RETRIES", "4", 1);
+  setenv("GCS_RETRY_BASE_MS", "1", 1);
+  setenv("GCS_RETRY_MAX_MS", "5", 1);
+  return GcsClient(GcsConfig::FromEnvAndPoolName("gcs://retry-bucket/p"));
+}
+
+/** Poll IsComplete with a wall-clock deadline. @return true if it settled. */
+bool PollUntilDone(GcsClient &client, void *tok, ObjectStoreResult &out,
+                   int timeout_s) {
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_s);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (client.IsComplete(tok, out)) return true;
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST_CASE("gcs_retry_exhausts_on_connect_refused", "[gcs][unit][retry]") {
+  // Port 1 refuses instantly -> every attempt hits CURLE_COULDNT_CONNECT (a
+  // transient error). The loop must re-arm up to the budget then terminate with
+  // a failure (proves the state machine is bounded and never spins forever).
+  GcsClient client = MakeClientForEndpoint("http://127.0.0.1:1");
+  REQUIRE(client.IsValid());
+  const char data[8] = "abc";
+  void *tok = client.WriteAsync(0, data, 3);
+  REQUIRE(tok != nullptr);
+  ObjectStoreResult out;
+  REQUIRE(PollUntilDone(client, tok, out, 10));
+  REQUIRE(!out.ok);                 // exhausted retries on a refused connection
+  REQUIRE_FALSE(out.not_found);     // a connect failure is not a 404
+  ClearGcsEnv();
+}
+
+TEST_CASE("gcs_retry_succeeds_after_transient_503", "[gcs][unit][retry]") {
+  // Server answers 503, 503, then 200: the write must transparently succeed on
+  // the third attempt (proves rebuild re-issues the request and the backoff
+  // window resolves to a terminal success).
+  FaultServer server({503, 503, 200});
+  REQUIRE(server.Start());
+  GcsClient client =
+      MakeClientForEndpoint("http://127.0.0.1:" + std::to_string(server.port()));
+  REQUIRE(client.IsValid());
+  const char data[8] = "hello";
+  void *tok = client.WriteAsync(0, data, 5);
+  REQUIRE(tok != nullptr);
+  ObjectStoreResult out;
+  REQUIRE(PollUntilDone(client, tok, out, 15));
+  REQUIRE(out.ok);                   // reached the 200 after two 503s
+  REQUIRE(out.http_status == 200);
+  server.Stop();
+  REQUIRE(server.connections() == 3);  // exactly three attempts were made
+  ClearGcsEnv();
+}
+
+TEST_CASE("gcs_retry_auth_refresh_then_success", "[gcs][unit][retry]") {
+  // Server answers 401 then 200: the write must invalidate-and-retry once
+  // (proves the OnAuthError hook fires and the auth-retry re-issues the
+  // request). Anonymous creds keep the retried request token-free; the point is
+  // the control flow, not a new token.
+  FaultServer server({401, 200});
+  REQUIRE(server.Start());
+  GcsClient client =
+      MakeClientForEndpoint("http://127.0.0.1:" + std::to_string(server.port()));
+  REQUIRE(client.IsValid());
+  const char data[8] = "world";
+  void *tok = client.WriteAsync(0, data, 5);
+  REQUIRE(tok != nullptr);
+  ObjectStoreResult out;
+  REQUIRE(PollUntilDone(client, tok, out, 15));
+  REQUIRE(out.ok);
+  REQUIRE(out.http_status == 200);
+  server.Stop();
+  REQUIRE(server.connections() == 2);  // 401 -> one auth-retry -> 200
+  ClearGcsEnv();
+}
+
+SIMPLE_TEST_MAIN()


### PR DESCRIPTION
Integrate google cloud into CLIO. (Issue #539): Adds a complete, hardened Google Cloud Storage backend for the CLIO bdev module behind the existing ObjectStoreClient factory pattern.

New files:
- gcs_credentials.h/cc  — ADC precedence chain (explicit token, SA JSON RS256 JWT, gcloud authorized_user refresh, GCE/GKE metadata server); shared TTL-aware GcsTokenProvider with mutex-guarded refresh-on-expiry and 401-driven invalidation.
- gcs_retry.h/cc        — Pure RetryPolicy (exponential + full jitter);
  classifies transient curl errors and HTTP 429/5xx; 404 never retried
  (sparse-read sentinel). Default max_attempts=1 is a no-op for other
  backends.
- http_object_store_client.h/cc  — Deduplicates the per-adapter curl-multi
  transport machinery (ReadCb/WriteCb, Op bookkeeping, retry state machine,
  HTTP/2 + TLS tuning, FinalizeOp logging).
- object_store_client.h / object_store_factory.h/cc  — Provider-agnostic
  abstract seam and factory switch (kGcs arm wired; kS3/kAzure/kOss guards
  present but adapters not included on this branch).
- gcs_client.h/cc       — GCS JSON API: media-upload PUT, resumable upload
  above GCS_RESUMABLE_THRESHOLD, GET with 404→zero-fill, EnsureBucket
  (409-tolerant), Mapping-A key layout (prefix/blk_<offset>).
- cloud_crypto.h/cc     — Base64url and HMAC helpers used by gcs_credentials.
- test_bdev_gcs.cc      — Integration trace: 8-iteration roundtrip (distinct
  per-iteration payloads, byte-verified) + sparse-read-zeros; self-skips
  without GCS_ENDPOINT; bucket selectable via GCS_TEST_BUCKET.
- test_gcs_unit.cc      — Always-on offline suite: RS256 JWT vs OpenSSL
  oracle, retry truth table, jitter bounds, token-expiry arithmetic, ADC
  precedence ordering.

Validated against real storage.googleapis.com: 8× PUT+GET http=200 byte-verified, sparse http=404→zero-fill, bucket idempotent create http=409, independently confirmed via plain curl oracle (2026-06-22).

Environment knobs: GCS_ENDPOINT, GCS_PROJECT_ID, GCS_ACCESS_TOKEN, GOOGLE_APPLICATION_CREDENTIALS, GCS_RESUMABLE_THRESHOLD, GCS_MAX_RETRIES, GCS_RETRY_BASE_MS, GCS_RETRY_MAX_MS, GCS_TEST_BUCKET.