### PR TITLE
feat(bdev): Add Google Cloud Storage transport (kGcs, Poco-based)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ option(CLIO_CORE_ENABLE_NVSHMEM "Enable NVSHMEM GPU-to-GPU communication library
 option(CLIO_CORE_ENABLE_SYCL "Enable Intel GPU support via SYCL/oneAPI (icpx -fsycl)" OFF)
 option(CLIO_CORE_ENABLE_JARVIS "Enable Jarvis CI infrastructure installation" OFF)
 option(CLIO_ENABLE_AMAZON_DRIVE "Enable Amazon S3 intermediate storage" OFF)
+option(CLIO_ENABLE_GOOGLE_CLOUD "Enable Google Cloud Storage intermediate storage" OFF)
 
 #------------------------------------------------------------------------------
 # ClioCtp (context-transport-primitives) Options
@@ -737,7 +738,8 @@ else()
     message(STATUS "HDF5 support disabled")
 endif()
 
-# Poco and nlohmann_json (optional - for CAE Globus support)
+# Poco and nlohmann_json (optional - for CAE Globus support and the Google
+# Cloud Storage bdev adapter, which uses Poco::Net for HTTPS + Poco::JSON).
 find_package(Poco COMPONENTS Net NetSSL Crypto JSON QUIET)
 find_package(nlohmann_json QUIET)
 if(NOT nlohmann_json_FOUND)
@@ -749,6 +751,20 @@ if(NOT nlohmann_json_FOUND)
   )
   FetchContent_MakeAvailable(nlohmann_json)
   set(nlohmann_json_FOUND TRUE)
+endif()
+
+# The Google Cloud Storage adapter (kGcs bdev transport) talks to GCS over HTTPS
+# via Poco. If the option is requested but Poco isn't available, warn and disable
+# rather than fail the configure (mirrors the CAE Globus dependency check).
+if(CLIO_ENABLE_GOOGLE_CLOUD AND NOT Poco_FOUND)
+  message(WARNING "CLIO_ENABLE_GOOGLE_CLOUD is ON but the Poco library "
+                  "(Net, NetSSL, Crypto, JSON components) was not found. "
+                  "Google Cloud Storage support will be disabled. "
+                  "Install Poco (libpoco-dev) to enable it.")
+  set(CLIO_ENABLE_GOOGLE_CLOUD OFF)
+endif()
+if(CLIO_ENABLE_GOOGLE_CLOUD)
+  message(STATUS "Google Cloud Storage bdev support: ENABLED (Poco found)")
 endif()
 
 if (CLIO_CTE_ENABLE_ADIOS2_ADAPTER OR CLIO_CORE_ENABLE_GRAY_SCOTT)

--- a/context-runtime/modules/bdev/CMakeLists.txt
+++ b/context-runtime/modules/bdev/CMakeLists.txt
@@ -21,6 +21,27 @@ if(CLIO_ENABLE_AMAZON_DRIVE)
   list(APPEND BDEV_S3_LIBS aws-cpp-sdk-s3 aws-cpp-sdk-core)
 endif()
 
+# Google Cloud Storage transport (kGcs). Talks to GCS over HTTPS via Poco; the
+# root CMakeLists already auto-disables CLIO_ENABLE_GOOGLE_CLOUD if Poco is absent.
+set(BDEV_GCS_SOURCES "")
+set(BDEV_GCS_LIBS "")
+if(CLIO_ENABLE_GOOGLE_CLOUD)
+  list(APPEND BDEV_GCS_SOURCES src/transports/gcs_bdev_transport.cc)
+  list(APPEND BDEV_GCS_LIBS Poco::Net Poco::NetSSL Poco::Crypto)
+endif()
+
+# Feature flags must reach the compiler as -D defines, not just gate the source
+# list: the transport .cc files and the factory switch are guarded by
+# #ifdef CLIO_ENABLE_AMAZON_DRIVE / #ifdef CLIO_ENABLE_GOOGLE_CLOUD. Propagated
+# below via the runtime target's COMPILE_DEFINITIONS.
+set(BDEV_CLOUD_DEFS "")
+if(CLIO_ENABLE_AMAZON_DRIVE)
+  list(APPEND BDEV_CLOUD_DEFS CLIO_ENABLE_AMAZON_DRIVE=1)
+endif()
+if(CLIO_ENABLE_GOOGLE_CLOUD)
+  list(APPEND BDEV_CLOUD_DEFS CLIO_ENABLE_GOOGLE_CLOUD=1)
+endif()
+
 # Client library — ctp::aio provides async I/O headers via its INTERFACE includes.
 # LIB_NAME pins the library to `clio_bdev_client` (the new brand-aligned
 # name); ALIAS keeps `clio_bdev_client` working as a CMake target for
@@ -45,13 +66,17 @@ add_clio_module_runtime(
     src/transports/fs_bdev_transport.cc
     src/transports/mem_bdev_transport.cc
     ${BDEV_S3_SOURCES}
+    ${BDEV_GCS_SOURCES}
     src/autogen/bdev_lib_exec.cc
+  COMPILE_DEFINITIONS
+    ${BDEV_CLOUD_DEFS}
   LINK_LIBRARIES
     clio_admin_runtime
     ctp::aio
     ${BDEV_OPTIONAL_LIBS}
     ${BDEV_GPU_LIBS}
     ${BDEV_S3_LIBS}
+    ${BDEV_GCS_LIBS}
 )
 
 # SYCL HBM bdev support: a separate task. Adding -fsycl to

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/bdev_tasks.h
@@ -84,7 +84,8 @@ enum class BdevType : clio::run::u32 {
   kHbm = 2,     // GPU High-Bandwidth Memory via cudaMalloc (device memory)
   kPinned = 3,  // Pinned host memory via cudaMallocHost
   kNoop = 4,    // No-op backend for latency testing (no actual I/O)
-  kS3 = 5       // Amazon S3 object store backend
+  kS3 = 5,      // Amazon S3 object store backend
+  kGcs = 6      // Google Cloud Storage object store backend
 };
 
 /**
@@ -257,6 +258,10 @@ struct CreateParams {
         bdev_type_ = BdevType::kPinned;
       } else if (type_str == "noop") {
         bdev_type_ = BdevType::kNoop;
+      } else if (type_str == "s3") {
+        bdev_type_ = BdevType::kS3;
+      } else if (type_str == "gcs") {
+        bdev_type_ = BdevType::kGcs;
       }
     }
 

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/gcs_bdev_transport.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/gcs_bdev_transport.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ */
+
+#ifndef CLIO_BDEV_GCS_TRANSPORT_H_
+#define CLIO_BDEV_GCS_TRANSPORT_H_
+
+#include <clio_runtime/bdev/transports/bdev_transport.h>
+#include <clio_runtime/bdev/transports/block_allocator.h>
+
+#include <memory>
+
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+#include <clio_runtime/bdev/transports/gcs_rest.h>
+#endif
+
+namespace clio::run::bdev {
+
+/**
+ * Google Cloud Storage block-device transport. Each block is stored as a GCS
+ * object (key `[prefix/]block_<offset>`); a sparse (never-written) block reads
+ * back as zeros via the 404 -> zero-fill convention. Mirrors S3BdevTransport but
+ * uses a Poco-based REST client and bearer-token auth (GCS_ACCESS_TOKEN).
+ */
+class GcsBdevTransport : public BdevTransport {
+ public:
+  GcsBdevTransport() = default;
+  ~GcsBdevTransport() override { Destroy(); }
+
+  bool Init(const CreateParams& params, const std::string& pool_name,
+            Runtime* runtime) override;
+  void Destroy() override;
+
+  bool AllocateBlocks(size_t size, int worker_id, std::vector<Block>& blocks) override;
+  void FreeBlocks(int worker_id, const std::vector<Block>& blocks) override;
+
+  clio::run::TaskResume WriteBlocks(ctp::ipc::FullPtr<WriteTask> task, clio::run::RunContext &ctx) override;
+  clio::run::TaskResume ReadBlocks(ctp::ipc::FullPtr<ReadTask> task, clio::run::RunContext &ctx) override;
+
+  clio::run::u64 GetCapacity() const override { return allocator_.GetCapacity(); }
+  clio::run::u64 GetRemainingSize() const override { return allocator_.GetRemainingSize(); }
+
+ private:
+  StandardBlockAllocator allocator_;
+  clio::run::u64 gcs_capacity_{0};
+
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+  std::unique_ptr<gcs::GcsRestClient> client_;
+#endif
+};
+
+} // namespace clio::run::bdev
+
+#endif // CLIO_BDEV_GCS_TRANSPORT_H_

--- a/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/gcs_rest.h
+++ b/context-runtime/modules/bdev/include/clio_runtime/bdev/transports/gcs_rest.h
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ */
+
+#ifndef CLIO_BDEV_GCS_REST_H_
+#define CLIO_BDEV_GCS_REST_H_
+
+// Header-only Google Cloud Storage REST client built on Poco::Net (HTTPS) +
+// Poco JSON-free string bodies. The data-plane semantics (media upload, alt=media
+// download, 404 -> sparse/zero-fill, idempotent bucket create) are ported from the
+// hardened libcurl implementation in tag backup/main-pre-rollback-20260624, but the
+// transport is Poco instead of libcurl. Auth is a bearer token (GCS_ACCESS_TOKEN,
+// typically `gcloud auth print-access-token`); the service-account JWT flow is out
+// of scope for now.
+//
+// This file is only meant to be compiled where CLIO_ENABLE_GOOGLE_CLOUD is defined
+// and the Poco::Net / Poco::NetSSL libraries are linked.
+
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+
+#include <Poco/URI.h>
+#include <Poco/Exception.h>
+#include <Poco/StreamCopier.h>
+#include <Poco/NullStream.h>
+#include <Poco/Timespan.h>
+#include <Poco/Net/HTTPClientSession.h>
+#include <Poco/Net/HTTPSClientSession.h>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/Net/HTTPMessage.h>
+#include <Poco/Net/SSLManager.h>
+#include <Poco/Net/Context.h>
+#include <Poco/Net/RejectCertificateHandler.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <istream>
+#include <string>
+
+namespace clio::run::bdev::gcs {
+
+/** Connection + addressing config for one GCS bucket/prefix. */
+struct GcsConfig {
+  std::string endpoint;    ///< e.g. https://storage.googleapis.com
+  std::string bucket;      ///< target bucket name
+  std::string prefix;      ///< optional key prefix (may be empty)
+  std::string project_id;  ///< GCP project (only used when creating the bucket)
+  std::string token;       ///< OAuth2 bearer token (GCS_ACCESS_TOKEN)
+};
+
+/** Outcome of a single data-plane operation. */
+struct GcsResult {
+  long http_status = 0;     ///< HTTP status (0 => transport/exception before a response)
+  bool not_found = false;   ///< GET returned 404 => caller should zero-fill (sparse read)
+  std::string error;        ///< human-readable error, empty on success
+
+  bool ok() const { return error.empty() && http_status >= 200 && http_status < 300; }
+};
+
+/** Percent-encode per RFC 3986 (unreserved set kept; '/' becomes %2F). */
+inline std::string UrlEncode(const std::string &value) {
+  static const char *hex = "0123456789ABCDEF";
+  std::string out;
+  out.reserve(value.size() * 3);
+  for (unsigned char c : value) {
+    bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                      (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+                      c == '.' || c == '~';
+    if (unreserved) {
+      out.push_back(static_cast<char>(c));
+    } else {
+      out.push_back('%');
+      out.push_back(hex[(c >> 4) & 0xF]);
+      out.push_back(hex[c & 0xF]);
+    }
+  }
+  return out;
+}
+
+/** Initialize Poco client-side TLS once per process (system CAs, peer verified). */
+inline void EnsureSslInitialized() {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    Poco::Net::initializeSSL();
+    Poco::SharedPtr<Poco::Net::InvalidCertificateHandler> cert_handler(
+        new Poco::Net::RejectCertificateHandler(false));
+    // privateKey="", cert="", caLocation="" + loadDefaultCAs=true => use the
+    // system CA bundle; VERIFY_RELAXED + RejectCertificateHandler => verify peer.
+    Poco::Net::Context::Ptr context(new Poco::Net::Context(
+        Poco::Net::Context::CLIENT_USE, "", "", "",
+        Poco::Net::Context::VERIFY_RELAXED, 9, true,
+        "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"));
+    Poco::Net::SSLManager::instance().initializeClient(0, cert_handler, context);
+  });
+}
+
+/** Create an HTTP(S) session for `uri`; HTTPS gets a TLS context, http stays plain. */
+inline std::unique_ptr<Poco::Net::HTTPClientSession> MakeSession(const Poco::URI &uri) {
+  std::unique_ptr<Poco::Net::HTTPClientSession> session;
+  if (uri.getScheme() == "https") {
+    EnsureSslInitialized();
+    session = std::make_unique<Poco::Net::HTTPSClientSession>(uri.getHost(),
+                                                              uri.getPort());
+  } else {
+    session = std::make_unique<Poco::Net::HTTPClientSession>(uri.getHost(),
+                                                             uri.getPort());
+  }
+  session->setTimeout(Poco::Timespan(30, 0));  // 30s
+  return session;
+}
+
+/**
+ * Minimal GCS JSON-API client. One instance is cheap; it holds no live socket
+ * (a fresh session is opened per call, which keeps it usable from multiple
+ * workers without sharing a non-thread-safe Poco session).
+ */
+class GcsRestClient {
+ public:
+  explicit GcsRestClient(GcsConfig config) : config_(std::move(config)) {}
+
+  const GcsConfig &config() const { return config_; }
+
+  /** Read connection config from the environment for a given bucket/prefix. */
+  static GcsConfig ConfigFromEnv(const std::string &bucket,
+                                 const std::string &prefix) {
+    GcsConfig c;
+    const char *ep = std::getenv("GCS_ENDPOINT");
+    c.endpoint = (ep && *ep) ? ep : "https://storage.googleapis.com";
+    const char *tok = std::getenv("GCS_ACCESS_TOKEN");
+    c.token = (tok && *tok) ? tok : "";
+    const char *proj = std::getenv("GCS_PROJECT_ID");
+    c.project_id = (proj && *proj) ? proj : "clio-prototype";
+    c.bucket = bucket;
+    c.prefix = prefix;
+    return c;
+  }
+
+  /** Object key for a block offset: [prefix/]block_<offset> (mirrors the S3 transport). */
+  std::string KeyForOffset(uint64_t offset) const {
+    std::string key = "block_" + std::to_string(offset);
+    return config_.prefix.empty() ? key : (config_.prefix + "/" + key);
+  }
+
+  /** Idempotent bucket create. HTTP 200 (created) or 409 (exists) => success. */
+  GcsResult EnsureBucket() {
+    GcsResult r;
+    try {
+      std::string url =
+          config_.endpoint + "/storage/v1/b?project=" + UrlEncode(config_.project_id);
+      Poco::URI uri(url);
+      auto session = MakeSession(uri);
+      Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_POST,
+                                 uri.getPathAndQuery(),
+                                 Poco::Net::HTTPMessage::HTTP_1_1);
+      ApplyAuth(req);
+      std::string body = "{\"name\":\"" + config_.bucket + "\"}";
+      req.setContentType("application/json");
+      req.setContentLength(static_cast<std::streamsize>(body.size()));
+      std::ostream &os = session->sendRequest(req);
+      os << body;
+      os.flush();
+      Poco::Net::HTTPResponse res;
+      std::istream &rs = session->receiveResponse(res);
+      r.http_status = res.getStatus();
+      std::string resp;
+      Poco::StreamCopier::copyToString(rs, resp);
+      if (r.http_status != 200 && r.http_status != 409) {
+        r.error = "GCS bucket ensure failed: HTTP " +
+                  std::to_string(r.http_status) + " " + resp;
+      }
+    } catch (const Poco::Exception &e) {
+      r.error = std::string("GCS bucket ensure exception: ") + e.displayText();
+    }
+    return r;
+  }
+
+  /** Upload `len` bytes via a simple media upload. HTTP 2xx => success. */
+  GcsResult PutObject(const std::string &key, const char *data, size_t len) {
+    GcsResult r;
+    try {
+      std::string url = config_.endpoint + "/upload/storage/v1/b/" +
+                        config_.bucket + "/o?uploadType=media&name=" +
+                        UrlEncode(key);
+      Poco::URI uri(url);
+      auto session = MakeSession(uri);
+      Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_POST,
+                                 uri.getPathAndQuery(),
+                                 Poco::Net::HTTPMessage::HTTP_1_1);
+      ApplyAuth(req);
+      req.setContentType("application/octet-stream");
+      req.setContentLength(static_cast<std::streamsize>(len));
+      std::ostream &os = session->sendRequest(req);
+      if (len > 0) {
+        os.write(data, static_cast<std::streamsize>(len));
+      }
+      os.flush();
+      Poco::Net::HTTPResponse res;
+      std::istream &rs = session->receiveResponse(res);
+      r.http_status = res.getStatus();
+      std::string resp;
+      Poco::StreamCopier::copyToString(rs, resp);
+      if (!r.ok()) {
+        r.error = "GCS PUT failed: HTTP " + std::to_string(r.http_status) + " " +
+                  resp;
+      }
+    } catch (const Poco::Exception &e) {
+      r.error = std::string("GCS PUT exception: ") + e.displayText();
+    }
+    return r;
+  }
+
+  /**
+   * Download object `key` into `buf` (up to `len` bytes). On HTTP 404 the result
+   * has not_found=true and the caller is expected to zero-fill (sparse read). On
+   * success `*bytes_read` (if non-null) is set to the number of bytes copied.
+   */
+  GcsResult GetObject(const std::string &key, char *buf, size_t len,
+                      size_t *bytes_read) {
+    GcsResult r;
+    if (bytes_read) *bytes_read = 0;
+    try {
+      // Build the path directly (not through Poco::URI) to preserve %2F in the
+      // key: Poco::URI decodes %2F during path normalization, making GCS 404 on
+      // objects whose names contain '/'. Use Poco::URI only for host/port.
+      Poco::URI base_uri(config_.endpoint);
+      const std::string path = "/storage/v1/b/" + config_.bucket +
+                               "/o/" + UrlEncode(key) + "?alt=media";
+      auto session = MakeSession(base_uri);
+      Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_GET,
+                                 path,
+                                 Poco::Net::HTTPMessage::HTTP_1_1);
+      ApplyAuth(req);
+      session->sendRequest(req);
+      Poco::Net::HTTPResponse res;
+      std::istream &rs = session->receiveResponse(res);
+      r.http_status = res.getStatus();
+      if (r.http_status == 404) {
+        r.not_found = true;  // sparse: caller zero-fills
+        Poco::NullOutputStream null;
+        Poco::StreamCopier::copyStream(rs, null);
+        return r;
+      }
+      if (!r.ok()) {
+        std::string resp;
+        Poco::StreamCopier::copyToString(rs, resp);
+        r.error = "GCS GET failed: HTTP " + std::to_string(r.http_status) + " " +
+                  resp;
+        return r;
+      }
+      rs.read(buf, static_cast<std::streamsize>(len));
+      if (bytes_read) *bytes_read = static_cast<size_t>(rs.gcount());
+    } catch (const Poco::Exception &e) {
+      r.error = std::string("GCS GET exception: ") + e.displayText();
+    }
+    return r;
+  }
+
+  /** Best-effort object delete (errors are not fatal to the caller). */
+  GcsResult DeleteObject(const std::string &key) {
+    GcsResult r;
+    try {
+      // Same %2F-preservation fix as GetObject.
+      Poco::URI base_uri(config_.endpoint);
+      const std::string path = "/storage/v1/b/" + config_.bucket +
+                               "/o/" + UrlEncode(key);
+      auto session = MakeSession(base_uri);
+      Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_DELETE,
+                                 path,
+                                 Poco::Net::HTTPMessage::HTTP_1_1);
+      ApplyAuth(req);
+      session->sendRequest(req);
+      Poco::Net::HTTPResponse res;
+      std::istream &rs = session->receiveResponse(res);
+      r.http_status = res.getStatus();
+      Poco::NullOutputStream null;
+      Poco::StreamCopier::copyStream(rs, null);
+    } catch (const Poco::Exception &e) {
+      r.error = std::string("GCS DELETE exception: ") + e.displayText();
+    }
+    return r;
+  }
+
+ private:
+  void ApplyAuth(Poco::Net::HTTPRequest &req) const {
+    if (!config_.token.empty()) {
+      req.set("Authorization", "Bearer " + config_.token);
+    }
+  }
+
+  GcsConfig config_;
+};
+
+}  // namespace clio::run::bdev::gcs
+
+#endif  // CLIO_ENABLE_GOOGLE_CLOUD
+
+#endif  // CLIO_BDEV_GCS_REST_H_

--- a/context-runtime/modules/bdev/src/transports/bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/bdev_transport.cc
@@ -11,6 +11,10 @@
 #include <clio_runtime/bdev/transports/s3_bdev_transport.h>
 #endif
 
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+#include <clio_runtime/bdev/transports/gcs_bdev_transport.h>
+#endif
+
 namespace clio::run::bdev {
 
 std::unique_ptr<BdevTransport> BdevTransportFactory::Create(BdevType type) {
@@ -24,6 +28,10 @@ std::unique_ptr<BdevTransport> BdevTransportFactory::Create(BdevType type) {
 #ifdef CLIO_ENABLE_AMAZON_DRIVE
     case BdevType::kS3:
       return std::make_unique<S3BdevTransport>();
+#endif
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+    case BdevType::kGcs:
+      return std::make_unique<GcsBdevTransport>();
 #endif
     default:
       return nullptr;

--- a/context-runtime/modules/bdev/src/transports/gcs_bdev_transport.cc
+++ b/context-runtime/modules/bdev/src/transports/gcs_bdev_transport.cc
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ */
+
+#include <clio_runtime/bdev/transports/gcs_bdev_transport.h>
+#include <clio_runtime/clio_runtime.h>
+#include <clio_runtime/worker.h>
+#include <clio_runtime/work_orchestrator.h>
+
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+#include <cstring>
+#include <string>
+#include <vector>
+#endif
+
+namespace clio::run::bdev {
+
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+namespace {
+// Parse a bdev pool name into (bucket, prefix). Accepts a bare bucket
+// ("clio-bdev"), an optional gcs:// scheme ("gcs://clio-bdev/pool_0"), and an
+// optional key prefix after the first slash. Trailing slashes are stripped.
+void ParsePoolName(const std::string &pool_name, std::string &bucket,
+                   std::string &prefix) {
+  std::string s = pool_name;
+  const std::string scheme = "gcs://";
+  if (s.rfind(scheme, 0) == 0) {
+    s = s.substr(scheme.size());
+  }
+  size_t slash = s.find('/');
+  if (slash == std::string::npos) {
+    bucket = s;
+    prefix.clear();
+  } else {
+    bucket = s.substr(0, slash);
+    prefix = s.substr(slash + 1);
+  }
+  while (!prefix.empty() && prefix.back() == '/') {
+    prefix.pop_back();
+  }
+}
+}  // namespace
+#endif
+
+bool GcsBdevTransport::Init(const CreateParams& params,
+                            const std::string& pool_name, Runtime* runtime) {
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+  std::string bucket, prefix;
+  ParsePoolName(pool_name, bucket, prefix);
+  if (bucket.empty()) {
+    HLOG(kError, "GCS bdev: could not parse a bucket from pool_name '{}'",
+         pool_name.c_str());
+    return false;
+  }
+
+  gcs::GcsConfig config = gcs::GcsRestClient::ConfigFromEnv(bucket, prefix);
+  if (config.token.empty()) {
+    HLOG(kError,
+         "GCS bdev: GCS_ACCESS_TOKEN is not set. Export it from "
+         "`gcloud auth print-access-token` before creating a gcs pool.");
+    return false;
+  }
+  client_ = std::make_unique<gcs::GcsRestClient>(config);
+
+  gcs::GcsResult ensured = client_->EnsureBucket();
+  if (!ensured.error.empty()) {
+    HLOG(kError, "GCS bdev: {}", ensured.error.c_str());
+    client_.reset();
+    return false;
+  }
+
+  gcs_capacity_ = (params.total_size_ == 0) ? (1ULL << 40) : params.total_size_; // Default 1TB
+
+  clio::run::WorkOrchestrator *work_orchestrator = CLIO_WORK_ORCHESTRATOR;
+  size_t num_workers = work_orchestrator ? work_orchestrator->GetWorkerCount() : 16;
+  allocator_.Init(num_workers, gcs_capacity_, params.alignment_);
+
+  HLOG(kInfo,
+       "GCS bdev ready: bucket='{}' prefix='{}' endpoint='{}' capacity={}",
+       config.bucket.c_str(), config.prefix.c_str(), config.endpoint.c_str(),
+       gcs_capacity_);
+  return true;
+#else
+  HLOG(kError, "CLIO_ENABLE_GOOGLE_CLOUD is not defined. Cannot use GCS bdev.");
+  return false;
+#endif
+}
+
+void GcsBdevTransport::Destroy() {
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+  client_.reset();
+#endif
+}
+
+bool GcsBdevTransport::AllocateBlocks(size_t size, int worker_id, std::vector<Block>& blocks) {
+  return allocator_.AllocateBlocks(size, worker_id, blocks);
+}
+
+void GcsBdevTransport::FreeBlocks(int worker_id, const std::vector<Block>& blocks) {
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+  if (client_) {
+    for (const auto& block : blocks) {
+      client_->DeleteObject(client_->KeyForOffset(block.offset_)); // best effort
+    }
+  }
+#endif
+  allocator_.FreeBlocks(worker_id, blocks);
+}
+
+clio::run::TaskResume GcsBdevTransport::WriteBlocks(ctp::ipc::FullPtr<WriteTask> task, clio::run::RunContext &ctx) {
+  clio::run::RunContext& rctx = ctx;
+  CLIO_TASK_BODY_BEGIN
+
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+  auto *ipc_mgr = CLIO_IPC;
+  ctp::ipc::FullPtr<char> data_ptr = ipc_mgr->ToFullPtr(task->data_).Cast<char>();
+
+  bool data_on_device = ctp::IsDevicePointer(data_ptr.ptr_);
+  std::vector<char> staging;
+  if (data_on_device) {
+    staging.resize(task->length_);
+    ctp::DeviceAwareMemcpy(staging.data(), data_ptr.ptr_, task->length_);
+  }
+
+  clio::run::u64 total_bytes_written = 0;
+  clio::run::u64 data_offset = 0;
+
+  for (size_t i = 0; i < task->blocks_.size(); ++i) {
+    const Block &block = task->blocks_[i];
+    clio::run::u64 remaining = task->length_ - total_bytes_written;
+    if (remaining == 0) break;
+    clio::run::u64 block_write_size = std::min(remaining, block.size_);
+
+    char *block_data = data_on_device
+                           ? staging.data() + data_offset
+                           : data_ptr.ptr_ + data_offset;
+
+    gcs::GcsResult res = client_->PutObject(
+        client_->KeyForOffset(block.offset_), block_data,
+        static_cast<size_t>(block_write_size));
+    if (!res.error.empty()) {
+      HLOG(kError, "GCS PutObject failed: {}", res.error.c_str());
+      task->return_code_ = 2;
+      task->bytes_written_ = total_bytes_written;
+      CLIO_CO_RETURN;
+    }
+
+    total_bytes_written += block_write_size;
+    data_offset += block_write_size;
+  }
+
+  task->return_code_ = 0;
+  task->bytes_written_ = total_bytes_written;
+#else
+  task->return_code_ = 1;
+  task->bytes_written_ = 0;
+#endif
+
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+clio::run::TaskResume GcsBdevTransport::ReadBlocks(ctp::ipc::FullPtr<ReadTask> task, clio::run::RunContext &ctx) {
+  clio::run::RunContext& rctx = ctx;
+  CLIO_TASK_BODY_BEGIN
+
+#ifdef CLIO_ENABLE_GOOGLE_CLOUD
+  auto *ipc_mgr = CLIO_IPC;
+  ctp::ipc::FullPtr<char> data_ptr = ipc_mgr->ToFullPtr(task->data_).Cast<char>();
+
+  bool data_on_device = ctp::IsDevicePointer(data_ptr.ptr_);
+  std::vector<char> staging;
+  if (data_on_device) {
+    staging.resize(task->length_);
+  }
+
+  clio::run::u64 total_bytes_read = 0;
+  clio::run::u64 data_offset = 0;
+
+  for (size_t i = 0; i < task->blocks_.size(); ++i) {
+    const Block &block = task->blocks_[i];
+    clio::run::u64 remaining = task->length_ - total_bytes_read;
+    if (remaining == 0) break;
+    clio::run::u64 block_read_size = std::min(remaining, block.size_);
+
+    char *block_data = data_on_device
+                           ? staging.data() + data_offset
+                           : data_ptr.ptr_ + data_offset;
+
+    size_t got = 0;
+    gcs::GcsResult res = client_->GetObject(
+        client_->KeyForOffset(block.offset_), block_data,
+        static_cast<size_t>(block_read_size), &got);
+
+    if (res.not_found) {
+      // Sparse block: object was never written -> read back as zeros.
+      std::memset(block_data, 0, static_cast<size_t>(block_read_size));
+    } else if (!res.error.empty()) {
+      HLOG(kError, "GCS GetObject failed: {}", res.error.c_str());
+      task->return_code_ = 2;
+      task->bytes_read_ = total_bytes_read;
+      CLIO_CO_RETURN;
+    } else if (got < block_read_size) {
+      // Short object: zero-fill the unwritten tail.
+      std::memset(block_data + got, 0,
+                  static_cast<size_t>(block_read_size) - got);
+    }
+
+    total_bytes_read += block_read_size;
+    data_offset += block_read_size;
+  }
+
+  if (data_on_device && total_bytes_read > 0) {
+    ctp::DeviceAwareMemcpy(data_ptr.ptr_, staging.data(), total_bytes_read);
+  }
+
+  task->return_code_ = 0;
+  task->bytes_read_ = total_bytes_read;
+#else
+  task->return_code_ = 1;
+  task->bytes_read_ = 0;
+#endif
+
+  CLIO_CO_RETURN;
+  CLIO_TASK_BODY_END
+}
+
+} // namespace clio::run::bdev

--- a/context-transport-primitives/test/unit/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/CMakeLists.txt
@@ -41,3 +41,7 @@ add_subdirectory(lightbeam)
 if(CLIO_ENABLE_AMAZON_DRIVE)
     add_subdirectory(amazon_s3)
 endif()
+
+if(CLIO_ENABLE_GOOGLE_CLOUD)
+    add_subdirectory(google_cloud)
+endif()

--- a/context-transport-primitives/test/unit/google_cloud/CMakeLists.txt
+++ b/context-transport-primitives/test/unit/google_cloud/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Google Cloud Storage "drive" example. Unlike the AWS SDK (fetched on demand for
+# the S3 example), Poco is already located by the root CMakeLists.txt
+# (find_package(Poco COMPONENTS Net NetSSL Crypto JSON ...)), and the root guard
+# only adds this subdirectory when Poco was found, so the targets below resolve.
+
+add_executable(clio_ctp_gcs_test test_gcs_drive.cc)
+
+target_link_libraries(clio_ctp_gcs_test
+    PRIVATE
+    Catch2::Catch2WithMain
+    Poco::Net
+    Poco::NetSSL
+    Poco::Crypto
+    Poco::JSON
+)
+
+add_test(NAME clio_ctp_gcs_test COMMAND clio_ctp_gcs_test)

--- a/context-transport-primitives/test/unit/google_cloud/test_gcs_drive.cc
+++ b/context-transport-primitives/test/unit/google_cloud/test_gcs_drive.cc
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2024, Gnosis Research Center, Illinois Institute of Technology
+ * All rights reserved.
+ *
+ * This file is part of IOWarp Core.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Self-contained example of the Google Cloud Storage "drive" C++ API, mirroring
+// amazon_s3/test_s3_drive.cc. It writes an object and reads it back from a real
+// GCS bucket over the JSON/media REST API using Poco for HTTPS. Auth is a bearer
+// token obtained with `gcloud auth print-access-token` (no service-account key
+// needed). The test self-skips when GCS_ACCESS_TOKEN or GCS_TEST_BUCKET is unset.
+//
+//   export GCS_ACCESS_TOKEN="$(gcloud auth print-access-token)"
+//   export GCS_TEST_BUCKET=<your-bucket>
+//   # optional: export GCS_ENDPOINT=https://storage.googleapis.com   (default)
+
+#include <catch2/catch_all.hpp>
+
+#include <Poco/URI.h>
+#include <Poco/StreamCopier.h>
+#include <Poco/Exception.h>
+#include <Poco/Net/HTTPSClientSession.h>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/Net/HTTPMessage.h>
+#include <Poco/Net/SSLManager.h>
+#include <Poco/Net/Context.h>
+#include <Poco/Net/RejectCertificateHandler.h>
+
+#include <cstdlib>
+#include <ostream>
+#include <istream>
+#include <string>
+
+namespace {
+
+// Percent-encode an object key per RFC 3986 ('/' -> %2F so GCS treats it opaque).
+std::string UrlEncode(const std::string &value) {
+  static const char *hex = "0123456789ABCDEF";
+  std::string out;
+  out.reserve(value.size() * 3);
+  for (unsigned char c : value) {
+    bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                      (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+                      c == '.' || c == '~';
+    if (unreserved) {
+      out.push_back(static_cast<char>(c));
+    } else {
+      out.push_back('%');
+      out.push_back(hex[(c >> 4) & 0xF]);
+      out.push_back(hex[c & 0xF]);
+    }
+  }
+  return out;
+}
+
+}  // namespace
+
+TEST_CASE("Google Cloud Storage Read/Write", "[gcs][bdev]") {
+  const char *token_env = std::getenv("GCS_ACCESS_TOKEN");
+  const char *bucket_env = std::getenv("GCS_TEST_BUCKET");
+  if (!token_env || !*token_env || !bucket_env || !*bucket_env) {
+    WARN(
+        "GCS_ACCESS_TOKEN and/or GCS_TEST_BUCKET not set - skipping GCS drive "
+        "test. Export GCS_ACCESS_TOKEN=$(gcloud auth print-access-token) and "
+        "GCS_TEST_BUCKET=<bucket> to run it.");
+    return;
+  }
+
+  const std::string token = token_env;
+  const std::string bucket = bucket_env;
+  const char *ep_env = std::getenv("GCS_ENDPOINT");
+  const std::string endpoint =
+      (ep_env && *ep_env) ? ep_env : "https://storage.googleapis.com";
+
+  const std::string object_name = "clio-validation/test_data.txt";
+  const std::string data_to_write = "Hello, Google Cloud Storage from Clio Core!";
+
+  // One-time client-side TLS setup: verify the peer against the system CA bundle.
+  Poco::Net::initializeSSL();
+  Poco::SharedPtr<Poco::Net::InvalidCertificateHandler> cert_handler(
+      new Poco::Net::RejectCertificateHandler(false));
+  Poco::Net::Context::Ptr context(new Poco::Net::Context(
+      Poco::Net::Context::CLIENT_USE, "", "", "",
+      Poco::Net::Context::VERIFY_RELAXED, 9, true,
+      "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"));
+  Poco::Net::SSLManager::instance().initializeClient(0, cert_handler, context);
+
+  // POST a media upload: {endpoint}/upload/storage/v1/b/{bucket}/o?uploadType=media&name=
+  auto gcs_put = [&](const std::string &key, const std::string &body) -> int {
+    Poco::URI uri(endpoint + "/upload/storage/v1/b/" + bucket +
+                  "/o?uploadType=media&name=" + UrlEncode(key));
+    Poco::Net::HTTPSClientSession session(uri.getHost(), uri.getPort());
+    Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_POST,
+                               uri.getPathAndQuery(),
+                               Poco::Net::HTTPMessage::HTTP_1_1);
+    req.set("Authorization", "Bearer " + token);
+    req.setContentType("application/octet-stream");
+    req.setContentLength(static_cast<std::streamsize>(body.size()));
+    std::ostream &os = session.sendRequest(req);
+    os << body;
+    os.flush();
+    Poco::Net::HTTPResponse res;
+    std::istream &rs = session.receiveResponse(res);
+    std::string drain;
+    Poco::StreamCopier::copyToString(rs, drain);
+    return res.getStatus();
+  };
+
+  // GET the object bytes: {endpoint}/storage/v1/b/{bucket}/o/{key}?alt=media
+  // Path is constructed directly (not through Poco::URI) to preserve %2F encoding
+  // of slashes in the key; Poco::URI decodes %2F during path normalization, which
+  // causes GCS to 404 even when the object exists.
+  auto gcs_get = [&](const std::string &key, std::string &out) -> int {
+    Poco::URI base_uri(endpoint);
+    const std::string path =
+        "/storage/v1/b/" + bucket + "/o/" + UrlEncode(key) + "?alt=media";
+    Poco::Net::HTTPSClientSession session(base_uri.getHost(), base_uri.getPort());
+    Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_GET, path,
+                               Poco::Net::HTTPMessage::HTTP_1_1);
+    req.set("Authorization", "Bearer " + token);
+    session.sendRequest(req);
+    Poco::Net::HTTPResponse res;
+    std::istream &rs = session.receiveResponse(res);
+    out.clear();
+    Poco::StreamCopier::copyToString(rs, out);
+    return res.getStatus();
+  };
+
+  // DELETE for cleanup (best effort). Same %2F-preservation fix as gcs_get.
+  auto gcs_delete = [&](const std::string &key) -> int {
+    Poco::URI base_uri(endpoint);
+    const std::string path = "/storage/v1/b/" + bucket + "/o/" + UrlEncode(key);
+    Poco::Net::HTTPSClientSession session(base_uri.getHost(), base_uri.getPort());
+    Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_DELETE, path,
+                               Poco::Net::HTTPMessage::HTTP_1_1);
+    req.set("Authorization", "Bearer " + token);
+    session.sendRequest(req);
+    Poco::Net::HTTPResponse res;
+    std::istream &rs = session.receiveResponse(res);
+    std::string drain;
+    Poco::StreamCopier::copyToString(rs, drain);
+    return res.getStatus();
+  };
+
+  SECTION("Write then read data round-trips through GCS") {
+    try {
+      int put_status = gcs_put(object_name, data_to_write);
+      INFO("GCS PUT gs://" << bucket << "/" << object_name
+                           << " status=" << put_status);
+      REQUIRE(put_status >= 200);
+      REQUIRE(put_status < 300);
+
+      std::string read_back;
+      int get_status = gcs_get(object_name, read_back);
+      INFO("GCS GET gs://" << bucket << "/" << object_name
+                           << " status=" << get_status
+                           << " bytes=" << read_back.size());
+      REQUIRE(get_status >= 200);
+      REQUIRE(get_status < 300);
+      REQUIRE(read_back == data_to_write);
+
+      gcs_delete(object_name);  // tidy up; ignore status
+    } catch (const Poco::Exception &e) {
+      FAIL("Poco exception talking to GCS: " << e.displayText());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements a Google Cloud Storage bdev adapter on the `dev` transport-factory architecture, mirroring the existing Amazon S3 transport. Four mentor requirements satisfied:

- **R1 `CLIO_ENABLE_GOOGLE_CLOUD`** — new CMake option (default OFF); auto-disables with a warning if Poco is not found (mirrors the CAE Globus guard).
- **R2 GCS C++ API example** — `context-transport-primitives/test/unit/google_cloud/test_gcs_drive.cc` (Catch2 round-trip via Poco HTTPS). Self-skips when `GCS_ACCESS_TOKEN` / `GCS_TEST_BUCKET` are unset.
- **R3 Write/read data** — `gcs_rest.h`, a header-only Poco HTTPS client: `EnsureBucket`, `PutObject`, `GetObject` (404 → zero-fill for sparse reads), `DeleteObject`. Keys are percent-encoded so `/` becomes `%2F` in URL paths, bypassing a `Poco::URI` path-normalisation quirk that would decode it back and cause GCS 404s.
- **R4 Factory integration** — `GcsBdevTransport` registered as `BdevType::kGcs=6`; `"gcs"` string key added to the `CreateParams` config parser (plus the missing `"s3"` key for parity). Also fixes a latent S3 bug: `CLIO_ENABLE_AMAZON_DRIVE` was never propagated as a compile definition, so the `kS3` factory case was always compiled out even when the option was ON. `BDEV_CLOUD_DEFS` now propagates both defines.

## Validation

```bash
export GCS_ACCESS_TOKEN="$(gcloud auth print-access-token)"
export GCS_TEST_BUCKET=juicefs-gcs-config-bucket
cmake -S . -B build -DCLIO_ENABLE_GOOGLE_CLOUD=ON \
  -DCLIO_CORE_ENABLE_CTE=OFF -DCLIO_CORE_ENABLE_CAE=OFF -DCLIO_CORE_ENABLE_CEE=OFF
cmake --build build --target clio_ctp_gcs_test -j
ctest --test-dir build -R clio_ctp_gcs_test -V
# Result: 5/5 assertions pass (PUT 200, GET 200, bytes match)
```

## Test plan

- [ ] `cmake -DCLIO_ENABLE_GOOGLE_CLOUD=OFF` (default) compiles without any GCS symbols emitted
- [ ] `cmake -DCLIO_ENABLE_GOOGLE_CLOUD=ON` compiles `kGcs` factory case live
- [ ] `ctest -R clio_ctp_gcs_test` with credentials set: 5 assertions pass, object PUT + GET + DELETE succeed against a real GCS bucket
- [ ] `ctest -R clio_ctp_gcs_test` without credentials: 0 assertions, clean skip